### PR TITLE
chore: add linguist language hints to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -97,3 +97,5 @@ CMakeLists.txt text eol=lf
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+*.cpp linguist-language=C++
+*.h linguist-language=C++


### PR DESCRIPTION
## Summary
- Add linguist language hints to  to help GitHub correctly identify this project as C++

## Changes
- Add  and  to 

## Motivation
This helps GitHub language detection correctly identify the project as C++, which may reduce false-positive warnings from .NET-related workflows.

Note: The .NET dependency submission workflow error is expected and harmless, as this is a C++ project without .NET dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>