### PR TITLE
feat: ODBC Unicode API移行とDB接続UX改善

### DIFF
--- a/backend/database/odbc_unicode.h
+++ b/backend/database/odbc_unicode.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../utils/encoding.h"
+
+#include <sql.h>
+
+#include <concepts>
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+static_assert(sizeof(SQLWCHAR) == sizeof(wchar_t), "SQLWCHAR and wchar_t must have the same size");
+
+inline SQLWCHAR* toSqlWchar(wchar_t* p) {
+    return reinterpret_cast<SQLWCHAR*>(p);
+}
+inline const wchar_t* toWchar(const SQLWCHAR* p) {
+    return reinterpret_cast<const wchar_t*>(p);
+}
+
+// SQLWCHAR buffer → UTF-8 string (convenience wrapper)
+inline std::string sqlWcharToUtf8(const SQLWCHAR* buf, size_t len) {
+    return wideToUtf8(toWchar(buf), len);
+}
+
+// UTF-8 string → std::wstring, ready for ODBC W APIs via toSqlWchar(result.data())
+using ::velocitydb::utf8ToWide;
+
+// ODBC APIs accept integer attribute values as SQLPOINTER (void*).
+// This is by ODBC specification design; wrap the cast for clarity.
+template <typename T>
+    requires std::integral<T>
+inline SQLPOINTER toSqlPointer(T value) {
+    return reinterpret_cast<SQLPOINTER>(static_cast<uintptr_t>(value));
+}
+
+}  // namespace velocitydb

--- a/backend/utils/encoding.h
+++ b/backend/utils/encoding.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <Windows.h>
+
+#include <climits>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+// Convert UTF-8 (std::string) to UTF-16 (std::wstring)
+inline std::wstring utf8ToWide(std::string_view str) {
+    if (str.empty()) {
+        return {};
+    }
+
+    if (str.size() > static_cast<size_t>(INT_MAX)) [[unlikely]] {
+        throw std::length_error("utf8ToWide: input exceeds INT_MAX");
+    }
+
+    int wideLen = MultiByteToWideChar(CP_UTF8, 0, str.data(), static_cast<int>(str.size()), nullptr, 0);
+    if (wideLen == 0) {
+        return {};
+    }
+
+    auto wideStr = std::wstring(static_cast<size_t>(wideLen), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, str.data(), static_cast<int>(str.size()), wideStr.data(), wideLen);
+    return wideStr;
+}
+
+// Convert UTF-16 (wchar_t) to UTF-8 (std::string)
+inline std::string wideToUtf8(const wchar_t* wstr, size_t len) {
+    if (len == 0 || wstr == nullptr) {
+        return {};
+    }
+
+    if (len > static_cast<size_t>(INT_MAX)) [[unlikely]] {
+        throw std::length_error("wideToUtf8: input exceeds INT_MAX");
+    }
+
+    int utf8Len = WideCharToMultiByte(CP_UTF8, 0, wstr, static_cast<int>(len), nullptr, 0, nullptr, nullptr);
+    if (utf8Len == 0) {
+        return {};
+    }
+
+    auto utf8Str = std::string(static_cast<size_t>(utf8Len), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, wstr, static_cast<int>(len), utf8Str.data(), utf8Len, nullptr, nullptr);
+    return utf8Str;
+}
+
+}  // namespace velocitydb

--- a/frontend/src/components/editor/EditorTabs.tsx
+++ b/frontend/src/components/editor/EditorTabs.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useConnectionStore } from '../../store/connectionStore';
 import { useQueries, useQueryActions, useQueryStore } from '../../store/queryStore';
 import type { Query } from '../../types';
 import styles from './EditorTabs.module.css';
@@ -54,6 +55,12 @@ function buildTooltip(query: Query): string {
     parts.push(query.logicalName);
   } else if (query.isDataView && query.sourceTable && query.sourceTable !== query.name) {
     parts.push(query.sourceTable);
+  }
+  if (query.connectionId) {
+    const conn = useConnectionStore.getState().connections.find((c) => c.id === query.connectionId);
+    if (conn) {
+      parts.push(`接続先: ${conn.server}/${conn.database}`);
+    }
   }
   return parts.join('\n');
 }

