### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/2](https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/2)

The best fix is to explicitly specify the minimum required `permissions` for the workflow. Since none of the jobs shown (lint, build, test, and artifact upload/download) require write permissions to the repository, the minimal permissions block should be set to `contents: read`. The fix can be applied at the workflow root, ensuring all jobs inherit the least privilege by default. If a particular job requires more permissions in the future, an override can be added to that job specifically. Insert the following at the top-level (e.g., between `name:` and `on:`).

- Edit file `.github/workflows/ci.yml`
- Insert the block:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name: CI` line and before the `on:` block.

No new methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
