### PR TITLE
refactor: isTransactionControl/isReadOnlyQueryのSTL化とBEGIN互換性修正

### DIFF
--- a/backend/database/async_query_executor.cpp
+++ b/backend/database/async_query_executor.cpp
@@ -3,6 +3,7 @@
 #include "../parsers/split_utils.h"
 #include "../parsers/sql_parser.h"
 
+#include <algorithm>
 #include <format>
 
 namespace velocitydb {
@@ -24,6 +25,7 @@ AsyncQueryExecutor::~AsyncQueryExecutor() {
         if (task->future.valid()) {
             // Cancel if still running
             if (task->status == QueryStatus::Running && task->driver) {
+                task->cancelled.store(true, std::memory_order_release);
                 task->driver->cancel();
             }
             // Wait for completion (this can block, but we're not holding the mutex)
@@ -45,15 +47,24 @@ std::string AsyncQueryExecutor::submitQuery(std::shared_ptr<IDatabaseDriver> dri
     auto statements = splitStatementsForDriver(sql, driver->getType());
     task->multipleResults = statements.size() > 1;
 
+    // Auto-wrap in transaction if multiple statements and no user-supplied transaction control
+    auto wrapTransaction = statements.size() > 1 && std::ranges::none_of(statements, &SQLParser::isTransactionControl);
+
     // Capture shared_ptr by value to ensure driver and task lifetime extends through async execution
     if (statements.size() > 1) {
         // Multiple statements: execute sequentially and collect all results
-        task->future = std::async(std::launch::async, [driver, statements, task]() -> QueryResultVariant {
+        task->future = std::async(std::launch::async, [driver, statements, task, wrapTransaction]() -> QueryResultVariant {
             try {
+                if (wrapTransaction)
+                    (void)driver->execute("BEGIN");
+
                 std::vector<StatementResult> allResults;
                 allResults.reserve(statements.size());
 
                 for (const auto& stmt : statements) {
+                    if (task->cancelled.load(std::memory_order_acquire))
+                        throw std::runtime_error("Query cancelled");
+
                     ResultSet currentResult;
 
                     if (SQLParser::isUseStatement(stmt)) {
@@ -75,10 +86,18 @@ std::string AsyncQueryExecutor::submitQuery(std::shared_ptr<IDatabaseDriver> dri
                     allResults.push_back(StatementResult{.statement = stmt, .result = std::move(currentResult)});
                 }
 
+                if (wrapTransaction)
+                    (void)driver->execute("COMMIT");
+
                 task->endTime = std::chrono::steady_clock::now();
                 task->status = QueryStatus::Completed;
                 return allResults;
             } catch (const std::exception& e) {
+                if (wrapTransaction)
+                    try {
+                        (void)driver->execute("ROLLBACK");
+                    } catch (...) {
+                    }
                 task->endTime = std::chrono::steady_clock::now();
                 task->errorMessage = e.what();
                 task->status = QueryStatus::Failed;
@@ -172,6 +191,7 @@ bool AsyncQueryExecutor::cancelQuery(std::string_view queryId) {
 
     auto& task = iter->second;
     if (task->status == QueryStatus::Running && task->driver) {
+        task->cancelled.store(true, std::memory_order_release);
         task->driver->cancel();
         task->status = QueryStatus::Cancelled;
         task->endTime = std::chrono::steady_clock::now();

--- a/backend/database/async_query_executor.h
+++ b/backend/database/async_query_executor.h
@@ -74,6 +74,7 @@ private:
         std::optional<QueryResultVariant> cachedResult;  // Cache result after first get()
         bool multipleResults = false;
         std::atomic<QueryStatus> status{QueryStatus::Pending};
+        std::atomic<bool> cancelled{false};
         std::shared_ptr<IDatabaseDriver> driver;  // shared_ptr to prevent use-after-free
         std::string sql;
         std::string errorMessage;

--- a/backend/parsers/sql_parser.cpp
+++ b/backend/parsers/sql_parser.cpp
@@ -222,18 +222,23 @@ std::string SQLParser::extractDatabaseName(std::string_view sql) {
 
 bool SQLParser::isReadOnlyQuery(std::string_view sql) {
     auto trimmed = trim(sql);
-    constexpr auto ci = [](unsigned char a, unsigned char b) constexpr {
-        constexpr auto lo = [](unsigned char c) constexpr -> unsigned char { return (c >= 'A' && c <= 'Z') ? static_cast<unsigned char>(c + 32) : c; };
-        return lo(a) == lo(b);
-    };
+    auto lo = [](unsigned char c) -> char { return static_cast<char>(std::tolower(c)); };
     using namespace std::string_view_literals;
-    if (std::ranges::starts_with(trimmed, "select"sv, ci))
+    if (std::ranges::starts_with(trimmed, "select"sv, {}, lo, lo))
         return true;
-    if (!std::ranges::starts_with(trimmed, "with"sv, ci))
+    if (!std::ranges::starts_with(trimmed, "with"sv, {}, lo, lo))
         return false;
     auto upper = toUpper(trimmed);
     constexpr std::string_view dmlKeywords[] = {"INSERT", "UPDATE", "DELETE", "MERGE"};
     return std::ranges::none_of(dmlKeywords, [&](auto kw) { return upper.find(kw) != std::string::npos; });
+}
+
+bool SQLParser::isTransactionControl(std::string_view sql) {
+    auto trimmed = trim(sql);
+    auto lo = [](unsigned char c) -> char { return static_cast<char>(std::tolower(c)); };
+    using namespace std::string_view_literals;
+    constexpr std::string_view prefixes[] = {"begin"sv, "commit"sv, "rollback"sv, "start transaction"sv};
+    return std::ranges::any_of(prefixes, [&](auto p) { return std::ranges::starts_with(trimmed, p, {}, lo, lo); });
 }
 
 // Backward-compatible: no block detection

--- a/backend/parsers/sql_parser.h
+++ b/backend/parsers/sql_parser.h
@@ -31,6 +31,9 @@ public:
     /// Check if the SQL starts with SELECT or WITH (i.e. read-only query).
     [[nodiscard]] static bool isReadOnlyQuery(std::string_view sql);
 
+    /// Check if the SQL is a transaction control statement (BEGIN/COMMIT/ROLLBACK/START TRANSACTION)
+    [[nodiscard]] static bool isTransactionControl(std::string_view sql);
+
     /// Split SQL text into individual statements (semicolon-delimited)
     /// No block detection — backward-compatible with existing callers
     [[nodiscard]] static std::vector<std::string> splitStatements(std::string_view sql);

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -14,6 +14,7 @@
 #include "../utils/sql_validation.h"
 #include "simdjson.h"
 
+#include <algorithm>
 #include <chrono>
 #include <format>
 
@@ -54,9 +55,13 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
                 ResultSet result;
             };
             std::vector<StatementResult> allResults;
+            auto wrapTransaction = std::ranges::none_of(statements, &SQLParser::isTransactionControl);
 
             size_t stmtIdx = 0;
             try {
+                if (wrapTransaction)
+                    (void)driver->execute("BEGIN");
+
                 for (const auto& stmt : statements) {
                     auto stmtStart = std::chrono::high_resolution_clock::now();
                     ResultSet currentResult;
@@ -77,6 +82,9 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
                     ++stmtIdx;
                 }
 
+                if (wrapTransaction)
+                    (void)driver->execute("COMMIT");
+
                 std::string jsonResponse = R"({"multipleResults":true,"results":[)";
                 for (size_t i = 0; i < allResults.size(); ++i) {
                     if (i > 0)
@@ -90,6 +98,11 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
                 jsonResponse += "]}";
                 return JsonUtils::successResponse(jsonResponse);
             } catch (const std::exception& e) {
+                if (wrapTransaction)
+                    try {
+                        (void)driver->execute("ROLLBACK");
+                    } catch (...) {
+                    }
                 return JsonUtils::errorResponse(std::format("Statement {} of {}: {}", stmtIdx + 1, statements.size(), e.what()));
             }
         }

--- a/tests/parsers/test_sql_parser.cpp
+++ b/tests/parsers/test_sql_parser.cpp
@@ -170,6 +170,42 @@ TEST_F(SQLParserSplitTest, NoSemicolonSingleStatement) {
     EXPECT_NE(stmts[0].find("SELECT 1"), std::string::npos);
 }
 
+// ===== isTransactionControl =====
+
+TEST(SQLParserTest, IsTransactionControlBegin) {
+    EXPECT_TRUE(SQLParser::isTransactionControl("BEGIN"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("begin"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("BEGIN TRANSACTION"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("  BEGIN  "));
+}
+
+TEST(SQLParserTest, IsTransactionControlCommit) {
+    EXPECT_TRUE(SQLParser::isTransactionControl("COMMIT"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("commit"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("  COMMIT  "));
+}
+
+TEST(SQLParserTest, IsTransactionControlRollback) {
+    EXPECT_TRUE(SQLParser::isTransactionControl("ROLLBACK"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("rollback"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("  ROLLBACK  "));
+}
+
+TEST(SQLParserTest, IsTransactionControlStartTransaction) {
+    EXPECT_TRUE(SQLParser::isTransactionControl("START TRANSACTION"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("start transaction"));
+    EXPECT_TRUE(SQLParser::isTransactionControl("  START TRANSACTION  "));
+    EXPECT_TRUE(SQLParser::isTransactionControl("Start Transaction"));
+}
+
+TEST(SQLParserTest, IsTransactionControlNegative) {
+    EXPECT_FALSE(SQLParser::isTransactionControl("SELECT 1"));
+    EXPECT_FALSE(SQLParser::isTransactionControl("SET x = 1"));
+    EXPECT_FALSE(SQLParser::isTransactionControl("INSERT INTO t VALUES (1)"));
+    EXPECT_FALSE(SQLParser::isTransactionControl("CREATE TABLE t (id int)"));
+    EXPECT_FALSE(SQLParser::isTransactionControl(""));
+}
+
 // ===== CopyBlockDetector unit tests =====
 
 class CopyBlockDetectorTest : public ::testing::Test {


### PR DESCRIPTION
- BEGIN TRANSACTION → BEGIN（MySQL互換）
- isTransactionControl: toUpperコピー排除、projection方式 + START TRANSACTION追加
- isReadOnlyQuery: hand-rolled tolower → std::tolower projection統一
- [[nodiscard]]警告を(void)キャストで抑制
- テストケース追加（START TRANSACTION）