### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/10](https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/10)

To fix the issue, we should explicitly add a `permissions` key to the workflow. This can be added at the root of the workflow file (before the `jobs:` section), so it applies to all jobs unless a given job requires more specific permissions, in which case the job itself can be given a more granular permissions block. In this case, based on the shown jobs and steps, they only read repository contents and upload/download artifacts from Actions (which do not require repository write permissions). Therefore, the minimal permissions are either `{}` (which allows only read access) or `contents: read` (for reading repo contents). To future-proof, it's often a good idea to set `contents: read` at the root; if you know none of your jobs need even that, use `{}`. If an individual job ever needs elevated permissions (e.g., creating a PR or writing to issues), update that job's permissions block only.

Edit the file `.github/workflows/ci.yml` and add either `permissions: {}` or `permissions: contents: read` after the workflow name and before the `on:` trigger block (around line 2–3).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
