### PR TITLE
feat: Glaze v5.0.0導入によるJSON serialize/deserialize置換

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -120,6 +120,7 @@ set(HEADERS
     utils/file_dialog.h
     utils/settings_manager.h
     utils/session_manager.h
+    utils/glaze_meta.h
     utils/global_search.h
     utils/credential_protector.h
     utils/logger.h
@@ -142,11 +143,17 @@ target_link_libraries(VelocityDBCore PUBLIC
     webview
     simdjson
     pugixml
+    glaze::glaze
     odbc32
     odbccp32
     crypt32
     comdlg32
 )
+
+# Glaze requires /Zc:preprocessor for MSVC (conformant preprocessor)
+if(MSVC)
+    target_compile_options(VelocityDBCore PRIVATE /Zc:preprocessor)
+endif()
 
 # Link libssh2 if available
 if(SSH_TUNNEL_ENABLED)

--- a/backend/interfaces/providers/settings_provider.h
+++ b/backend/interfaces/providers/settings_provider.h
@@ -10,16 +10,16 @@ class ISettingsProvider {
 public:
     virtual ~ISettingsProvider() = default;
 
-    [[nodiscard]] virtual std::string handleGetSettings() = 0;
-    [[nodiscard]] virtual std::string handleUpdateSettings(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string handleGetConnectionProfiles() = 0;
-    [[nodiscard]] virtual std::string handleSaveConnectionProfile(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string handleDeleteConnectionProfile(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string handleGetProfilePassword(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string handleGetSshPassword(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string handleGetSshKeyPassphrase(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string handleGetSessionState() = 0;
-    [[nodiscard]] virtual std::string handleSaveSessionState(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getSettings() = 0;
+    [[nodiscard]] virtual std::string updateSettings(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getConnectionProfiles() = 0;
+    [[nodiscard]] virtual std::string saveConnectionProfile(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string deleteConnectionProfile(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getProfilePassword(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getSshPassword(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getSshKeyPassphrase(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getSessionState() = 0;
+    [[nodiscard]] virtual std::string saveSessionState(std::string_view params) = 0;
 };
 
 }  // namespace velocitydb

--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -87,16 +87,16 @@ void IPCHandler::registerRoutes() {
     m_routes["quickSearch"] = [this](auto p) { return m_ctx.search().handleQuickSearch(p); };
 
     // Settings
-    m_routes["getSettings"] = [this](auto) { return m_ctx.settings().handleGetSettings(); };
-    m_routes["updateSettings"] = [this](auto p) { return m_ctx.settings().handleUpdateSettings(p); };
-    m_routes["getConnectionProfiles"] = [this](auto) { return m_ctx.settings().handleGetConnectionProfiles(); };
-    m_routes["saveConnectionProfile"] = [this](auto p) { return m_ctx.settings().handleSaveConnectionProfile(p); };
-    m_routes["deleteConnectionProfile"] = [this](auto p) { return m_ctx.settings().handleDeleteConnectionProfile(p); };
-    m_routes["getProfilePassword"] = [this](auto p) { return m_ctx.settings().handleGetProfilePassword(p); };
-    m_routes["getSshPassword"] = [this](auto p) { return m_ctx.settings().handleGetSshPassword(p); };
-    m_routes["getSshKeyPassphrase"] = [this](auto p) { return m_ctx.settings().handleGetSshKeyPassphrase(p); };
-    m_routes["getSessionState"] = [this](auto) { return m_ctx.settings().handleGetSessionState(); };
-    m_routes["saveSessionState"] = [this](auto p) { return m_ctx.settings().handleSaveSessionState(p); };
+    m_routes["getSettings"] = [this](auto) { return m_ctx.settings().getSettings(); };
+    m_routes["updateSettings"] = [this](auto p) { return m_ctx.settings().updateSettings(p); };
+    m_routes["getConnectionProfiles"] = [this](auto) { return m_ctx.settings().getConnectionProfiles(); };
+    m_routes["saveConnectionProfile"] = [this](auto p) { return m_ctx.settings().saveConnectionProfile(p); };
+    m_routes["deleteConnectionProfile"] = [this](auto p) { return m_ctx.settings().deleteConnectionProfile(p); };
+    m_routes["getProfilePassword"] = [this](auto p) { return m_ctx.settings().getProfilePassword(p); };
+    m_routes["getSshPassword"] = [this](auto p) { return m_ctx.settings().getSshPassword(p); };
+    m_routes["getSshKeyPassphrase"] = [this](auto p) { return m_ctx.settings().getSshKeyPassphrase(p); };
+    m_routes["getSessionState"] = [this](auto) { return m_ctx.settings().getSessionState(); };
+    m_routes["saveSessionState"] = [this](auto p) { return m_ctx.settings().saveSessionState(p); };
 
     // IO
     m_routes["writeFrontendLog"] = [this](auto p) { return m_ctx.io().handleWriteFrontendLog(p); };

--- a/backend/providers/settings_provider.h
+++ b/backend/providers/settings_provider.h
@@ -22,16 +22,16 @@ public:
     SettingsProvider(SettingsProvider&&) noexcept;
     SettingsProvider& operator=(SettingsProvider&&) noexcept;
 
-    [[nodiscard]] std::string handleGetSettings() override;
-    [[nodiscard]] std::string handleUpdateSettings(std::string_view params) override;
-    [[nodiscard]] std::string handleGetConnectionProfiles() override;
-    [[nodiscard]] std::string handleSaveConnectionProfile(std::string_view params) override;
-    [[nodiscard]] std::string handleDeleteConnectionProfile(std::string_view params) override;
-    [[nodiscard]] std::string handleGetProfilePassword(std::string_view params) override;
-    [[nodiscard]] std::string handleGetSshPassword(std::string_view params) override;
-    [[nodiscard]] std::string handleGetSshKeyPassphrase(std::string_view params) override;
-    [[nodiscard]] std::string handleGetSessionState() override;
-    [[nodiscard]] std::string handleSaveSessionState(std::string_view params) override;
+    [[nodiscard]] std::string getSettings() override;
+    [[nodiscard]] std::string updateSettings(std::string_view params) override;
+    [[nodiscard]] std::string getConnectionProfiles() override;
+    [[nodiscard]] std::string saveConnectionProfile(std::string_view params) override;
+    [[nodiscard]] std::string deleteConnectionProfile(std::string_view params) override;
+    [[nodiscard]] std::string getProfilePassword(std::string_view params) override;
+    [[nodiscard]] std::string getSshPassword(std::string_view params) override;
+    [[nodiscard]] std::string getSshKeyPassphrase(std::string_view params) override;
+    [[nodiscard]] std::string getSessionState() override;
+    [[nodiscard]] std::string saveSessionState(std::string_view params) override;
 
     [[nodiscard]] SettingsManager& settingsManager() { return *m_settingsManager; }
     [[nodiscard]] const SettingsManager& settingsManager() const { return *m_settingsManager; }

--- a/backend/utils/glaze_meta.h
+++ b/backend/utils/glaze_meta.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "session_manager.h"
+#include "settings_manager.h"
+
+#include <glaze/glaze.hpp>
+
+// --- Enum ---
+
+template <>
+struct glz::meta<velocitydb::SshAuthType> {
+    using enum velocitydb::SshAuthType;
+    static constexpr auto value = enumerate("password", Password, "privateKey", PrivateKey);
+};
+
+// --- Settings structs ---
+
+template <>
+struct glz::meta<velocitydb::SshConfig> {
+    using T = velocitydb::SshConfig;
+    static constexpr auto value = object("enabled", &T::enabled, "host", &T::host, "port", &T::port, "username", &T::username, "authType", &T::authType, "encryptedPassword", &T::encryptedPassword,
+                                         "privateKeyPath", &T::privateKeyPath, "encryptedKeyPassphrase", &T::encryptedKeyPassphrase);
+};
+
+template <>
+struct glz::meta<velocitydb::ConnectionProfile> {
+    using T = velocitydb::ConnectionProfile;
+    static constexpr auto value = object("id", &T::id, "name", &T::name, "server", &T::server, "port", &T::port, "database", &T::database, "username", &T::username, "useWindowsAuth",
+                                         &T::useWindowsAuth, "savePassword", &T::savePassword, "encryptedPassword", &T::encryptedPassword, "isProduction", &T::isProduction, "isReadOnly",
+                                         &T::isReadOnly, "environment", &T::environment, "dbType", &T::dbType, "ssh", &T::ssh);
+};
+
+template <>
+struct glz::meta<velocitydb::EditorSettings> {
+    using T = velocitydb::EditorSettings;
+    static constexpr auto value = object("fontSize", &T::fontSize, "fontFamily", &T::fontFamily, "wordWrap", &T::wordWrap, "tabSize", &T::tabSize, "insertSpaces", &T::insertSpaces, "showLineNumbers",
+                                         &T::showLineNumbers, "showMinimap", &T::showMinimap, "theme", &T::theme);
+};
+
+template <>
+struct glz::meta<velocitydb::GridSettings> {
+    using T = velocitydb::GridSettings;
+    static constexpr auto value =
+        object("defaultPageSize", &T::defaultPageSize, "showRowNumbers", &T::showRowNumbers, "enableCellEditing", &T::enableCellEditing, "dateFormat", &T::dateFormat, "nullDisplay", &T::nullDisplay);
+};
+
+template <>
+struct glz::meta<velocitydb::GeneralSettings> {
+    using T = velocitydb::GeneralSettings;
+    static constexpr auto value = object("autoConnect", &T::autoConnect, "lastConnectionId", &T::lastConnectionId, "confirmOnExit", &T::confirmOnExit, "maxQueryHistory", &T::maxQueryHistory,
+                                         "maxRecentConnections", &T::maxRecentConnections, "language", &T::language);
+};
+
+template <>
+struct glz::meta<velocitydb::WindowSettings> {
+    using T = velocitydb::WindowSettings;
+    static constexpr auto value = object("width", &T::width, "height", &T::height, "x", &T::x, "y", &T::y, "isMaximized", &T::isMaximized);
+};
+
+template <>
+struct glz::meta<velocitydb::AppSettings> {
+    using T = velocitydb::AppSettings;
+    static constexpr auto value = object("general", &T::general, "editor", &T::editor, "grid", &T::grid, "window", &T::window, "connectionProfiles", &T::connectionProfiles);
+};
+
+// --- Session structs ---
+
+template <>
+struct glz::meta<velocitydb::EditorTab> {
+    using T = velocitydb::EditorTab;
+    static constexpr auto value =
+        object("id", &T::id, "title", &T::title, "content", &T::content, "filePath", &T::filePath, "isDirty", &T::isDirty, "cursorLine", &T::cursorLine, "cursorColumn", &T::cursorColumn);
+};
+
+template <>
+struct glz::meta<velocitydb::SessionState> {
+    using T = velocitydb::SessionState;
+    static constexpr auto value = object("activeConnectionId", &T::activeConnectionId, "activeTabId", &T::activeTabId, "openTabs", &T::openTabs, "expandedTreeNodes", &T::expandedTreeNodes,
+                                         "windowWidth", &T::windowWidth, "windowHeight", &T::windowHeight, "windowX", &T::windowX, "windowY", &T::windowY, "isMaximized", &T::isMaximized,
+                                         "leftPanelWidth", &T::leftPanelWidth, "bottomPanelHeight", &T::bottomPanelHeight, "lastSaved", glz::custom<&T::readLastSavedEpoch, &T::writeLastSavedEpoch>);
+};

--- a/backend/utils/session_manager.h
+++ b/backend/utils/session_manager.h
@@ -31,6 +31,10 @@ struct SessionState {
     int leftPanelWidth = 250;
     int bottomPanelHeight = 200;
     std::chrono::system_clock::time_point lastSaved;
+
+    // Glaze custom serialization (lastSaved as Unix epoch seconds)
+    void readLastSavedEpoch(int64_t epoch) { lastSaved = std::chrono::system_clock::time_point(std::chrono::seconds(epoch)); }
+    [[nodiscard]] int64_t writeLastSavedEpoch() const { return std::chrono::duration_cast<std::chrono::seconds>(lastSaved.time_since_epoch()).count(); }
 };
 
 class SessionManager {

--- a/backend/utils/settings_manager.cpp
+++ b/backend/utils/settings_manager.cpp
@@ -1,8 +1,8 @@
 #include "settings_manager.h"
 
 #include "credential_protector.h"
-#include "json_utils.h"
-#include "simdjson.h"
+#include "glaze_meta.h"
+#include "logger.h"
 
 #include <Windows.h>
 
@@ -57,12 +57,17 @@ bool SettingsManager::load() {
 bool SettingsManager::save() {
     std::lock_guard lock(m_mutex);
 
+    auto json = serializeSettings();
+    if (json.empty()) {
+        return false;  // Serialization failed — preserve existing file
+    }
+
     std::ofstream file(m_settingsPath);
     if (!file.is_open()) {
         return false;
     }
 
-    file << serializeSettings();
+    file << json;
     return file.good();
 }
 
@@ -215,212 +220,21 @@ std::expected<std::string, std::string> SettingsManager::getSshKeyPassphrase(con
 }
 
 std::string SettingsManager::serializeSettings() const {
-    std::string json = "{\n";
-
-    // General settings
-    json += "  \"general\": {\n";
-    json += std::format("    \"autoConnect\": {},\n", m_settings.general.autoConnect ? "true" : "false");
-    json += std::format("    \"lastConnectionId\": \"{}\",\n", JsonUtils::escapeString(m_settings.general.lastConnectionId));
-    json += std::format("    \"confirmOnExit\": {},\n", m_settings.general.confirmOnExit ? "true" : "false");
-    json += std::format("    \"maxQueryHistory\": {},\n", m_settings.general.maxQueryHistory);
-    json += std::format("    \"maxRecentConnections\": {},\n", m_settings.general.maxRecentConnections);
-    json += std::format("    \"language\": \"{}\"\n", JsonUtils::escapeString(m_settings.general.language));
-    json += "  },\n";
-
-    // Editor settings
-    json += "  \"editor\": {\n";
-    json += std::format("    \"fontSize\": {},\n", m_settings.editor.fontSize);
-    json += std::format("    \"fontFamily\": \"{}\",\n", JsonUtils::escapeString(m_settings.editor.fontFamily));
-    json += std::format("    \"wordWrap\": {},\n", m_settings.editor.wordWrap ? "true" : "false");
-    json += std::format("    \"tabSize\": {},\n", m_settings.editor.tabSize);
-    json += std::format("    \"insertSpaces\": {},\n", m_settings.editor.insertSpaces ? "true" : "false");
-    json += std::format("    \"showLineNumbers\": {},\n", m_settings.editor.showLineNumbers ? "true" : "false");
-    json += std::format("    \"showMinimap\": {},\n", m_settings.editor.showMinimap ? "true" : "false");
-    json += std::format("    \"theme\": \"{}\"\n", JsonUtils::escapeString(m_settings.editor.theme));
-    json += "  },\n";
-
-    // Grid settings
-    json += "  \"grid\": {\n";
-    json += std::format("    \"defaultPageSize\": {},\n", m_settings.grid.defaultPageSize);
-    json += std::format("    \"showRowNumbers\": {},\n", m_settings.grid.showRowNumbers ? "true" : "false");
-    json += std::format("    \"enableCellEditing\": {},\n", m_settings.grid.enableCellEditing ? "true" : "false");
-    json += std::format("    \"dateFormat\": \"{}\",\n", JsonUtils::escapeString(m_settings.grid.dateFormat));
-    json += std::format("    \"nullDisplay\": \"{}\"\n", JsonUtils::escapeString(m_settings.grid.nullDisplay));
-    json += "  },\n";
-
-    // Window settings
-    json += "  \"window\": {\n";
-    json += std::format("    \"width\": {},\n", m_settings.window.width);
-    json += std::format("    \"height\": {},\n", m_settings.window.height);
-    json += std::format("    \"x\": {},\n", m_settings.window.x);
-    json += std::format("    \"y\": {},\n", m_settings.window.y);
-    json += std::format("    \"isMaximized\": {}\n", m_settings.window.isMaximized ? "true" : "false");
-    json += "  },\n";
-
-    // Connection profiles
-    json += "  \"connectionProfiles\": [\n";
-    for (size_t i = 0; i < m_settings.connectionProfiles.size(); ++i) {
-        const auto& profile = m_settings.connectionProfiles[i];
-        json += "    {\n";
-        json += std::format("      \"id\": \"{}\",\n", JsonUtils::escapeString(profile.id));
-        json += std::format("      \"name\": \"{}\",\n", JsonUtils::escapeString(profile.name));
-        json += std::format("      \"server\": \"{}\",\n", JsonUtils::escapeString(profile.server));
-        json += std::format("      \"port\": {},\n", profile.port);
-        json += std::format("      \"database\": \"{}\",\n", JsonUtils::escapeString(profile.database));
-        json += std::format("      \"username\": \"{}\",\n", JsonUtils::escapeString(profile.username));
-        json += std::format("      \"useWindowsAuth\": {},\n", profile.useWindowsAuth ? "true" : "false");
-        json += std::format("      \"savePassword\": {},\n", profile.savePassword ? "true" : "false");
-        json += std::format("      \"encryptedPassword\": \"{}\",\n", JsonUtils::escapeString(profile.encryptedPassword));
-        json += std::format("      \"isProduction\": {},\n", profile.isProduction ? "true" : "false");
-        json += std::format("      \"isReadOnly\": {},\n", profile.isReadOnly ? "true" : "false");
-        json += std::format("      \"environment\": \"{}\",\n", JsonUtils::escapeString(profile.environment));
-        json += std::format("      \"dbType\": \"{}\",\n", JsonUtils::escapeString(profile.dbType));
-        // SSH configuration
-        json += "      \"ssh\": {\n";
-        json += std::format("        \"enabled\": {},\n", profile.ssh.enabled ? "true" : "false");
-        json += std::format("        \"host\": \"{}\",\n", JsonUtils::escapeString(profile.ssh.host));
-        json += std::format("        \"port\": {},\n", profile.ssh.port);
-        json += std::format("        \"username\": \"{}\",\n", JsonUtils::escapeString(profile.ssh.username));
-        json += std::format("        \"authType\": \"{}\",\n", profile.ssh.authType == SshAuthType::Password ? "password" : "privateKey");
-        json += std::format("        \"encryptedPassword\": \"{}\",\n", JsonUtils::escapeString(profile.ssh.encryptedPassword));
-        json += std::format("        \"privateKeyPath\": \"{}\",\n", JsonUtils::escapeString(profile.ssh.privateKeyPath));
-        json += std::format("        \"encryptedKeyPassphrase\": \"{}\"\n", JsonUtils::escapeString(profile.ssh.encryptedKeyPassphrase));
-        json += "      }\n";
-        json += i < m_settings.connectionProfiles.size() - 1 ? "    },\n" : "    }\n";
+    std::string buffer;
+    if (auto ec = glz::write<glz::opts{.prettify = true}>(m_settings, buffer); bool(ec)) {
+        log<LogLevel::WARNING>("Failed to serialize settings");
+        return {};
     }
-    json += "  ]\n";
-
-    json += "}\n";
-    return json;
+    return buffer;
 }
 
-bool SettingsManager::deserializeSettings(std::string_view jsonStr) {
-    try {
-        simdjson::dom::parser parser;
-        auto doc = parser.parse(jsonStr);
-
-        // General settings
-        if (auto general = doc["general"]; !general.error()) {
-            if (auto val = general["autoConnect"].get_bool(); !val.error())
-                m_settings.general.autoConnect = val.value();
-            if (auto val = general["lastConnectionId"].get_string(); !val.error())
-                m_settings.general.lastConnectionId = std::string(val.value());
-            if (auto val = general["confirmOnExit"].get_bool(); !val.error())
-                m_settings.general.confirmOnExit = val.value();
-            if (auto val = general["maxQueryHistory"].get_int64(); !val.error())
-                m_settings.general.maxQueryHistory = static_cast<int>(val.value());
-            if (auto val = general["maxRecentConnections"].get_int64(); !val.error())
-                m_settings.general.maxRecentConnections = static_cast<int>(val.value());
-            if (auto val = general["language"].get_string(); !val.error())
-                m_settings.general.language = std::string(val.value());
-        }
-
-        // Editor settings
-        if (auto editor = doc["editor"]; !editor.error()) {
-            if (auto val = editor["fontSize"].get_int64(); !val.error())
-                m_settings.editor.fontSize = static_cast<int>(val.value());
-            if (auto val = editor["fontFamily"].get_string(); !val.error())
-                m_settings.editor.fontFamily = std::string(val.value());
-            if (auto val = editor["wordWrap"].get_bool(); !val.error())
-                m_settings.editor.wordWrap = val.value();
-            if (auto val = editor["tabSize"].get_int64(); !val.error())
-                m_settings.editor.tabSize = static_cast<int>(val.value());
-            if (auto val = editor["insertSpaces"].get_bool(); !val.error())
-                m_settings.editor.insertSpaces = val.value();
-            if (auto val = editor["showLineNumbers"].get_bool(); !val.error())
-                m_settings.editor.showLineNumbers = val.value();
-            if (auto val = editor["showMinimap"].get_bool(); !val.error())
-                m_settings.editor.showMinimap = val.value();
-            if (auto val = editor["theme"].get_string(); !val.error())
-                m_settings.editor.theme = std::string(val.value());
-        }
-
-        // Grid settings
-        if (auto grid = doc["grid"]; !grid.error()) {
-            if (auto val = grid["defaultPageSize"].get_int64(); !val.error())
-                m_settings.grid.defaultPageSize = static_cast<int>(val.value());
-            if (auto val = grid["showRowNumbers"].get_bool(); !val.error())
-                m_settings.grid.showRowNumbers = val.value();
-            if (auto val = grid["enableCellEditing"].get_bool(); !val.error())
-                m_settings.grid.enableCellEditing = val.value();
-            if (auto val = grid["dateFormat"].get_string(); !val.error())
-                m_settings.grid.dateFormat = std::string(val.value());
-            if (auto val = grid["nullDisplay"].get_string(); !val.error())
-                m_settings.grid.nullDisplay = std::string(val.value());
-        }
-
-        // Window settings
-        if (auto window = doc["window"]; !window.error()) {
-            if (auto val = window["width"].get_int64(); !val.error())
-                m_settings.window.width = static_cast<int>(val.value());
-            if (auto val = window["height"].get_int64(); !val.error())
-                m_settings.window.height = static_cast<int>(val.value());
-            if (auto val = window["x"].get_int64(); !val.error())
-                m_settings.window.x = static_cast<int>(val.value());
-            if (auto val = window["y"].get_int64(); !val.error())
-                m_settings.window.y = static_cast<int>(val.value());
-            if (auto val = window["isMaximized"].get_bool(); !val.error())
-                m_settings.window.isMaximized = val.value();
-        }
-
-        // Connection profiles
-        m_settings.connectionProfiles.clear();
-        if (auto profiles = doc["connectionProfiles"].get_array(); !profiles.error()) {
-            for (auto profileEl : profiles.value()) {
-                ConnectionProfile profile;
-                if (auto val = profileEl["id"].get_string(); !val.error())
-                    profile.id = std::string(val.value());
-                if (auto val = profileEl["name"].get_string(); !val.error())
-                    profile.name = std::string(val.value());
-                if (auto val = profileEl["server"].get_string(); !val.error())
-                    profile.server = std::string(val.value());
-                if (auto val = profileEl["port"].get_int64(); !val.error())
-                    profile.port = static_cast<int>(val.value());
-                if (auto val = profileEl["database"].get_string(); !val.error())
-                    profile.database = std::string(val.value());
-                if (auto val = profileEl["username"].get_string(); !val.error())
-                    profile.username = std::string(val.value());
-                if (auto val = profileEl["useWindowsAuth"].get_bool(); !val.error())
-                    profile.useWindowsAuth = val.value();
-                if (auto val = profileEl["savePassword"].get_bool(); !val.error())
-                    profile.savePassword = val.value();
-                if (auto val = profileEl["encryptedPassword"].get_string(); !val.error())
-                    profile.encryptedPassword = std::string(val.value());
-                if (auto val = profileEl["isProduction"].get_bool(); !val.error())
-                    profile.isProduction = val.value();
-                if (auto val = profileEl["isReadOnly"].get_bool(); !val.error())
-                    profile.isReadOnly = val.value();
-                if (auto val = profileEl["environment"].get_string(); !val.error())
-                    profile.environment = std::string(val.value());
-                if (auto val = profileEl["dbType"].get_string(); !val.error())
-                    profile.dbType = std::string(val.value());
-                // SSH configuration
-                if (auto ssh = profileEl["ssh"]; !ssh.error()) {
-                    if (auto val = ssh["enabled"].get_bool(); !val.error())
-                        profile.ssh.enabled = val.value();
-                    if (auto val = ssh["host"].get_string(); !val.error())
-                        profile.ssh.host = std::string(val.value());
-                    if (auto val = ssh["port"].get_int64(); !val.error())
-                        profile.ssh.port = static_cast<int>(val.value());
-                    if (auto val = ssh["username"].get_string(); !val.error())
-                        profile.ssh.username = std::string(val.value());
-                    if (auto val = ssh["authType"].get_string(); !val.error())
-                        profile.ssh.authType = (val.value() == "privateKey") ? SshAuthType::PrivateKey : SshAuthType::Password;
-                    if (auto val = ssh["encryptedPassword"].get_string(); !val.error())
-                        profile.ssh.encryptedPassword = std::string(val.value());
-                    if (auto val = ssh["privateKeyPath"].get_string(); !val.error())
-                        profile.ssh.privateKeyPath = std::string(val.value());
-                    if (auto val = ssh["encryptedKeyPassphrase"].get_string(); !val.error())
-                        profile.ssh.encryptedKeyPassphrase = std::string(val.value());
-                }
-                m_settings.connectionProfiles.push_back(profile);
-            }
-        }
-
-        return true;
-    } catch (...) {
+bool SettingsManager::deserializeSettings(std::string_view json) {
+    auto ec = glz::read_json(m_settings, json);
+    if (bool(ec)) {
+        log<LogLevel::WARNING>(std::format("Failed to parse settings.json: {}", glz::format_error(ec, json)));
         return false;
     }
+    return true;
 }
 
 }  // namespace velocitydb

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -49,5 +49,16 @@ else()
     target_compile_definitions(pugixml INTERFACE PUGIXML_HEADER_ONLY)
 endif()
 
+# Glaze - C++23 JSON reflection library
+# https://github.com/stephenberry/glaze
+include(FetchContent)
+FetchContent_Declare(
+    glaze
+    URL https://github.com/stephenberry/glaze/archive/refs/tags/v5.0.0.tar.gz
+    URL_HASH SHA256=37e4ab809f18c5497a35481f347c1ed63761324644e358d92a7a11fe647fd44a
+    EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(glaze)
+
 # Note: xlsxwriter requires separate build
 # For now, it's disabled until properly integrated


### PR DESCRIPTION
- simdjson手書きシリアライズ → glz::write_json/read_jsonに移行（-456/+247行）
- DTO層導入でencryptedPasswordのAPI漏洩を型レベルで防止
- handle*() → get*/save*/update*/delete*() 命名修正（hierarchical-architecture準拠）
- save()時のシリアライズ失敗で既存ファイルを上書きしないsafe fallback