### PR TITLE
feat: AsyncQuery完了後のメモリ自動解放とstaleクエリ自動eviction

### DIFF
--- a/backend/contexts/database_context.h
+++ b/backend/contexts/database_context.h
@@ -51,6 +51,7 @@ public:
     [[nodiscard]] std::string handleGetAsyncQueryResult(std::string_view params) override;
     [[nodiscard]] std::string handleCancelAsyncQuery(std::string_view params) override;
     [[nodiscard]] std::string handleGetActiveQueries(std::string_view params) override;
+    [[nodiscard]] std::string handleRemoveAsyncQuery(std::string_view params) override;
 
     // Schema
     [[nodiscard]] std::string handleGetDatabases(std::string_view params) override;

--- a/backend/interfaces/database_context.h
+++ b/backend/interfaces/database_context.h
@@ -29,6 +29,7 @@ public:
     [[nodiscard]] virtual std::string handleGetAsyncQueryResult(std::string_view params) = 0;
     [[nodiscard]] virtual std::string handleCancelAsyncQuery(std::string_view params) = 0;
     [[nodiscard]] virtual std::string handleGetActiveQueries(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string handleRemoveAsyncQuery(std::string_view params) = 0;
 
     // Schema
     [[nodiscard]] virtual std::string handleGetDatabases(std::string_view params) = 0;

--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -36,6 +36,7 @@ void IPCHandler::registerRoutes() {
     m_routes["getAsyncQueryResult"] = [this](auto p) { return m_ctx.database().handleGetAsyncQueryResult(p); };
     m_routes["cancelAsyncQuery"] = [this](auto p) { return m_ctx.database().handleCancelAsyncQuery(p); };
     m_routes["getActiveQueries"] = [this](auto p) { return m_ctx.database().handleGetActiveQueries(p); };
+    m_routes["removeAsyncQuery"] = [this](auto p) { return m_ctx.database().handleRemoveAsyncQuery(p); };
 
     // Schema
     m_routes["getDatabases"] = [this](auto p) { return m_ctx.database().handleGetDatabases(p); };

--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -433,6 +433,10 @@ class Bridge {
     return this.call('cancelAsyncQuery', { queryId });
   }
 
+  async removeAsyncQuery(queryId: string): Promise<{ removed: boolean }> {
+    return this.call('removeAsyncQuery', { queryId });
+  }
+
   async getActiveQueries(): Promise<string[]> {
     return this.call('getActiveQueries', {});
   }

--- a/frontend/src/store/query/interfaces/QueryBridgeable.ts
+++ b/frontend/src/store/query/interfaces/QueryBridgeable.ts
@@ -4,5 +4,6 @@ export interface QueryBridgeable {
   executeAsyncQuery(connectionId: string, sql: string): Promise<{ queryId: string }>;
   getAsyncQueryResult(queryId: string): Promise<AsyncQueryResultResponse>;
   cancelAsyncQuery(queryId: string): Promise<{ cancelled: boolean }>;
+  removeAsyncQuery(queryId: string): Promise<{ removed: boolean }>;
   cancelQuery(connectionId: string): Promise<void>;
 }

--- a/frontend/src/tests/stores/queryStore.cancel.test.ts
+++ b/frontend/src/tests/stores/queryStore.cancel.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../api/bridge', () => ({
     executeAsyncQuery: vi.fn(),
     getAsyncQueryResult: vi.fn(),
     cancelAsyncQuery: vi.fn(),
+    removeAsyncQuery: vi.fn().mockResolvedValue({ removed: true }),
     cancelQuery: vi.fn(),
     getColumns: vi.fn(),
     formatSQL: vi.fn(),

--- a/frontend/src/tests/stores/queryStore.dataview.test.ts
+++ b/frontend/src/tests/stores/queryStore.dataview.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../api/bridge', () => ({
     executeAsyncQuery: vi.fn(),
     getAsyncQueryResult: vi.fn(),
     cancelAsyncQuery: vi.fn(),
+    removeAsyncQuery: vi.fn().mockResolvedValue({ removed: true }),
     cancelQuery: vi.fn(),
     getColumns: vi.fn(),
     formatSQL: vi.fn(),

--- a/frontend/src/tests/stores/queryStore.format-fileio.test.ts
+++ b/frontend/src/tests/stores/queryStore.format-fileio.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../api/bridge', () => ({
     executeAsyncQuery: vi.fn(),
     getAsyncQueryResult: vi.fn(),
     cancelAsyncQuery: vi.fn(),
+    removeAsyncQuery: vi.fn().mockResolvedValue({ removed: true }),
     cancelQuery: vi.fn(),
     getColumns: vi.fn(),
     formatSQL: vi.fn(),


### PR DESCRIPTION
- removeAsyncQuery IPCで完了/失敗/キャンセル済みクエリを即時解放
- evictStaleQueries(300秒/60秒スロットル)で安全弁として自動クリーンアップ
- removeQueryにステータスガード追加(Running/Pending削除を防止)
- フロントエンド全終了パス(5箇所)でfire-and-forget removeAsyncQuery呼び出し