### PR TITLE
feat: A5:ERページタブ分離・全カラム表示・Context Hook導入

### DIFF
--- a/backend/contexts/utility_context.cpp
+++ b/backend/contexts/utility_context.cpp
@@ -60,8 +60,9 @@ std::string serializeA5ERModelToJson(const A5ERModel& model, const std::string& 
         }
         indexesJson += "]";
 
-        tablesJson += std::format(R"({{"name":"{}","logicalName":"{}","comment":"{}","columns":{},"indexes":{},"posX":{},"posY":{}}})", JsonUtils::escapeString(table.name),
-                                  JsonUtils::escapeString(table.logicalName), JsonUtils::escapeString(table.comment), columnsJson, indexesJson, table.posX, table.posY);
+        tablesJson +=
+            std::format(R"({{"name":"{}","logicalName":"{}","comment":"{}","page":"{}","columns":{},"indexes":{},"posX":{},"posY":{}}})", JsonUtils::escapeString(table.name),
+                        JsonUtils::escapeString(table.logicalName), JsonUtils::escapeString(table.comment), JsonUtils::escapeString(table.page), columnsJson, indexesJson, table.posX, table.posY);
     }
     tablesJson += "]";
 

--- a/backend/parsers/a5er_parser.h
+++ b/backend/parsers/a5er_parser.h
@@ -28,6 +28,7 @@ struct A5ERTable {
     std::string name;
     std::string logicalName;
     std::string comment;
+    std::string page;  // A5:ER Page property (e.g. "MAIN")
     std::vector<A5ERColumn> columns;
     std::vector<A5ERIndex> indexes;
     double posX;

--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -1,4 +1,5 @@
 import type { IPCRequest, IPCResponse } from '../types';
+import { DEFAULT_PAGE } from '../utils/erDiagramConstants';
 import type { ERDiagramModel } from '../utils/erDiagramParser';
 import { log } from '../utils/logger';
 
@@ -34,6 +35,7 @@ export interface A5ERParseResult {
     }[];
     posX: number;
     posY: number;
+    page: string;
   }[];
   relations: {
     name: string;
@@ -54,6 +56,7 @@ export function toERDiagramModel(result: A5ERParseResult, fallbackName?: string)
       name: t.name,
       logicalName: t.logicalName,
       comment: t.comment,
+      page: t.page || DEFAULT_PAGE,
       posX: t.posX,
       posY: t.posY,
       columns: t.columns.map((c) => ({

--- a/frontend/src/components/diagram/ERDiagram.module.css
+++ b/frontend/src/components/diagram/ERDiagram.module.css
@@ -1,30 +1,69 @@
 .container {
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
   background-color: var(--bg-primary);
 }
 
-.container :global(.react-flow__node) {
+.tabBar {
+  display: flex;
+  gap: 2px;
+  padding: 4px 8px;
+  background-color: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+  overflow-x: auto;
+}
+
+.tab {
+  padding: 4px 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.tab:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.tabActive {
+  color: var(--text-primary);
+  background-color: var(--bg-tertiary);
+  border-color: var(--border-color);
+}
+
+.flowContainer {
+  flex: 1;
+  min-height: 0;
+}
+
+.flowContainer :global(.react-flow__node) {
   cursor: pointer;
 }
 
-.container :global(.react-flow__controls) {
+.flowContainer :global(.react-flow__controls) {
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 4px;
 }
 
-.container :global(.react-flow__controls-button) {
+.flowContainer :global(.react-flow__controls-button) {
   background-color: var(--bg-secondary);
   border-bottom: 1px solid var(--border-color);
   fill: var(--text-primary);
 }
 
-.container :global(.react-flow__controls-button:hover) {
+.flowContainer :global(.react-flow__controls-button:hover) {
   background-color: var(--bg-hover);
 }
 
-.container :global(.react-flow__minimap) {
+.flowContainer :global(.react-flow__minimap) {
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 4px;

--- a/frontend/src/components/diagram/ERDiagram.tsx
+++ b/frontend/src/components/diagram/ERDiagram.tsx
@@ -11,13 +11,13 @@ import {
 } from '@xyflow/react';
 import { useCallback, useMemo } from 'react';
 import '@xyflow/react/dist/style.css';
+import { useERDiagramContext } from '../../hooks/useERDiagramContext';
 import type { ERRelationEdge, ERTableNode } from '../../types';
+import { ALL_PAGES, GRID_LAYOUT } from '../../utils/erDiagramConstants';
 import styles from './ERDiagram.module.css';
 import { TableNode } from './TableNode';
 
 interface ERDiagramProps {
-  tables: ERTableNode[];
-  relations: ERRelationEdge[];
   onTableClick?: (tableId: string) => void;
 }
 
@@ -25,40 +25,64 @@ const nodeTypes = {
   table: TableNode,
 };
 
-export function ERDiagram({ tables, relations, onTableClick }: ERDiagramProps) {
-  const initialNodes: Node[] = useMemo(() => {
-    return tables.map((table) => ({
-      id: table.id,
-      type: 'table',
-      position: table.position,
-      data: table.data,
-    }));
-  }, [tables]);
+/** 「すべて」タブ時のグリッド再配置 */
+function applyGridLayout(tables: ERTableNode[]): ERTableNode[] {
+  const { columns, nodeWidth, nodeHeight, gap } = GRID_LAYOUT;
+  return tables.map((t, i) => ({
+    ...t,
+    position: {
+      x: (i % columns) * (nodeWidth + gap),
+      y: Math.floor(i / columns) * (nodeHeight + gap),
+    },
+  }));
+}
 
-  const initialEdges: Edge[] = useMemo(() => {
-    return relations.map((rel) => ({
-      id: rel.id,
-      source: rel.source,
-      target: rel.target,
-      type: 'smoothstep',
-      animated: false,
-      label: rel.data.cardinality,
-      labelStyle: { fontSize: 10, fill: '#888' },
-      labelBgStyle: { fill: '#1e1e1e', fillOpacity: 0.8 },
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        width: 15,
-        height: 15,
-        color: '#888',
-      },
-      style: { stroke: '#888', strokeWidth: 1 },
-    }));
-  }, [relations]);
+function ERDiagramFlow({
+  tables,
+  relations,
+  onTableClick,
+}: {
+  tables: ERTableNode[];
+  relations: ERRelationEdge[];
+  onTableClick?: (tableId: string) => void;
+}) {
+  const initialNodes: Node[] = useMemo(
+    () =>
+      tables.map((table) => ({
+        id: table.id,
+        type: 'table',
+        position: table.position,
+        data: table.data,
+      })),
+    [tables]
+  );
+
+  const initialEdges: Edge[] = useMemo(
+    () =>
+      relations.map((rel) => ({
+        id: rel.id,
+        source: rel.source,
+        target: rel.target,
+        type: 'smoothstep',
+        animated: false,
+        label: rel.data.cardinality,
+        labelStyle: { fontSize: 10, fill: '#888' },
+        labelBgStyle: { fill: '#1e1e1e', fillOpacity: 0.8 },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 15,
+          height: 15,
+          color: '#888',
+        },
+        style: { stroke: '#888', strokeWidth: 1 },
+      })),
+    [relations]
+  );
 
   const [nodes, , onNodesChange] = useNodesState(initialNodes);
   const [edges, , onEdgesChange] = useEdgesState(initialEdges);
 
-  const onNodeClick = useCallback(
+  const handleNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {
       onTableClick?.(node.id);
     },
@@ -66,22 +90,80 @@ export function ERDiagram({ tables, relations, onTableClick }: ERDiagramProps) {
   );
 
   return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      onNodesChange={onNodesChange}
+      onEdgesChange={onEdgesChange}
+      onNodeClick={handleNodeClick}
+      nodeTypes={nodeTypes}
+      fitView
+      minZoom={0.1}
+      maxZoom={2}
+      defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
+    >
+      <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#333" />
+      <Controls />
+    </ReactFlow>
+  );
+}
+
+export function ERDiagram({ onTableClick }: ERDiagramProps) {
+  const {
+    pages,
+    selectedPage,
+    setSelectedPage,
+    pageCounts,
+    tables: filteredTables,
+    relations: filteredRelations,
+  } = useERDiagramContext();
+
+  // 「すべて」タブ時はグリッド再配置（ページ間で座標が重複するため）
+  const layoutTables = useMemo(
+    () => (selectedPage === ALL_PAGES ? applyGridLayout(filteredTables) : filteredTables),
+    [filteredTables, selectedPage]
+  );
+
+  const showTabs = pages.length > 1;
+
+  // key を変えることで ReactFlow を再マウントし、fitView をリトリガー
+  const flowKey = useMemo(() => {
+    const first = layoutTables[0]?.id ?? '';
+    const last = layoutTables[layoutTables.length - 1]?.id ?? '';
+    return `${selectedPage}-${layoutTables.length}-${first}-${last}`;
+  }, [selectedPage, layoutTables]);
+
+  return (
     <div className={styles.container}>
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        onNodesChange={onNodesChange}
-        onEdgesChange={onEdgesChange}
-        onNodeClick={onNodeClick}
-        nodeTypes={nodeTypes}
-        fitView
-        minZoom={0.1}
-        maxZoom={2}
-        defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
-      >
-        <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#333" />
-        <Controls />
-      </ReactFlow>
+      {showTabs && (
+        <div className={styles.tabBar}>
+          <button
+            type="button"
+            className={`${styles.tab} ${selectedPage === ALL_PAGES ? styles.tabActive : ''}`}
+            onClick={() => setSelectedPage(ALL_PAGES)}
+          >
+            すべて ({pageCounts.get(ALL_PAGES) ?? 0})
+          </button>
+          {pages.map((page) => (
+            <button
+              type="button"
+              key={page}
+              className={`${styles.tab} ${selectedPage === page ? styles.tabActive : ''}`}
+              onClick={() => setSelectedPage(page)}
+            >
+              {page} ({pageCounts.get(page) ?? 0})
+            </button>
+          ))}
+        </div>
+      )}
+      <div className={styles.flowContainer}>
+        <ERDiagramFlow
+          key={flowKey}
+          tables={layoutTables}
+          relations={filteredRelations}
+          onTableClick={onTableClick}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/diagram/TableNode.module.css
+++ b/frontend/src/components/diagram/TableNode.module.css
@@ -3,7 +3,7 @@
   border: 1px solid var(--border-color);
   border-radius: 6px;
   min-width: 180px;
-  max-width: 250px;
+  max-width: 320px;
   font-size: 11px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
@@ -37,8 +37,6 @@
 
 .columns {
   padding: 6px 0;
-  max-height: 200px;
-  overflow-y: auto;
 }
 
 .column {
@@ -68,23 +66,28 @@
   text-overflow: ellipsis;
 }
 
+.logicalName {
+  color: var(--text-secondary);
+  font-size: 10px;
+}
+
 .columnType {
   color: var(--text-secondary);
   font-size: 10px;
   white-space: nowrap;
 }
 
+.defaultValue {
+  color: var(--text-secondary);
+  font-size: 10px;
+  white-space: nowrap;
+  opacity: 0.7;
+}
+
 .divider {
   height: 1px;
   background-color: var(--border-color);
   margin: 4px 10px;
-}
-
-.moreColumns {
-  padding: 4px 10px;
-  color: var(--text-secondary);
-  font-style: italic;
-  text-align: center;
 }
 
 .handle {

--- a/frontend/src/components/diagram/TableNode.tsx
+++ b/frontend/src/components/diagram/TableNode.tsx
@@ -1,11 +1,11 @@
 import { Handle, Position } from '@xyflow/react';
 import { memo } from 'react';
-import type { Column } from '../../types';
+import type { ERColumn } from '../../types';
 import styles from './TableNode.module.css';
 
 interface TableNodeData {
   tableName: string;
-  columns: Column[];
+  columns: ERColumn[];
 }
 
 interface TableNodeProps {
@@ -18,6 +18,24 @@ const icons = {
   table: '\uD83D\uDCCB', // 📋
   key: '\uD83D\uDD11', // 🔑
 };
+
+function ColumnRow({ col, isPK }: { col: ERColumn; isPK: boolean }) {
+  return (
+    <div
+      className={`${styles.column} ${isPK ? styles.primaryKey : ''}`}
+      title={col.comment || undefined}
+    >
+      {isPK && <span className={styles.keyIcon}>{icons.key}</span>}
+      <span className={styles.columnName}>
+        {!isPK && !col.nullable ? '*' : ''}
+        {col.name}
+        {col.logicalName && <span className={styles.logicalName}> ({col.logicalName})</span>}
+      </span>
+      <span className={styles.columnType}>{col.type}</span>
+      {col.defaultValue && <span className={styles.defaultValue}>={col.defaultValue}</span>}
+    </div>
+  );
+}
 
 export const TableNode = memo(function TableNode({ data, selected }: TableNodeProps) {
   const { tableName, columns } = data;
@@ -35,29 +53,15 @@ export const TableNode = memo(function TableNode({ data, selected }: TableNodePr
       </div>
 
       <div className={styles.columns}>
-        {primaryKeys.map((col) => (
-          <div key={col.name} className={`${styles.column} ${styles.primaryKey}`}>
-            <span className={styles.keyIcon}>{icons.key}</span>
-            <span className={styles.columnName}>{col.name}</span>
-            <span className={styles.columnType}>{col.type}</span>
-          </div>
+        {primaryKeys.map((col, i) => (
+          <ColumnRow key={`pk-${i}-${col.name}`} col={col} isPK />
         ))}
 
         {primaryKeys.length > 0 && regularColumns.length > 0 && <div className={styles.divider} />}
 
-        {regularColumns.slice(0, 10).map((col) => (
-          <div key={col.name} className={styles.column}>
-            <span className={styles.columnName}>
-              {col.nullable ? '' : '*'}
-              {col.name}
-            </span>
-            <span className={styles.columnType}>{col.type}</span>
-          </div>
+        {regularColumns.map((col, i) => (
+          <ColumnRow key={`col-${i}-${col.name}`} col={col} isPK={false} />
         ))}
-
-        {regularColumns.length > 10 && (
-          <div className={styles.moreColumns}>+{regularColumns.length - 10} more columns</div>
-        )}
       </div>
 
       <Handle type="source" position={Position.Right} className={styles.handle} />

--- a/frontend/src/components/layout/CenterPanel.tsx
+++ b/frontend/src/components/layout/CenterPanel.tsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense } from 'react';
-import { useERDiagramStore } from '../../store/erDiagramStore';
 import { useActiveQuery } from '../../store/queryStore';
 import { log } from '../../utils/logger';
 import { EditorTabs } from '../editor/EditorTabs';
@@ -16,9 +15,6 @@ const ERDiagramView = lazy(() =>
   import('../diagram/ERDiagram').then((module) => ({ default: module.ERDiagram }))
 );
 
-const EMPTY_TABLES: ReturnType<typeof useERDiagramStore.getState>['tables'] = [];
-const EMPTY_RELATIONS: ReturnType<typeof useERDiagramStore.getState>['relations'] = [];
-
 // Loading fallback for Monaco Editor
 function EditorLoadingFallback() {
   return (
@@ -33,8 +29,6 @@ export function CenterPanel() {
   const activeQuery = useActiveQuery();
   const isDataView = activeQuery?.isDataView === true;
   const isERDiagram = activeQuery?.isERDiagram === true;
-  const tables = useERDiagramStore((s) => (isERDiagram ? s.tables : EMPTY_TABLES));
-  const relations = useERDiagramStore((s) => (isERDiagram ? s.relations : EMPTY_RELATIONS));
 
   log.debug(
     `[CenterPanel] Render: activeQuery=${activeQuery?.id}, isDataView=${isDataView}, isERDiagram=${isERDiagram}`
@@ -46,7 +40,7 @@ export function CenterPanel() {
       <div className={styles.editorContainer}>
         <Suspense fallback={<EditorLoadingFallback />}>
           {isERDiagram ? (
-            <ERDiagramView tables={tables} relations={relations} />
+            <ERDiagramView />
           ) : isDataView ? (
             <ResultGrid queryId={activeQuery?.id} />
           ) : (

--- a/frontend/src/hooks/useERDiagramContext.ts
+++ b/frontend/src/hooks/useERDiagramContext.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useERDiagramStore } from '../store/erDiagramStore';
+import type { ERRelationEdge, ERTableNode } from '../types';
+import { ALL_PAGES, DEFAULT_PAGE } from '../utils/erDiagramConstants';
+
+export interface ERDiagramContextValue {
+  pages: string[];
+  selectedPage: string;
+  setSelectedPage: (page: string) => void;
+  pageCounts: Map<string, number>;
+  tables: ERTableNode[];
+  relations: ERRelationEdge[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * ER図表示に必要な全データを提供するContext Hook。
+ * Store への直接アクセスをカプセル化し、View と Store を分離する。
+ */
+export function useERDiagramContext(): ERDiagramContextValue {
+  const { allTables, allRelations, selectedPage, setSelectedPage, isLoading, error } =
+    useERDiagramStore(
+      useShallow((s) => ({
+        allTables: s.tables,
+        allRelations: s.relations,
+        selectedPage: s.selectedPage,
+        setSelectedPage: s.setSelectedPage,
+        isLoading: s.isLoading,
+        error: s.error,
+      }))
+    );
+
+  // pages と pageCounts を1回の走査で同時計算
+  const { pages, pageCounts } = useMemo(() => {
+    const countMap = new Map<string, number>();
+    countMap.set(ALL_PAGES, allTables.length);
+    for (const t of allTables) {
+      const page = t.data.page || DEFAULT_PAGE;
+      countMap.set(page, (countMap.get(page) || 0) + 1);
+    }
+    const pageList = Array.from(countMap.keys()).filter((k) => k !== ALL_PAGES);
+    return { pages: pageList, pageCounts: countMap };
+  }, [allTables]);
+
+  const tables = useMemo(() => {
+    if (selectedPage === ALL_PAGES) return allTables;
+    return allTables.filter((t) => (t.data.page || DEFAULT_PAGE) === selectedPage);
+  }, [allTables, selectedPage]);
+
+  const relations = useMemo(() => {
+    const tableIds = new Set(tables.map((t) => t.id));
+    return allRelations.filter((r) => tableIds.has(r.source) && tableIds.has(r.target));
+  }, [allRelations, tables]);
+
+  return {
+    pages,
+    selectedPage,
+    setSelectedPage,
+    pageCounts,
+    tables,
+    relations,
+    isLoading,
+    error,
+  };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -99,6 +99,12 @@ export interface Column {
   comment?: string;
 }
 
+/** ER図表示用の拡張カラム型（Column + ER固有属性） */
+export interface ERColumn extends Column {
+  logicalName?: string;
+  defaultValue?: string;
+}
+
 export interface ResultSet {
   columns: Column[];
   rows: string[][];
@@ -257,7 +263,8 @@ export interface ERTableNode {
   type: 'table';
   data: {
     tableName: string;
-    columns: Column[];
+    columns: ERColumn[];
+    page?: string;
   };
   position: { x: number; y: number };
 }

--- a/frontend/src/utils/erDiagramConstants.ts
+++ b/frontend/src/utils/erDiagramConstants.ts
@@ -1,0 +1,13 @@
+/** A5:ER ファイルでPageプロパティが未設定時のデフォルトページ名 */
+export const DEFAULT_PAGE = 'MAIN';
+
+/** 「すべてのページ」を表す内部識別子 */
+export const ALL_PAGES = '__ALL__';
+
+/** ER図グリッド自動レイアウト設定 */
+export const GRID_LAYOUT = {
+  columns: 4,
+  nodeWidth: 280,
+  nodeHeight: 200,
+  gap: 80,
+} as const;

--- a/frontend/src/utils/erDiagramParser.ts
+++ b/frontend/src/utils/erDiagramParser.ts
@@ -10,6 +10,7 @@ export interface ERDiagramTable {
   name: string;
   logicalName: string;
   comment: string;
+  page: string;
   posX: number;
   posY: number;
   columns: ERDiagramColumn[];

--- a/frontend/src/utils/erDiagramUtils.ts
+++ b/frontend/src/utils/erDiagramUtils.ts
@@ -1,0 +1,10 @@
+import { DEFAULT_PAGE } from './erDiagramConstants';
+
+/** テーブル一覧からユニークなページ名を抽出 */
+export function extractPages(tables: { data: { page?: string } }[]): string[] {
+  const pageSet = new Set<string>();
+  for (const t of tables) {
+    pageSet.add(t.data.page || DEFAULT_PAGE);
+  }
+  return Array.from(pageSet);
+}


### PR DESCRIPTION
- Backend: pageフィールド追加、BOM除去、DELなしファイル対応、PK判定修正
- Frontend: useERDiagramContext hookでView→Hook→Store依存分離
- ERDiagram: ページタブUI、グリッド再配置、ERDiagramFlow分離
- TableNode: 10件制限撤廃、論理名・デフォルト値・コメント表示、ColumnRow統合
- deprecated importFromA5ER削除、定数・ユーティリティ一元化