### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build-frontend:
     name: Build Frontend
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -35,6 +37,8 @@ jobs:
   build-backend:
     name: Build Backend
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Potential fix for [https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/1](https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/1)

To fix, explicitly specify the minimal required permissions for each job that does not already have a `permissions:` block. According to CodeQL’s recommendation and the workflow’s usage, `build-frontend` and `build-backend` can operate with just `contents: read`. Add a `permissions:` block right after `runs-on` for these jobs:

- For `build-frontend` (after `runs-on: ubuntu-latest`)
- For `build-backend` (after `runs-on: windows-latest`)

No changes are needed for the `release` job, which already sets `permissions`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
