### PR TITLE
fix: 列幅をウィンドウサイズから独立させる

### DIFF
--- a/frontend/src/components/grid/ResultGrid.module.css
+++ b/frontend/src/components/grid/ResultGrid.module.css
@@ -266,11 +266,10 @@
 }
 
 .table {
-  width: 100%;
+  width: max-content;
   border-collapse: collapse;
   font-size: 13px;
   font-family: var(--font-mono);
-  table-layout: fixed;
 }
 
 .thead {


### PR DESCRIPTION
- table-layout: fixedを削除、width: max-contentに変更
- 列幅のパディングを縮小（CSS padding考慮）
- useEffectの依存配列をrefで最適化

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>