### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
     name: Package Application
     runs-on: windows-latest
     needs: [build-frontend, build-backend]
+    permissions:
+      contents: read
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/9](https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/9)

To fix this problem, the `permissions` key should be added to the `package` job within the workflow `.github/workflows/ci.yml`. This block should set the permissions for the GITHUB_TOKEN to only those required; in this case, setting `contents: read` is appropriate, as the steps only involve artifact handling and packaging. Specifically, you should add a block as follows to the `package` job, before the `steps:` block (i.e., after line 157):  
```yaml
permissions:
  contents: read
```
This ensures that only read access is granted for repository contents, reducing the attack surface and adhering to least privilege principles.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