--- a/frontend/src/components/grid/GridStatusBar.tsx
+++ b/frontend/src/components/grid/GridStatusBar.tsx
@@ -7,6 +7,7 @@ interface GridStatusBarProps {
   filteredRowCount: number;
   isFiltered: boolean;
   isEditMode: boolean;
+  connectionLabel?: string;
 }
 
 function GridStatusBarInner({
@@ -14,9 +15,16 @@ function GridStatusBarInner({
   filteredRowCount,
   isFiltered,
   isEditMode,
+  connectionLabel,
 }: GridStatusBarProps) {
   return (
     <div className={styles.statusBar}>
+      {connectionLabel && (
+        <>
+          <span>{connectionLabel}</span>
+          <span>|</span>
+        </>
+      )}
       <span>
         {isFiltered
           ? resultSet.truncated

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -9,7 +9,7 @@ import {
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, useCallback, useMemo, useRef, useState } from 'react';
-import { useConnectionStore } from '../../store/connectionStore';
+import { useActiveConnection, useConnectionStore } from '../../store/connectionStore';
 import {
   useIsActiveDataView,
   useIsQueryExecuting,
@@ -45,6 +45,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   // --- Store subscriptions ---
   const activeQueryId = useQueryStore((state) => state.activeQueryId);
   const activeConnectionId = useConnectionStore((state) => state.activeConnectionId);
+  const activeConn = useActiveConnection();
   const isActiveDataView = useIsActiveDataView();
   const targetQueryId = excludeDataView && isActiveDataView ? null : (queryId ?? activeQueryId);
   const currentQuery = useQueryById(targetQueryId);
@@ -413,6 +414,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
         filteredRowCount={rows.length}
         isFiltered={columnFilters.length > 0}
         isEditMode={isEditMode}
+        connectionLabel={activeConn ? `${activeConn.server}/${activeConn.database}` : undefined}
       />
 
       <ExportDialog

--- a/frontend/src/components/layout/MainLayout.module.css
+++ b/frontend/src/components/layout/MainLayout.module.css
@@ -129,6 +129,33 @@
   color: var(--success-color);
 }
 
+/* DB Selector dropdown */
+.dbSelector {
+  height: 28px;
+  padding: 2px 24px 2px 8px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 12px;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6z' fill='%23888'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  max-width: 220px;
+  text-overflow: ellipsis;
+}
+
+.dbSelector:hover:not(:disabled) {
+  border-color: var(--accent-color);
+}
+
+.dbSelector:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 /* Toolbar spacer */
 .toolbarSpacer {
   flex: 1;

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -134,7 +134,7 @@ export function MainLayout() {
     isBlocked?: boolean;
   }>({ isOpen: false, title: '', message: '' });
 
-  const { connections, activeConnectionId, addConnection } = useConnectionStore();
+  const { connections, activeConnectionId, addConnection, setActive } = useConnectionStore();
   const {
     queries,
     activeQueryId,
@@ -417,6 +417,34 @@ export function MainLayout() {
             {Icons.database}
             <span>接続</span>
           </button>
+        </div>
+
+        {/* DB Selector */}
+        <div className={styles.toolbarGroup}>
+          <select
+            className={styles.dbSelector}
+            value={activeConnectionId ?? ''}
+            onChange={(e) => {
+              const id = e.target.value || null;
+              setActive(id);
+            }}
+            disabled={connections.length === 0}
+            title="接続先データベースを切り替え"
+          >
+            {connections.length === 0 ? (
+              <option value="">未接続</option>
+            ) : (
+              <>
+                {!activeConnectionId && <option value="">選択してください</option>}
+                {connections.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.server}/{c.database}
+                    {c.isProduction ? ' (本番)' : ''}
+                  </option>
+                ))}
+              </>
+            )}
+          </select>
         </div>
 
         <div className={styles.toolbarDivider} />


### PR DESCRIPTION
- SQLExecDirectA/SQLDriverConnectA/SQLDriversAをW系APIに変換し日本語SQL文字化けを解消
- 型安全なODBC Unicode変換ヘルパー(odbc_unicode.h/encoding.h)を導入
- ツールバーにDB切替プルダウンを追加
- タブツールチップ・結果グリッドステータスバーに接続先情報を表示