### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
   build-backend:
     name: Build Backend
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Potential fix for [https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/3](https://github.com/TakumiOkayasu/Pre-DateGrip/security/code-scanning/3)

To address this issue, add a `permissions` block to the `build-backend` job to restrict the GITHUB_TOKEN permissions to the minimum required—namely, `contents: read`. This should go directly under the job's definition, i.e., after `runs-on: windows-latest` (line 37). No changes to other jobs are needed for this particular finding; each job should limit permissions unless they genuinely need elevated access. No external libraries or definitions are involved since this is a configuration change within the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
