### PR TITLE
refactor: FE→BE責務分離（履歴記録・port結合・行truncation・CRUD IPC）

### DIFF
--- a/backend/contexts/system_context.cpp
+++ b/backend/contexts/system_context.cpp
@@ -1,5 +1,6 @@
 #include "system_context.h"
 
+#include "../database/query_history.h"
 #include "../providers/async_query_provider.h"
 #include "../providers/connection_provider.h"
 #include "../providers/export_provider.h"
@@ -15,8 +16,9 @@ namespace velocitydb {
 
 SystemContext::SystemContext()
     : m_connections(std::make_unique<ConnectionProvider>())
-    , m_queries(std::make_unique<QueryProvider>(*m_connections))
-    , m_asyncQueries(std::make_unique<AsyncQueryProvider>(*m_connections))
+    , m_queryHistory(std::make_unique<QueryHistory>())
+    , m_queries(std::make_unique<QueryProvider>(*m_connections, *m_queryHistory))
+    , m_asyncQueries(std::make_unique<AsyncQueryProvider>(*m_connections, *m_queryHistory))
     , m_schema(std::make_unique<SchemaProvider>(*m_connections))
     , m_transactions(std::make_unique<TransactionProvider>(*m_connections))
     , m_exports(std::make_unique<ExportProvider>(*m_connections))

--- a/backend/contexts/system_context.h
+++ b/backend/contexts/system_context.h
@@ -6,6 +6,8 @@
 
 namespace velocitydb {
 
+class QueryHistory;
+
 /// Concrete implementation of ISystemContext, owning all provider instances.
 class SystemContext : public ISystemContext {
 public:
@@ -30,6 +32,7 @@ public:
 
 private:
     std::unique_ptr<IConnectionProvider> m_connections;
+    std::unique_ptr<QueryHistory> m_queryHistory;
     std::unique_ptr<IQueryProvider> m_queries;
     std::unique_ptr<IAsyncQueryProvider> m_asyncQueries;
     std::unique_ptr<ISchemaProvider> m_schema;

--- a/backend/database/async_query_executor.cpp
+++ b/backend/database/async_query_executor.cpp
@@ -2,6 +2,7 @@
 
 #include "../parsers/split_utils.h"
 #include "../parsers/sql_parser.h"
+#include "../utils/string_utils.h"
 
 #include <algorithm>
 #include <format>
@@ -83,7 +84,7 @@ std::string AsyncQueryExecutor::submitQuery(std::shared_ptr<IDatabaseDriver> dri
                         currentResult = driver->execute(stmt);
                     }
 
-                    allResults.push_back(StatementResult{.statement = stmt, .result = std::move(currentResult)});
+                    allResults.push_back(StatementResult{.statement = std::string(firstLine(stmt)), .result = std::move(currentResult)});
                 }
 
                 if (wrapTransaction)

--- a/backend/database/connection_utils.cpp
+++ b/backend/database/connection_utils.cpp
@@ -120,6 +120,16 @@ std::expected<DatabaseConnectionParams, std::string> extractConnectionParams(std
             }
         }
 
+        // Combine port into server string ("host,port") — must be after dbType parsing.
+        // When port equals the default for the dbType, skip combining: splitHostPort()
+        // in buildConnectionString() already falls back to defaultDbPort().
+        if (auto port = doc["port"].get_int64(); !port.error()) {
+            auto portVal = static_cast<int>(port.value());
+            if (portVal >= 1 && portVal <= 65535 && portVal != defaultDbPort(result.dbType)) {
+                result.server = std::format("{},{}", result.server, portVal);
+            }
+        }
+
         // Extract SSH settings
         auto sshObj = doc["ssh"];
         if (!sshObj.error()) {

--- a/backend/database/query_history.h
+++ b/backend/database/query_history.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
+#include <format>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -8,6 +10,25 @@
 #include <vector>
 
 namespace velocitydb {
+
+/// Truncate SQL to a safe size for history storage.
+constexpr size_t MAX_HISTORY_SQL_BYTES = 10240;  // 10KB
+
+[[nodiscard]] inline std::string truncateHistorySql(std::string_view sql) {
+    if (sql.size() <= MAX_HISTORY_SQL_BYTES)
+        return std::string(sql);
+    // Back off from MAX to avoid splitting a multi-byte UTF-8 character.
+    auto pos = MAX_HISTORY_SQL_BYTES;
+    while (pos > 0 && (static_cast<unsigned char>(sql[pos]) & 0xC0) == 0x80)
+        --pos;
+    return std::string(sql.substr(0, pos));
+}
+
+/// Generate a unique history ID (timestamp + monotonic counter).
+[[nodiscard]] inline std::string generateHistoryId() {
+    static std::atomic<uint64_t> counter{0};
+    return std::format("hist_{}_{}", std::chrono::system_clock::now().time_since_epoch().count(), counter.fetch_add(1, std::memory_order_relaxed));
+}
 
 struct HistoryItem {
     std::string id;

--- a/backend/interfaces/providers/query_provider.h
+++ b/backend/interfaces/providers/query_provider.h
@@ -18,6 +18,9 @@ public:
     [[nodiscard]] virtual std::string handleGetCacheStats(std::string_view params) = 0;
     [[nodiscard]] virtual std::string handleClearCache(std::string_view params) = 0;
     [[nodiscard]] virtual std::string handleGetQueryHistory(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string handleRemoveQueryHistory(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string handleClearQueryHistory(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string handleSetQueryHistoryFavorite(std::string_view params) = 0;
 };
 
 }  // namespace velocitydb

--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -68,6 +68,9 @@ void IPCHandler::registerRoutes() {
     m_routes["getCacheStats"] = [this](auto p) { return m_ctx.queries().handleGetCacheStats(p); };
     m_routes["clearCache"] = [this](auto p) { return m_ctx.queries().handleClearCache(p); };
     m_routes["getQueryHistory"] = [this](auto p) { return m_ctx.queries().handleGetQueryHistory(p); };
+    m_routes["removeQueryHistory"] = [this](auto p) { return m_ctx.queries().handleRemoveQueryHistory(p); };
+    m_routes["clearQueryHistory"] = [this](auto p) { return m_ctx.queries().handleClearQueryHistory(p); };
+    m_routes["setQueryHistoryFavorite"] = [this](auto p) { return m_ctx.queries().handleSetQueryHistoryFavorite(p); };
 
     // Filter
     m_routes["filterResultSet"] = [this](auto p) { return m_ctx.queries().handleFilterResultSet(p); };

--- a/backend/parsers/sql_parser.cpp
+++ b/backend/parsers/sql_parser.cpp
@@ -99,25 +99,26 @@ size_t advanceLexer(LexerState& lex, std::string_view sql, size_t i) {
     return 0;
 }
 
-/// Remove psql meta-command lines (\-prefixed), preserving \. (COPY terminator).
+/// True if line is a psql meta-command (lowercase \cmd), excluding \. (COPY terminator).
+bool isPsqlMetaCommand(std::string_view line) {
+    auto t = trim(line);
+    if (t.size() < 2 || t.front() != '\\' || t == "\\.")
+        return false;
+    return std::islower(static_cast<unsigned char>(t[1])) != 0;
+}
+
+/// Remove psql meta-command lines, preserving \. (COPY terminator).
 std::string filterPsqlMetaCommands(std::string_view sql) {
     std::string result;
     result.reserve(sql.size());
     size_t pos = 0;
     while (pos < sql.size()) {
-        auto lineEnd = sql.find('\n', pos);
-        bool hasNewline = (lineEnd != std::string_view::npos);
-        if (!hasNewline)
-            lineEnd = sql.size();
-        auto line = sql.substr(pos, lineEnd - pos);
-        auto trimmedLine = trim(line);
-        bool isMetaCommand = !trimmedLine.empty() && trimmedLine.front() == '\\' && trimmedLine != "\\.";
-        if (!isMetaCommand) {
+        auto nl = sql.find('\n', pos);
+        auto end = (nl != std::string_view::npos) ? nl + 1 : sql.size();
+        auto line = sql.substr(pos, end - pos);
+        if (!isPsqlMetaCommand(line))
             result.append(line);
-            if (hasNewline)
-                result.push_back('\n');
-        }
-        pos = hasNewline ? lineEnd + 1 : sql.size();
+        pos = end;
     }
     return result;
 }
@@ -211,8 +212,9 @@ ParsedSQL SQLParser::parseSQL(std::string_view sql) {
 }
 
 bool SQLParser::isUseStatement(std::string_view sql) {
-    auto parsed = parseSQL(sql);
-    return parsed.type == "USE";
+    auto trimmed = trim(sql);
+    using namespace std::string_view_literals;
+    return trimmed.size() > 3 && std::ranges::starts_with(trimmed, "use"sv, {}, toLowerChar, toLowerChar) && std::isspace(static_cast<unsigned char>(trimmed[3]));
 }
 
 std::string SQLParser::extractDatabaseName(std::string_view sql) {
@@ -222,23 +224,20 @@ std::string SQLParser::extractDatabaseName(std::string_view sql) {
 
 bool SQLParser::isReadOnlyQuery(std::string_view sql) {
     auto trimmed = trim(sql);
-    auto lo = [](unsigned char c) -> char { return static_cast<char>(std::tolower(c)); };
     using namespace std::string_view_literals;
-    if (std::ranges::starts_with(trimmed, "select"sv, {}, lo, lo))
+    if (std::ranges::starts_with(trimmed, "select"sv, {}, toLowerChar, toLowerChar))
         return true;
-    if (!std::ranges::starts_with(trimmed, "with"sv, {}, lo, lo))
+    if (!std::ranges::starts_with(trimmed, "with"sv, {}, toLowerChar, toLowerChar))
         return false;
-    auto upper = toUpper(trimmed);
     constexpr std::string_view dmlKeywords[] = {"INSERT", "UPDATE", "DELETE", "MERGE"};
-    return std::ranges::none_of(dmlKeywords, [&](auto kw) { return upper.find(kw) != std::string::npos; });
+    return std::ranges::none_of(dmlKeywords, [&](auto kw) { return !std::ranges::search(trimmed, kw, {}, toLowerChar, toLowerChar).empty(); });
 }
 
 bool SQLParser::isTransactionControl(std::string_view sql) {
     auto trimmed = trim(sql);
-    auto lo = [](unsigned char c) -> char { return static_cast<char>(std::tolower(c)); };
     using namespace std::string_view_literals;
     constexpr std::string_view prefixes[] = {"begin"sv, "commit"sv, "rollback"sv, "start transaction"sv};
-    return std::ranges::any_of(prefixes, [&](auto p) { return std::ranges::starts_with(trimmed, p, {}, lo, lo); });
+    return std::ranges::any_of(prefixes, [&](auto p) { return std::ranges::starts_with(trimmed, p, {}, toLowerChar, toLowerChar); });
 }
 
 // Backward-compatible: no block detection

--- a/backend/providers/async_query_provider.cpp
+++ b/backend/providers/async_query_provider.cpp
@@ -2,6 +2,7 @@
 
 #include "../database/async_query_executor.h"
 #include "../database/driver_interface.h"
+#include "../database/query_history.h"
 #include "../interfaces/providers/connection_provider.h"
 #include "../utils/json_utils.h"
 #include "simdjson.h"
@@ -10,7 +11,8 @@
 
 namespace velocitydb {
 
-AsyncQueryProvider::AsyncQueryProvider(IConnectionProvider& connections) : m_connections(connections), m_asyncExecutor(std::make_unique<AsyncQueryExecutor>()) {}
+AsyncQueryProvider::AsyncQueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory)
+    : m_connections(connections), m_queryHistory(queryHistory), m_asyncExecutor(std::make_unique<AsyncQueryExecutor>()) {}
 
 AsyncQueryProvider::~AsyncQueryProvider() = default;
 
@@ -33,6 +35,7 @@ std::string AsyncQueryProvider::handleExecuteAsyncQuery(std::string_view params)
         }
 
         std::string queryId = m_asyncExecutor->submitQuery(driver, sqlQuery);
+        m_queryMeta[queryId] = {.connectionId = connectionId, .sql = truncateHistorySql(sqlQuery)};
         return JsonUtils::successResponse(std::format(R"({{"queryId":"{}"}})", queryId));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
@@ -98,6 +101,33 @@ std::string AsyncQueryProvider::handleGetAsyncQueryResult(std::string_view param
             JsonUtils::appendResultSetFields(jsonResponse, *asyncResult.result);
         }
 
+        // Record history on completion/failure; erase meta on any terminal status to prevent leaks
+        if (auto metaIt = m_queryMeta.find(queryId); metaIt != m_queryMeta.end()) {
+            bool terminal = asyncResult.status == QueryStatus::Completed || asyncResult.status == QueryStatus::Failed || asyncResult.status == QueryStatus::Cancelled;
+            if (asyncResult.status == QueryStatus::Completed || asyncResult.status == QueryStatus::Failed) {
+                double totalExecMs = 0.0;
+                int64_t totalAffected = 0;
+                if (asyncResult.result.has_value()) {
+                    totalExecMs = asyncResult.result->executionTimeMs;
+                    totalAffected = static_cast<int64_t>(asyncResult.result->affectedRows);
+                }
+                for (const auto& r : asyncResult.results) {
+                    totalExecMs += r.result.executionTimeMs;
+                    totalAffected += static_cast<int64_t>(r.result.affectedRows);
+                }
+                m_queryHistory.add({.id = generateHistoryId(),
+                                    .sql = metaIt->second.sql,
+                                    .connectionId = metaIt->second.connectionId,
+                                    .executionTimeMs = totalExecMs,
+                                    .success = (asyncResult.status == QueryStatus::Completed),
+                                    .errorMessage = asyncResult.errorMessage,
+                                    .affectedRows = totalAffected,
+                                    .isFavorite = false});
+            }
+            if (terminal)
+                m_queryMeta.erase(metaIt);
+        }
+
         jsonResponse += "}";
         return JsonUtils::successResponse(jsonResponse);
     } catch (const std::exception& e) {
@@ -130,7 +160,9 @@ std::string AsyncQueryProvider::handleRemoveAsyncQuery(std::string_view params) 
         if (queryIdResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required field: queryId");
         }
-        bool removed = m_asyncExecutor->removeQuery(std::string(queryIdResult.value()));
+        auto qid = std::string(queryIdResult.value());
+        bool removed = m_asyncExecutor->removeQuery(qid);
+        m_queryMeta.erase(qid);
         return JsonUtils::successResponse(std::format(R"({{"removed":{}}})", removed ? "true" : "false"));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());

--- a/backend/providers/async_query_provider.h
+++ b/backend/providers/async_query_provider.h
@@ -5,16 +5,18 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 
 namespace velocitydb {
 
 class IConnectionProvider;
 class AsyncQueryExecutor;
+class QueryHistory;
 
 /// Provider for asynchronous query execution
 class AsyncQueryProvider : public IAsyncQueryProvider {
 public:
-    explicit AsyncQueryProvider(IConnectionProvider& connections);
+    AsyncQueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory);
     ~AsyncQueryProvider() override;
 
     AsyncQueryProvider(const AsyncQueryProvider&) = delete;
@@ -29,8 +31,16 @@ public:
     [[nodiscard]] std::string handleRemoveAsyncQuery(std::string_view params) override;
 
 private:
+    struct QueryMeta {
+        std::string connectionId;
+        std::string sql;
+    };
+
     IConnectionProvider& m_connections;
+    QueryHistory& m_queryHistory;
     std::unique_ptr<AsyncQueryExecutor> m_asyncExecutor;
+    // Accessed only from WebView2 UI thread (IPC calls are serialized). No mutex needed.
+    std::unordered_map<std::string, QueryMeta> m_queryMeta;
 };
 
 }  // namespace velocitydb

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -12,6 +12,7 @@
 #include "../utils/logger.h"
 #include "../utils/simd_filter.h"
 #include "../utils/sql_validation.h"
+#include "../utils/string_utils.h"
 #include "simdjson.h"
 
 #include <algorithm>
@@ -22,11 +23,25 @@ using namespace std::literals;
 
 namespace velocitydb {
 
-QueryProvider::QueryProvider(IConnectionProvider& connections) : m_connections(connections), m_resultCache(std::make_unique<ResultCache>()), m_queryHistory(std::make_unique<QueryHistory>()) {}
+QueryProvider::QueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory) : m_connections(connections), m_resultCache(std::make_unique<ResultCache>()), m_queryHistory(queryHistory) {}
 
 QueryProvider::~QueryProvider() = default;
 
+void QueryProvider::recordHistory(const std::string& sql, const std::string& connectionId, double execTimeMs, bool success, std::string_view errorMsg, int64_t affectedRows) {
+    m_queryHistory.add({.id = generateHistoryId(),
+                        .sql = truncateHistorySql(sql),
+                        .connectionId = connectionId,
+                        .executionTimeMs = execTimeMs,
+                        .success = success,
+                        .errorMessage = std::string(errorMsg),
+                        .affectedRows = affectedRows,
+                        .isFavorite = false});
+}
+
 std::string QueryProvider::handleExecuteQuery(std::string_view params) {
+    std::string connectionId;
+    std::string sqlQuery;
+
     try {
         simdjson::dom::parser parser;
         auto doc = parser.parse(params);
@@ -36,8 +51,8 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
         if (connectionIdResult.error() || sqlQueryResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or sql");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto sqlQuery = std::string(sqlQueryResult.value());
+        connectionId = std::string(connectionIdResult.value());
+        sqlQuery = std::string(sqlQueryResult.value());
 
         auto driver = m_connections.getQueryDriver(connectionId);
         if (!driver) [[unlikely]] {
@@ -78,12 +93,21 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
                     }
                     auto stmtEnd = std::chrono::high_resolution_clock::now();
                     currentResult.executionTimeMs = std::chrono::duration<double, std::milli>(stmtEnd - stmtStart).count();
-                    allResults.push_back({.statement = stmt, .result = std::move(currentResult)});
+                    allResults.push_back({.statement = std::string(firstLine(stmt)), .result = std::move(currentResult)});
                     ++stmtIdx;
                 }
 
                 if (wrapTransaction)
                     (void)driver->execute("COMMIT");
+
+                // Record history for multi-statement execution
+                double totalExecMs = 0.0;
+                int64_t totalAffected = 0;
+                for (const auto& r : allResults) {
+                    totalExecMs += r.result.executionTimeMs;
+                    totalAffected += static_cast<int64_t>(r.result.affectedRows);
+                }
+                recordHistory(sqlQuery, connectionId, totalExecMs, true, {}, totalAffected);
 
                 std::string jsonResponse = R"({"multipleResults":true,"results":[)";
                 for (size_t i = 0; i < allResults.size(); ++i) {
@@ -103,7 +127,9 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
                         (void)driver->execute("ROLLBACK");
                     } catch (...) {
                     }
-                return JsonUtils::errorResponse(std::format("Statement {} of {}: {}", stmtIdx + 1, statements.size(), e.what()));
+                auto errorMsg = std::format("Statement {} of {}: {}", stmtIdx + 1, statements.size(), e.what());
+                recordHistory(sqlQuery, connectionId, 0.0, false, errorMsg);
+                return JsonUtils::errorResponse(errorMsg);
             }
         }
 
@@ -119,9 +145,12 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
                 useResult.rows.push_back(messageRow);
                 useResult.affectedRows = 0;
                 useResult.executionTimeMs = 0.0;
+                recordHistory(sqlQuery, connectionId, 0.0, true);
                 return JsonUtils::successResponse(JsonUtils::serializeResultSet(useResult, false));
             } catch (const std::exception& e) {
-                return JsonUtils::errorResponse(std::format("Failed to switch database: {}", e.what()));
+                auto errorMsg = std::format("Failed to switch database: {}", e.what());
+                recordHistory(sqlQuery, connectionId, 0.0, false, errorMsg);
+                return JsonUtils::errorResponse(errorMsg);
             }
         }
 
@@ -150,16 +179,13 @@ std::string QueryProvider::handleExecuteQuery(std::string_view params) {
 
         std::string jsonResponse = JsonUtils::serializeResultSet(queryResult, false);
 
-        HistoryItem historyEntry{.id = std::format("hist_{}", std::chrono::system_clock::now().time_since_epoch().count()),
-                                 .sql = sqlQuery,
-                                 .executionTimeMs = queryResult.executionTimeMs,
-                                 .success = true,
-                                 .affectedRows = static_cast<int64_t>(queryResult.affectedRows),
-                                 .isFavorite = false};
-        m_queryHistory->add(historyEntry);
+        recordHistory(sqlQuery, connectionId, queryResult.executionTimeMs, true, {}, static_cast<int64_t>(queryResult.affectedRows));
 
         return JsonUtils::successResponse(jsonResponse);
     } catch (const std::exception& e) {
+        if (!sqlQuery.empty()) {
+            recordHistory(sqlQuery, connectionId, 0.0, false, e.what());
+        }
         return JsonUtils::errorResponse(e.what());
     }
 }
@@ -346,12 +372,50 @@ std::string QueryProvider::handleClearCache(std::string_view) {
 }
 
 std::string QueryProvider::handleGetQueryHistory(std::string_view) {
-    auto historyEntries = m_queryHistory->getAll();
+    auto historyEntries = m_queryHistory.getAll();
     auto jsonResponse = JsonUtils::buildArray(historyEntries, [](std::string& out, const HistoryItem& e) {
-        out += std::format(R"({{"id":"{}","sql":"{}","executionTimeMs":{},"success":{},"affectedRows":{},"isFavorite":{}}})", e.id, JsonUtils::escapeString(e.sql), e.executionTimeMs,
-                           e.success ? "true" : "false", e.affectedRows, e.isFavorite ? "true" : "false");
+        auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(e.timestamp.time_since_epoch()).count();
+        out += std::format(R"({{"id":"{}","sql":"{}","connectionId":"{}","timestamp":{},"executionTimeMs":{},"success":{},"errorMessage":"{}","affectedRows":{},"isFavorite":{}}})", e.id,
+                           JsonUtils::escapeString(e.sql), JsonUtils::escapeString(e.connectionId), timestamp, e.executionTimeMs, e.success ? "true" : "false", JsonUtils::escapeString(e.errorMessage),
+                           e.affectedRows, e.isFavorite ? "true" : "false");
     });
     return JsonUtils::successResponse(jsonResponse);
+}
+
+std::string QueryProvider::handleRemoveQueryHistory(std::string_view params) {
+    try {
+        simdjson::dom::parser parser;
+        auto doc = parser.parse(params);
+        auto idResult = doc["id"].get_string();
+        if (idResult.error()) [[unlikely]] {
+            return JsonUtils::errorResponse("Missing required field: id");
+        }
+        m_queryHistory.remove(idResult.value());
+        return JsonUtils::successResponse(R"({"removed":true})");
+    } catch (const std::exception& e) {
+        return JsonUtils::errorResponse(e.what());
+    }
+}
+
+std::string QueryProvider::handleClearQueryHistory(std::string_view) {
+    m_queryHistory.clear();
+    return JsonUtils::successResponse(R"({"cleared":true})");
+}
+
+std::string QueryProvider::handleSetQueryHistoryFavorite(std::string_view params) {
+    try {
+        simdjson::dom::parser parser;
+        auto doc = parser.parse(params);
+        auto idResult = doc["id"].get_string();
+        auto isFavoriteResult = doc["isFavorite"].get_bool();
+        if (idResult.error() || isFavoriteResult.error()) [[unlikely]] {
+            return JsonUtils::errorResponse("Missing required fields: id or isFavorite");
+        }
+        m_queryHistory.setFavorite(idResult.value(), isFavoriteResult.value());
+        return JsonUtils::successResponse(R"({"updated":true})");
+    } catch (const std::exception& e) {
+        return JsonUtils::errorResponse(e.what());
+    }
 }
 
 }  // namespace velocitydb

--- a/backend/providers/query_provider.h
+++ b/backend/providers/query_provider.h
@@ -15,7 +15,7 @@ class QueryHistory;
 /// Provider for query execution, cache, history, and filtering
 class QueryProvider : public IQueryProvider {
 public:
-    explicit QueryProvider(IConnectionProvider& connections);
+    QueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory);
     ~QueryProvider() override;
 
     QueryProvider(const QueryProvider&) = delete;
@@ -31,11 +31,16 @@ public:
     [[nodiscard]] std::string handleGetCacheStats(std::string_view params) override;
     [[nodiscard]] std::string handleClearCache(std::string_view params) override;
     [[nodiscard]] std::string handleGetQueryHistory(std::string_view params) override;
+    [[nodiscard]] std::string handleRemoveQueryHistory(std::string_view params) override;
+    [[nodiscard]] std::string handleClearQueryHistory(std::string_view params) override;
+    [[nodiscard]] std::string handleSetQueryHistoryFavorite(std::string_view params) override;
 
 private:
+    void recordHistory(const std::string& sql, const std::string& connectionId, double execTimeMs, bool success, std::string_view errorMsg = {}, int64_t affectedRows = 0);
+
     IConnectionProvider& m_connections;
     std::unique_ptr<ResultCache> m_resultCache;
-    std::unique_ptr<QueryHistory> m_queryHistory;
+    QueryHistory& m_queryHistory;
 };
 
 }  // namespace velocitydb

--- a/backend/utils/json_utils.cpp
+++ b/backend/utils/json_utils.cpp
@@ -80,8 +80,10 @@ void JsonUtils::appendResultSetFields(std::string& json, const ResultSet& result
     appendColumns(json, result.columns);
     json += R"(,"rows":[)";
 
-    // Rows array - minimize allocations and function calls
-    for (size_t rowIndex = 0; rowIndex < result.rows.size(); ++rowIndex) {
+    auto rowCount = std::min(result.rows.size(), QUERY_ROW_LIMIT);
+    bool truncated = result.rows.size() > QUERY_ROW_LIMIT;
+
+    for (size_t rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
         if (rowIndex > 0)
             json += ',';
         json += '[';
@@ -100,14 +102,17 @@ void JsonUtils::appendResultSetFields(std::string& json, const ResultSet& result
     json += std::to_string(result.affectedRows);
     json += R"(,"executionTimeMs":)";
     json += std::to_string(result.executionTimeMs);
+    json += R"(,"truncated":)";
+    json += truncated ? "true" : "false";
 }
 
 std::string JsonUtils::serializeResultSet(const ResultSet& result, bool cached) {
     // Buffer size estimation: base (~150) + columns (~65 each) + rows (per-cell ~2x + overhead)
+    auto rowLimit = std::min(result.rows.size(), QUERY_ROW_LIMIT);
     size_t estimatedSize = 150 + result.columns.size() * 65;
-    for (const auto& row : result.rows) {
+    for (size_t i = 0; i < rowLimit; ++i) {
         estimatedSize += 10;
-        for (const auto& val : row.values) {
+        for (const auto& val : result.rows[i].values) {
             estimatedSize += val.size() * 2 + 5;
         }
     }

--- a/backend/utils/json_utils.h
+++ b/backend/utils/json_utils.h
@@ -18,7 +18,11 @@ public:
     [[nodiscard]] static std::string errorResponse(std::string_view message);
     [[nodiscard]] static std::string escapeString(std::string_view str);
 
+    /// Maximum rows returned per result set (truncated beyond this).
+    static constexpr size_t QUERY_ROW_LIMIT = 10'000;
+
     /// Serialize a ResultSet to JSON with pre-allocated buffer for performance.
+    /// Rows exceeding QUERY_ROW_LIMIT are truncated with a "truncated" flag.
     /// @param result The query result to serialize
     /// @param cached Whether the result was from cache
     /// @return JSON string representation
@@ -27,7 +31,8 @@ public:
     /// Append column definitions as JSON array field: "columns":[...]
     static void appendColumns(std::string& json, const std::vector<ColumnInfo>& columns);
 
-    /// Append ResultSet columns/rows/affectedRows/executionTimeMs as JSON fields (no outer braces).
+    /// Append ResultSet columns/rows/affectedRows/executionTimeMs/truncated as JSON fields (no outer braces).
+    /// Rows exceeding QUERY_ROW_LIMIT are truncated.
     /// Use when embedding ResultSet data into a larger JSON object.
     static void appendResultSetFields(std::string& json, const ResultSet& result);
 

--- a/backend/utils/string_utils.h
+++ b/backend/utils/string_utils.h
@@ -18,11 +18,18 @@ namespace velocitydb {
     return str.substr(start - str.begin(), end - start);
 }
 
+/// Case-insensitive char projection for std::ranges algorithms
+inline constexpr auto toLowerChar = [](unsigned char c) -> char { return static_cast<char>(std::tolower(c)); };
+
 /// Convert string to uppercase
 [[nodiscard]] inline std::string toUpper(std::string_view str) {
-    std::string result(str);
-    std::ranges::transform(result, result.begin(), [](unsigned char c) { return std::toupper(c); });
-    return result;
+    return str | std::views::transform([](unsigned char c) -> char { return static_cast<char>(std::toupper(c)); }) | std::ranges::to<std::string>();
+}
+
+/// Extract the first line as a display label (for multi-line statements like COPY blocks).
+[[nodiscard]] inline std::string_view firstLine(std::string_view str) {
+    auto nl = str.find('\n');
+    return nl != std::string_view::npos ? str.substr(0, nl) : str;
 }
 
 }  // namespace velocitydb

--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -212,18 +212,7 @@ class Bridge {
       keyPassphrase?: string;
     };
   }): Promise<{ connectionId: string }> {
-    // Build server string with port if provided
-    const defaultPort =
-      connectionInfo.dbType === 'postgresql'
-        ? 5432
-        : connectionInfo.dbType === 'mysql'
-          ? 3306
-          : 1433;
-    const serverWithPort =
-      connectionInfo.port && connectionInfo.port !== defaultPort
-        ? `${connectionInfo.server},${connectionInfo.port}`
-        : connectionInfo.server;
-    return this.call('connect', { ...connectionInfo, server: serverWithPort });
+    return this.call('connect', connectionInfo);
   }
 
   async disconnect(connectionId: string): Promise<void> {
@@ -249,21 +238,7 @@ class Bridge {
       keyPassphrase?: string;
     };
   }): Promise<{ success: boolean; message: string }> {
-    // Build server string with port if provided
-    const defaultPort =
-      connectionInfo.dbType === 'postgresql'
-        ? 5432
-        : connectionInfo.dbType === 'mysql'
-          ? 3306
-          : 1433;
-    const serverWithPort =
-      connectionInfo.port && connectionInfo.port !== defaultPort
-        ? `${connectionInfo.server},${connectionInfo.port}`
-        : connectionInfo.server;
-    return this.call('testConnection', {
-      ...connectionInfo,
-      server: serverWithPort,
-    });
+    return this.call('testConnection', connectionInfo);
   }
 
   // Query methods
@@ -400,12 +375,28 @@ class Bridge {
     {
       id: string;
       sql: string;
+      connectionId: string;
       timestamp: number;
       executionTimeMs: number;
       success: boolean;
+      errorMessage: string;
+      affectedRows: number;
+      isFavorite: boolean;
     }[]
   > {
     return this.call('getQueryHistory', {});
+  }
+
+  async removeQueryHistory(id: string): Promise<{ removed: boolean }> {
+    return this.call('removeQueryHistory', { id });
+  }
+
+  async clearQueryHistory(): Promise<{ cleared: boolean }> {
+    return this.call('clearQueryHistory', {});
+  }
+
+  async setQueryHistoryFavorite(id: string, isFavorite: boolean): Promise<{ updated: boolean }> {
+    return this.call('setQueryHistoryFavorite', { id, isFavorite });
   }
 
   // ER diagram methods

--- a/frontend/src/components/history/HistoryItem.tsx
+++ b/frontend/src/components/history/HistoryItem.tsx
@@ -12,8 +12,8 @@ export const HistoryItem = memo(function HistoryItem({ item }: HistoryItemProps)
   const { setFavorite, removeHistory } = useHistoryStore();
   const { addQuery, queries, updateQuery, executeQuery } = useQueryStore();
 
-  const formatTimestamp = (date: Date): string => {
-    return date.toLocaleString('ja-JP', {
+  const formatTimestamp = (epochMs: number): string => {
+    return new Date(epochMs).toLocaleString('ja-JP', {
       month: '2-digit',
       day: '2-digit',
       hour: '2-digit',

--- a/frontend/src/components/history/QueryHistory.tsx
+++ b/frontend/src/components/history/QueryHistory.tsx
@@ -1,10 +1,22 @@
+import { useEffect } from 'react';
 import { useHistoryStore } from '../../store/historyStore';
 import { HistoryItem } from './HistoryItem';
 import styles from './QueryHistory.module.css';
 
 export function QueryHistory() {
-  const { searchKeyword, setSearchKeyword, getFilteredHistory, clearHistory, getStats } =
-    useHistoryStore();
+  const {
+    searchKeyword,
+    setSearchKeyword,
+    getFilteredHistory,
+    clearHistory,
+    getStats,
+    fetchHistory,
+  } = useHistoryStore();
+
+  useEffect(() => {
+    void fetchHistory();
+  }, [fetchHistory]);
+
   const history = getFilteredHistory();
   const stats = getStats();
 

--- a/frontend/src/store/historyStore.ts
+++ b/frontend/src/store/historyStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { useShallow } from 'zustand/react/shallow';
+import { bridge } from '../api/bridge';
 import type { HistoryItem } from '../types';
 
 export interface HistoryStats {
@@ -13,137 +13,83 @@ interface HistoryState {
   history: HistoryItem[];
   searchKeyword: string;
 
-  addHistory: (item: Omit<HistoryItem, 'id'>) => void;
-  removeHistory: (id: string) => void;
-  clearHistory: () => void;
-  setFavorite: (id: string, isFavorite: boolean) => void;
+  fetchHistory: () => Promise<void>;
+  removeHistory: (id: string) => Promise<void>;
+  clearHistory: () => Promise<void>;
+  setFavorite: (id: string, isFavorite: boolean) => Promise<void>;
   setSearchKeyword: (keyword: string) => void;
   getFilteredHistory: () => HistoryItem[];
   getFavorites: () => HistoryItem[];
   getStats: () => HistoryStats;
-  exportHistory: () => string;
-  importHistory: (json: string) => void;
 }
 
-let historyCounter = 0;
+export const useHistoryStore = create<HistoryState>()((set, get) => ({
+  history: [],
+  searchKeyword: '',
 
-export const useHistoryStore = create<HistoryState>()(
-  persist(
-    (set, get) => ({
-      history: [],
-      searchKeyword: '',
-
-      addHistory: (item) => {
-        const id = `history-${++historyCounter}`;
-        const newItem: HistoryItem = {
-          ...item,
-          id,
-        };
-
-        set((state) => ({
-          history: [newItem, ...state.history].slice(0, 10000), // Keep max 10000 items
-        }));
-      },
-
-      removeHistory: (id) => {
-        set((state) => ({
-          history: state.history.filter((h) => h.id !== id),
-        }));
-      },
-
-      clearHistory: () => {
-        // Keep favorites
-        set((state) => ({
-          history: state.history.filter((h) => h.isFavorite),
-        }));
-      },
-
-      setFavorite: (id, isFavorite) => {
-        set((state) => ({
-          history: state.history.map((h) => (h.id === id ? { ...h, isFavorite } : h)),
-        }));
-      },
-
-      setSearchKeyword: (keyword) => {
-        set({ searchKeyword: keyword });
-      },
-
-      getFilteredHistory: () => {
-        const { history, searchKeyword } = get();
-        if (!searchKeyword.trim()) {
-          return history;
-        }
-
-        const lowerKeyword = searchKeyword.toLowerCase();
-        return history.filter((h) => h.sql.toLowerCase().includes(lowerKeyword));
-      },
-
-      getFavorites: () => {
-        const { history } = get();
-        return history.filter((h) => h.isFavorite);
-      },
-
-      getStats: () => {
-        const { history } = get();
-        const total = history.length;
-        const success = history.filter((h) => h.success).length;
-        const failed = total - success;
-        return { total, success, failed };
-      },
-
-      exportHistory: () => {
-        const { history } = get();
-        return JSON.stringify(history, null, 2);
-      },
-
-      importHistory: (json: string) => {
-        try {
-          const parsed: unknown = JSON.parse(json);
-          if (!Array.isArray(parsed)) {
-            throw new Error('Invalid format');
-          }
-          // Validate each item has required fields with correct types
-          const imported = parsed.filter(
-            (h): h is HistoryItem =>
-              typeof h === 'object' &&
-              h !== null &&
-              typeof h.sql === 'string' &&
-              'timestamp' in h &&
-              (typeof h.timestamp === 'string' || typeof h.timestamp === 'number')
-          );
-          // Merge with existing, avoiding duplicates by SQL content
-          set((state) => {
-            const existingSql = new Set(state.history.map((h) => h.sql));
-            const newItems = imported.filter((h) => !existingSql.has(h.sql));
-            return {
-              history: [...state.history, ...newItems].slice(0, 10000),
-            };
-          });
-        } catch (error) {
-          console.error('Failed to import history:', error);
-        }
-      },
-    }),
-    {
-      name: 'query-history',
-      partialize: (state) => ({
-        history: state.history,
-      }),
-      onRehydrateStorage: () => {
-        return (state) => {
-          if (state?.history) {
-            // Update historyCounter to avoid ID collisions
-            const maxId = state.history.reduce((max, h) => {
-              const num = Number.parseInt(h.id.replace('history-', ''), 10);
-              return Number.isNaN(num) ? max : Math.max(max, num);
-            }, 0);
-            historyCounter = maxId;
-          }
-        };
-      },
+  fetchHistory: async () => {
+    try {
+      const items = await bridge.getQueryHistory();
+      set({ history: items });
+    } catch (error) {
+      console.error('Failed to fetch query history:', error);
     }
-  )
-);
+  },
+
+  removeHistory: async (id) => {
+    try {
+      await bridge.removeQueryHistory(id);
+      await get().fetchHistory();
+    } catch (error) {
+      console.error('Failed to remove history:', error);
+    }
+  },
+
+  clearHistory: async () => {
+    try {
+      await bridge.clearQueryHistory();
+      await get().fetchHistory();
+    } catch (error) {
+      console.error('Failed to clear history:', error);
+    }
+  },
+
+  setFavorite: async (id, isFavorite) => {
+    try {
+      await bridge.setQueryHistoryFavorite(id, isFavorite);
+      await get().fetchHistory();
+    } catch (error) {
+      console.error('Failed to set favorite:', error);
+    }
+  },
+
+  setSearchKeyword: (keyword) => {
+    set({ searchKeyword: keyword });
+  },
+
+  getFilteredHistory: () => {
+    const { history, searchKeyword } = get();
+    if (!searchKeyword.trim()) {
+      return history;
+    }
+
+    const lowerKeyword = searchKeyword.toLowerCase();
+    return history.filter((h) => h.sql.toLowerCase().includes(lowerKeyword));
+  },
+
+  getFavorites: () => {
+    const { history } = get();
+    return history.filter((h) => h.isFavorite);
+  },
+
+  getStats: () => {
+    const { history } = get();
+    const total = history.length;
+    const success = history.filter((h) => h.success).length;
+    const failed = total - success;
+    return { total, success, failed };
+  },
+}));
 
 // Optimized selectors to prevent unnecessary re-renders
 export const useHistoryItems = () => useHistoryStore(useShallow((state) => state.history));
@@ -153,7 +99,7 @@ export const useHistorySearch = () => useHistoryStore((state) => state.searchKey
 export const useHistoryActions = () =>
   useHistoryStore(
     useShallow((state) => ({
-      addHistory: state.addHistory,
+      fetchHistory: state.fetchHistory,
       removeHistory: state.removeHistory,
       clearHistory: state.clearHistory,
       setFavorite: state.setFavorite,
@@ -161,7 +107,5 @@ export const useHistoryActions = () =>
       getFilteredHistory: state.getFilteredHistory,
       getFavorites: state.getFavorites,
       getStats: state.getStats,
-      exportHistory: state.exportHistory,
-      importHistory: state.importHistory,
     }))
   );

--- a/frontend/src/store/query/helpers/asyncPolling.ts
+++ b/frontend/src/store/query/helpers/asyncPolling.ts
@@ -70,53 +70,28 @@ export async function executeAsyncWithPolling(
   }
 }
 
-const QUERY_ROW_LIMIT = 10_000;
-
-function truncateRows(rows: string[][]): { rows: string[][]; truncated: boolean } {
-  if (rows.length > QUERY_ROW_LIMIT) {
-    return { rows: rows.slice(0, QUERY_ROW_LIMIT), truncated: true };
-  }
-  return { rows, truncated: false };
-}
-
-export function toQueryResult(result: AsyncPollResult): {
-  queryResult: QueryResult;
-  totalAffectedRows: number;
-  totalExecutionTimeMs: number;
-} {
+export function toQueryResult(result: AsyncPollResult): QueryResult {
   if (result.multipleResults) {
     return {
-      queryResult: {
-        multipleResults: true,
-        results: result.results.map((r) => {
-          const { rows, truncated } = truncateRows(r.data.rows);
-          return {
-            statement: r.statement,
-            data: {
-              columns: r.data.columns.map(mapAsyncColumn),
-              rows,
-              affectedRows: r.data.affectedRows,
-              executionTimeMs: r.data.executionTimeMs,
-              truncated,
-            },
-          };
-        }),
-      },
-      totalAffectedRows: result.results.reduce((sum, r) => sum + r.data.affectedRows, 0),
-      totalExecutionTimeMs: result.results.reduce((sum, r) => sum + r.data.executionTimeMs, 0),
+      multipleResults: true,
+      results: result.results.map((r) => ({
+        statement: r.statement,
+        data: {
+          columns: r.data.columns.map(mapAsyncColumn),
+          rows: r.data.rows,
+          affectedRows: r.data.affectedRows,
+          executionTimeMs: r.data.executionTimeMs,
+          truncated: r.data.truncated,
+        },
+      })),
     };
   }
 
-  const { rows, truncated } = truncateRows(result.rows);
   return {
-    queryResult: {
-      columns: result.columns.map(mapAsyncColumn),
-      rows,
-      affectedRows: result.affectedRows,
-      executionTimeMs: result.executionTimeMs,
-      truncated,
-    },
-    totalAffectedRows: result.affectedRows,
-    totalExecutionTimeMs: result.executionTimeMs,
+    columns: result.columns.map(mapAsyncColumn),
+    rows: result.rows,
+    affectedRows: result.affectedRows,
+    executionTimeMs: result.executionTimeMs,
+    truncated: result.truncated,
   };
 }

--- a/frontend/src/store/query/interfaces/HistoryRecordable.ts
+++ b/frontend/src/store/query/interfaces/HistoryRecordable.ts
@@ -1,5 +1,0 @@
-import type { HistoryItem } from '../../../types';
-
-export interface HistoryRecordable {
-  addHistory(item: Omit<HistoryItem, 'id'>): void;
-}

--- a/frontend/src/store/query/queryStore.ts
+++ b/frontend/src/store/query/queryStore.ts
@@ -1,9 +1,7 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { bridge } from '../../api/bridge';
-import { useHistoryStore } from '../historyStore';
 import type { AbortRegistrable } from './interfaces/AbortRegistrable';
-import type { HistoryRecordable } from './interfaces/HistoryRecordable';
 import { createDataViewSlice } from './slices/dataViewSlice';
 import { createERDiagramSlice } from './slices/erDiagramSlice';
 import { createFileIOSlice } from './slices/fileIOSlice';
@@ -11,11 +9,6 @@ import { createFormatSlice } from './slices/formatSlice';
 import { createExecuteSlice } from './slices/queryExecuteSlice';
 import { createManageSlice } from './slices/queryManageSlice';
 import type { QueryState } from './types';
-
-// DI: History adapter (Omusubi Context Layer — bridge between stores)
-const historyAdapter: HistoryRecordable = {
-  addHistory: (entry) => useHistoryStore.getState().addHistory(entry),
-};
 
 // DI: Abort controller registry (Omusubi Context Layer — owns mutable state)
 const abortControllers = new Map<string, AbortController>();
@@ -44,7 +37,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
 
   // Slices (Device Layer implementations injected via DI)
   ...createManageSlice(set, get, { abort: abortAdapter }),
-  ...createExecuteSlice(set, get, { bridge, history: historyAdapter, abort: abortAdapter }),
+  ...createExecuteSlice(set, get, { bridge, abort: abortAdapter }),
   ...createDataViewSlice(set, get, { bridge, abort: abortAdapter }),
   ...createFileIOSlice(set, get, { bridge }),
   ...createFormatSlice(set, get),

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -2,13 +2,11 @@ import { executeAsyncWithPolling, toQueryResult } from '../helpers/asyncPolling'
 import { endExecution, failExecution, startExecution } from '../helpers/executionState';
 import type { AbortRegistrable } from '../interfaces/AbortRegistrable';
 import type { Executable } from '../interfaces/Executable';
-import type { HistoryRecordable } from '../interfaces/HistoryRecordable';
 import type { QueryBridgeable } from '../interfaces/QueryBridgeable';
 import type { GetState, SetState } from '../types';
 
 interface ExecuteSliceDeps {
   bridge: QueryBridgeable;
-  history: HistoryRecordable;
   abort: AbortRegistrable;
 }
 
@@ -17,10 +15,9 @@ export function createExecuteSlice(
   get: GetState,
   deps: ExecuteSliceDeps
 ): Executable {
-  const { bridge, history, abort } = deps;
+  const { bridge, abort } = deps;
 
-  // W1修正: DRY — 共通の execute + history 記録関数
-  async function executeAndRecord(id: string, connectionId: string, sql: string): Promise<void> {
+  async function executeAsync(id: string, connectionId: string, sql: string): Promise<void> {
     const controller = new AbortController();
     abort.register(id, controller);
 
@@ -28,39 +25,17 @@ export function createExecuteSlice(
 
     try {
       const result = await executeAsyncWithPolling(bridge, connectionId, sql, controller.signal);
-      const { queryResult, totalAffectedRows, totalExecutionTimeMs } = toQueryResult(result);
 
       set((state) => ({
         ...endExecution(state, id),
-        results: { ...state.results, [id]: queryResult },
+        results: { ...state.results, [id]: toQueryResult(result) },
       }));
-
-      history.addHistory({
-        sql,
-        connectionId,
-        timestamp: new Date(),
-        executionTimeMs: totalExecutionTimeMs,
-        affectedRows: totalAffectedRows,
-        success: true,
-        isFavorite: false,
-      });
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') {
         set((state) => endExecution(state, id));
         return;
       }
       const errorMessage = error instanceof Error ? error.message : 'Query execution failed';
-
-      history.addHistory({
-        sql,
-        connectionId,
-        timestamp: new Date(),
-        executionTimeMs: 0,
-        affectedRows: 0,
-        success: false,
-        errorMessage,
-        isFavorite: false,
-      });
 
       set((state) => failExecution(state, id, errorMessage));
     } finally {
@@ -72,12 +47,12 @@ export function createExecuteSlice(
     executeQuery: async (id, connectionId) => {
       const query = get().queries.find((q) => q.id === id);
       if (!query || !query.content.trim()) return;
-      await executeAndRecord(id, connectionId, query.content);
+      await executeAsync(id, connectionId, query.content);
     },
 
     executeSelectedText: async (id, connectionId, selectedText) => {
       if (!selectedText.trim()) return;
-      await executeAndRecord(id, connectionId, selectedText);
+      await executeAsync(id, connectionId, selectedText);
     },
 
     cancelQuery: async (connectionId) => {

--- a/frontend/src/tests/stores/helpers.test.ts
+++ b/frontend/src/tests/stores/helpers.test.ts
@@ -103,17 +103,17 @@ describe('toQueryResult', () => {
       executionTimeMs: 50,
     };
 
-    const { queryResult, totalAffectedRows, totalExecutionTimeMs } = toQueryResult(pollResult);
+    const queryResult = toQueryResult(pollResult);
 
-    expect(totalAffectedRows).toBe(0);
-    expect(totalExecutionTimeMs).toBe(50);
     expect('columns' in queryResult && queryResult.columns[0].name).toBe('id');
     expect('columns' in queryResult && queryResult.columns[0].comment).toBe('ID列');
     expect('columns' in queryResult && queryResult.columns[0].size).toBe(0);
     expect('rows' in queryResult && queryResult.rows).toHaveLength(2);
+    expect('affectedRows' in queryResult && queryResult.affectedRows).toBe(0);
+    expect('executionTimeMs' in queryResult && queryResult.executionTimeMs).toBe(50);
   });
 
-  it('should convert multiple results and sum totals', () => {
+  it('should convert multiple results', () => {
     const pollResult: AsyncPollResult = {
       multipleResults: true,
       results: [
@@ -138,10 +138,8 @@ describe('toQueryResult', () => {
       ],
     };
 
-    const { queryResult, totalAffectedRows, totalExecutionTimeMs } = toQueryResult(pollResult);
+    const queryResult = toQueryResult(pollResult);
 
-    expect(totalAffectedRows).toBe(8);
-    expect(totalExecutionTimeMs).toBe(30);
     expect('multipleResults' in queryResult && queryResult.multipleResults).toBe(true);
   });
 
@@ -153,7 +151,7 @@ describe('toQueryResult', () => {
       executionTimeMs: 0,
     };
 
-    const { queryResult } = toQueryResult(pollResult);
+    const queryResult = toQueryResult(pollResult);
     const col = 'columns' in queryResult ? queryResult.columns[0] : null;
     expect(col?.comment).toBe('ユーザー名');
     expect(col?.nullable).toBe(true);

--- a/frontend/src/tests/stores/historyStore.test.ts
+++ b/frontend/src/tests/stores/historyStore.test.ts
@@ -1,127 +1,103 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryStore } from '../../store/historyStore';
+
+// Mock bridge
+vi.mock('../../api/bridge', () => ({
+  bridge: {
+    getQueryHistory: vi.fn().mockResolvedValue([]),
+    removeQueryHistory: vi.fn().mockResolvedValue({ removed: true }),
+    clearQueryHistory: vi.fn().mockResolvedValue({ cleared: true }),
+    setQueryHistoryFavorite: vi.fn().mockResolvedValue({ updated: true }),
+  },
+}));
+
+// Import after mock
+const { bridge } = await import('../../api/bridge');
 
 describe('historyStore', () => {
   beforeEach(() => {
-    // Reset store before each test
     useHistoryStore.setState({ history: [], searchKeyword: '' });
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
-    // Clean up after each test
     useHistoryStore.setState({ history: [], searchKeyword: '' });
   });
 
-  describe('addHistory', () => {
-    it('should add a history item with generated id', () => {
-      const { addHistory } = useHistoryStore.getState();
+  describe('fetchHistory', () => {
+    it('should fetch history from backend and update store', async () => {
+      vi.mocked(bridge.getQueryHistory).mockResolvedValue([
+        {
+          id: 'hist_1',
+          sql: 'SELECT * FROM users',
+          connectionId: 'conn_1',
+          timestamp: 1706270400000,
+          executionTimeMs: 150,
+          success: true,
+          errorMessage: '',
+          affectedRows: 10,
+          isFavorite: false,
+        },
+      ]);
 
-      addHistory({
-        sql: 'SELECT * FROM users',
-        connectionId: 'conn_1',
-        timestamp: new Date('2026-01-09T12:00:00'),
-        executionTimeMs: 150,
-        affectedRows: 10,
-        success: true,
-        isFavorite: false,
-      });
+      await useHistoryStore.getState().fetchHistory();
 
       const { history } = useHistoryStore.getState();
       expect(history).toHaveLength(1);
       expect(history[0].sql).toBe('SELECT * FROM users');
-      expect(history[0].id).toMatch(/^history-\d+$/);
-      expect(history[0].success).toBe(true);
-    });
-
-    it('should prepend new items to history', () => {
-      const { addHistory } = useHistoryStore.getState();
-
-      addHistory({
-        sql: 'SELECT 1',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
-
-      addHistory({
-        sql: 'SELECT 2',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 20,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
-
-      const { history } = useHistoryStore.getState();
-      expect(history).toHaveLength(2);
-      expect(history[0].sql).toBe('SELECT 2'); // Most recent first
-      expect(history[1].sql).toBe('SELECT 1');
-    });
-
-    it('should record failed queries with error message', () => {
-      const { addHistory } = useHistoryStore.getState();
-
-      addHistory({
-        sql: 'SELECT * FROM nonexistent',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 0,
-        affectedRows: 0,
-        success: false,
-        errorMessage: 'Table not found',
-        isFavorite: false,
-      });
-
-      const { history } = useHistoryStore.getState();
-      expect(history[0].success).toBe(false);
-      expect(history[0].errorMessage).toBe('Table not found');
+      expect(history[0].connectionId).toBe('conn_1');
+      expect(history[0].timestamp).toBe(1706270400000);
     });
   });
 
   describe('getStats', () => {
     it('should return correct stats for mixed success/failure', () => {
-      const { addHistory, getStats } = useHistoryStore.getState();
+      useHistoryStore.setState({
+        history: [
+          {
+            id: '1',
+            sql: 'SELECT 1',
+            connectionId: 'c',
+            timestamp: Date.now(),
+            executionTimeMs: 10,
+            affectedRows: 0,
+            success: true,
+            errorMessage: '',
+            isFavorite: false,
+          },
+          {
+            id: '2',
+            sql: 'SELECT 2',
+            connectionId: 'c',
+            timestamp: Date.now(),
+            executionTimeMs: 10,
+            affectedRows: 0,
+            success: true,
+            errorMessage: '',
+            isFavorite: false,
+          },
+          {
+            id: '3',
+            sql: 'FAIL 1',
+            connectionId: 'c',
+            timestamp: Date.now(),
+            executionTimeMs: 0,
+            affectedRows: 0,
+            success: false,
+            errorMessage: '',
+            isFavorite: false,
+          },
+        ],
+      });
 
-      // Add 3 successful queries
-      for (let i = 0; i < 3; i++) {
-        addHistory({
-          sql: `SELECT ${i}`,
-          connectionId: 'conn_1',
-          timestamp: new Date(),
-          executionTimeMs: 10,
-          affectedRows: 0,
-          success: true,
-          isFavorite: false,
-        });
-      }
-
-      // Add 2 failed queries
-      for (let i = 0; i < 2; i++) {
-        addHistory({
-          sql: `FAIL ${i}`,
-          connectionId: 'conn_1',
-          timestamp: new Date(),
-          executionTimeMs: 0,
-          affectedRows: 0,
-          success: false,
-          isFavorite: false,
-        });
-      }
-
-      const stats = getStats();
-      expect(stats.total).toBe(5);
-      expect(stats.success).toBe(3);
-      expect(stats.failed).toBe(2);
+      const stats = useHistoryStore.getState().getStats();
+      expect(stats.total).toBe(3);
+      expect(stats.success).toBe(2);
+      expect(stats.failed).toBe(1);
     });
 
     it('should return zeros for empty history', () => {
-      const { getStats } = useHistoryStore.getState();
-      const stats = getStats();
-
+      const stats = useHistoryStore.getState().getStats();
       expect(stats.total).toBe(0);
       expect(stats.success).toBe(0);
       expect(stats.failed).toBe(0);
@@ -129,149 +105,105 @@ describe('historyStore', () => {
   });
 
   describe('setFavorite', () => {
-    it('should toggle favorite status', () => {
-      const { addHistory, setFavorite } = useHistoryStore.getState();
+    it('should call backend and refetch', async () => {
+      vi.mocked(bridge.getQueryHistory).mockResolvedValue([
+        {
+          id: 'hist_1',
+          sql: 'SELECT 1',
+          connectionId: 'conn_1',
+          timestamp: 1706270400000,
+          executionTimeMs: 10,
+          success: true,
+          errorMessage: '',
+          affectedRows: 0,
+          isFavorite: true,
+        },
+      ]);
 
-      addHistory({
-        sql: 'SELECT * FROM users',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
+      await useHistoryStore.getState().setFavorite('hist_1', true);
 
-      const { history } = useHistoryStore.getState();
-      const itemId = history[0].id;
-
-      setFavorite(itemId, true);
-      expect(useHistoryStore.getState().history[0].isFavorite).toBe(true);
-
-      setFavorite(itemId, false);
-      expect(useHistoryStore.getState().history[0].isFavorite).toBe(false);
+      expect(bridge.setQueryHistoryFavorite).toHaveBeenCalledWith('hist_1', true);
+      expect(bridge.getQueryHistory).toHaveBeenCalled();
     });
   });
 
   describe('clearHistory', () => {
-    it('should keep favorites when clearing', () => {
-      const { addHistory, setFavorite, clearHistory } = useHistoryStore.getState();
+    it('should call backend and refetch', async () => {
+      vi.mocked(bridge.getQueryHistory).mockResolvedValue([]);
 
-      addHistory({
-        sql: 'SELECT 1',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
+      await useHistoryStore.getState().clearHistory();
 
-      addHistory({
-        sql: 'SELECT 2 -- favorite',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
-
-      // Mark second item as favorite
-      const { history } = useHistoryStore.getState();
-      setFavorite(history[0].id, true);
-
-      clearHistory();
-
-      const newHistory = useHistoryStore.getState().history;
-      expect(newHistory).toHaveLength(1);
-      expect(newHistory[0].sql).toBe('SELECT 2 -- favorite');
+      expect(bridge.clearQueryHistory).toHaveBeenCalled();
+      expect(bridge.getQueryHistory).toHaveBeenCalled();
     });
   });
 
   describe('getFilteredHistory', () => {
     it('should filter by search keyword', () => {
-      const { addHistory, setSearchKeyword, getFilteredHistory } = useHistoryStore.getState();
-
-      addHistory({
-        sql: 'SELECT * FROM users',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
+      useHistoryStore.setState({
+        history: [
+          {
+            id: '1',
+            sql: 'SELECT * FROM users',
+            connectionId: 'c',
+            timestamp: Date.now(),
+            executionTimeMs: 10,
+            affectedRows: 0,
+            success: true,
+            errorMessage: '',
+            isFavorite: false,
+          },
+          {
+            id: '2',
+            sql: 'SELECT * FROM orders',
+            connectionId: 'c',
+            timestamp: Date.now(),
+            executionTimeMs: 10,
+            affectedRows: 0,
+            success: true,
+            errorMessage: '',
+            isFavorite: false,
+          },
+        ],
+        searchKeyword: 'users',
       });
 
-      addHistory({
-        sql: 'SELECT * FROM orders',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
-
-      setSearchKeyword('users');
-      const filtered = getFilteredHistory();
-
+      const filtered = useHistoryStore.getState().getFilteredHistory();
       expect(filtered).toHaveLength(1);
       expect(filtered[0].sql).toContain('users');
     });
 
     it('should be case insensitive', () => {
-      const { addHistory, setSearchKeyword, getFilteredHistory } = useHistoryStore.getState();
-
-      addHistory({
-        sql: 'SELECT * FROM USERS',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
+      useHistoryStore.setState({
+        history: [
+          {
+            id: '1',
+            sql: 'SELECT * FROM USERS',
+            connectionId: 'c',
+            timestamp: Date.now(),
+            executionTimeMs: 10,
+            affectedRows: 0,
+            success: true,
+            errorMessage: '',
+            isFavorite: false,
+          },
+        ],
+        searchKeyword: 'users',
       });
 
-      setSearchKeyword('users');
-      const filtered = getFilteredHistory();
-
+      const filtered = useHistoryStore.getState().getFilteredHistory();
       expect(filtered).toHaveLength(1);
     });
   });
 
   describe('removeHistory', () => {
-    it('should remove specific item by id', () => {
-      const { addHistory, removeHistory } = useHistoryStore.getState();
+    it('should call backend and refetch', async () => {
+      vi.mocked(bridge.getQueryHistory).mockResolvedValue([]);
 
-      addHistory({
-        sql: 'SELECT 1',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
+      await useHistoryStore.getState().removeHistory('hist_1');
 
-      addHistory({
-        sql: 'SELECT 2',
-        connectionId: 'conn_1',
-        timestamp: new Date(),
-        executionTimeMs: 10,
-        affectedRows: 0,
-        success: true,
-        isFavorite: false,
-      });
-
-      const { history } = useHistoryStore.getState();
-      const idToRemove = history[0].id;
-
-      removeHistory(idToRemove);
-
-      const newHistory = useHistoryStore.getState().history;
-      expect(newHistory).toHaveLength(1);
-      expect(newHistory[0].sql).toBe('SELECT 1');
+      expect(bridge.removeQueryHistory).toHaveBeenCalledWith('hist_1');
+      expect(bridge.getQueryHistory).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/tests/stores/queryStore.test.ts
+++ b/frontend/src/tests/stores/queryStore.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useHistoryStore } from '../../store/historyStore';
 import { useQueryStore } from '../../store/queryStore';
 
 // Mock the bridge module
@@ -31,7 +30,6 @@ describe('queryStore', () => {
       errors: {},
       isExecuting: false,
     });
-    useHistoryStore.setState({ history: [], searchKeyword: '' });
     vi.clearAllMocks();
   });
 
@@ -106,17 +104,15 @@ describe('queryStore', () => {
     });
   });
 
-  describe('executeQuery with history integration', () => {
-    it('should record successful query to history', async () => {
+  describe('executeQuery', () => {
+    it('should store result on successful execution', async () => {
       const { addQuery, updateQuery, executeQuery } = useQueryStore.getState();
 
-      // Setup
       addQuery('conn_1');
       const { queries } = useQueryStore.getState();
       const queryId = queries[0].id;
       updateQuery(queryId, 'SELECT * FROM users');
 
-      // Mock async query flow
       mockedBridge.executeAsyncQuery.mockResolvedValue({ queryId: 'async_1' });
       mockedBridge.getAsyncQueryResult.mockResolvedValue({
         queryId: 'async_1',
@@ -127,28 +123,22 @@ describe('queryStore', () => {
         executionTimeMs: 50,
       });
 
-      // Execute
       await executeQuery(queryId, 'conn_1');
 
-      // Verify history was recorded
-      const { history } = useHistoryStore.getState();
-      expect(history).toHaveLength(1);
-      expect(history[0].sql).toBe('SELECT * FROM users');
-      expect(history[0].success).toBe(true);
-      expect(history[0].connectionId).toBe('conn_1');
-      expect(history[0].executionTimeMs).toBe(50);
+      const { results, isExecuting } = useQueryStore.getState();
+      expect(results[queryId]).toBeDefined();
+      expect('rows' in results[queryId] && results[queryId].rows).toHaveLength(2);
+      expect(isExecuting).toBe(false);
     });
 
-    it('should record failed query to history', async () => {
+    it('should set error on async query failure', async () => {
       const { addQuery, updateQuery, executeQuery } = useQueryStore.getState();
 
-      // Setup
       addQuery('conn_1');
       const { queries } = useQueryStore.getState();
       const queryId = queries[0].id;
       updateQuery(queryId, 'SELECT * FROM nonexistent');
 
-      // Mock failed query
       mockedBridge.executeAsyncQuery.mockResolvedValue({ queryId: 'async_1' });
       mockedBridge.getAsyncQueryResult.mockResolvedValue({
         queryId: 'async_1',
@@ -156,15 +146,12 @@ describe('queryStore', () => {
         error: 'Table not found',
       });
 
-      // Execute
       await executeQuery(queryId, 'conn_1');
 
-      // Verify history was recorded with failure
-      const { history } = useHistoryStore.getState();
-      expect(history).toHaveLength(1);
-      expect(history[0].sql).toBe('SELECT * FROM nonexistent');
-      expect(history[0].success).toBe(false);
-      expect(history[0].errorMessage).toBe('Table not found');
+      const { errors, isExecuting, executingQueryIds } = useQueryStore.getState();
+      expect(errors[queryId]).toBe('Table not found');
+      expect(isExecuting).toBe(false);
+      expect(executingQueryIds.has(queryId)).toBe(false);
     });
 
     it('should set per-query error state on failure', async () => {
@@ -186,15 +173,14 @@ describe('queryStore', () => {
     });
   });
 
-  describe('executeSelectedText with history integration', () => {
-    it('should record selected text execution to history (async)', async () => {
+  describe('executeSelectedText', () => {
+    it('should store result on successful execution', async () => {
       const { addQuery, executeSelectedText } = useQueryStore.getState();
 
       addQuery('conn_1');
       const { queries } = useQueryStore.getState();
       const queryId = queries[0].id;
 
-      // Mock async query flow (same as executeQuery)
       mockedBridge.executeAsyncQuery.mockResolvedValue({ queryId: 'async_1' });
       mockedBridge.getAsyncQueryResult.mockResolvedValue({
         queryId: 'async_1',
@@ -207,12 +193,10 @@ describe('queryStore', () => {
 
       await executeSelectedText(queryId, 'conn_1', 'SELECT 42');
 
-      // Verify history
-      const { history } = useHistoryStore.getState();
-      expect(history).toHaveLength(1);
-      expect(history[0].sql).toBe('SELECT 42');
-      expect(history[0].success).toBe(true);
-      expect(history[0].executionTimeMs).toBe(25);
+      const { results, isExecuting } = useQueryStore.getState();
+      expect(results[queryId]).toBeDefined();
+      expect('rows' in results[queryId] && results[queryId].rows).toHaveLength(1);
+      expect(isExecuting).toBe(false);
     });
 
     it('should handle multiple results (async)', async () => {
@@ -252,17 +236,9 @@ describe('queryStore', () => {
 
       await executeSelectedText(queryId, 'conn_1', 'SELECT 1; SELECT 2');
 
-      // Verify result
       const { results } = useQueryStore.getState();
       expect(results[queryId]).toBeDefined();
       expect('multipleResults' in results[queryId] && results[queryId].multipleResults).toBe(true);
-
-      // Verify history
-      const { history } = useHistoryStore.getState();
-      expect(history).toHaveLength(1);
-      expect(history[0].sql).toBe('SELECT 1; SELECT 2');
-      expect(history[0].success).toBe(true);
-      expect(history[0].executionTimeMs).toBe(25); // 10 + 15
     });
 
     it('should not execute empty text', async () => {
@@ -275,17 +251,15 @@ describe('queryStore', () => {
       await executeSelectedText(queryId, 'conn_1', '   ');
 
       expect(mockedBridge.executeAsyncQuery).not.toHaveBeenCalled();
-      expect(useHistoryStore.getState().history).toHaveLength(0);
     });
 
-    it('should record failed query to history', async () => {
+    it('should set error on failed execution', async () => {
       const { addQuery, executeSelectedText } = useQueryStore.getState();
 
       addQuery('conn_1');
       const { queries } = useQueryStore.getState();
       const queryId = queries[0].id;
 
-      // Mock failed query
       mockedBridge.executeAsyncQuery.mockResolvedValue({ queryId: 'async_1' });
       mockedBridge.getAsyncQueryResult.mockResolvedValue({
         queryId: 'async_1',
@@ -295,13 +269,6 @@ describe('queryStore', () => {
 
       await executeSelectedText(queryId, 'conn_1', 'INVALID SQL');
 
-      // Verify history was recorded with failure
-      const { history } = useHistoryStore.getState();
-      expect(history).toHaveLength(1);
-      expect(history[0].success).toBe(false);
-      expect(history[0].errorMessage).toBe('Syntax error');
-
-      // Verify per-query error state
       const { errors, isExecuting } = useQueryStore.getState();
       expect(errors[queryId]).toBe('Syntax error');
       expect(isExecuting).toBe(false);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -140,6 +140,7 @@ export type AsyncPollResult =
       rows: string[][];
       affectedRows: number;
       executionTimeMs: number;
+      truncated?: boolean;
     }
   | {
       multipleResults: true;
@@ -150,6 +151,7 @@ export type AsyncPollResult =
           rows: string[][];
           affectedRows: number;
           executionTimeMs: number;
+          truncated?: boolean;
         };
       }>;
     };
@@ -168,6 +170,7 @@ export type AsyncQueryResultResponse =
           rows: string[][];
           affectedRows: number;
           executionTimeMs: number;
+          truncated?: boolean;
         };
       }>;
     }
@@ -179,6 +182,7 @@ export type AsyncQueryResultResponse =
       rows: string[][];
       affectedRows: number;
       executionTimeMs: number;
+      truncated?: boolean;
     }
   | { queryId: string; status: 'failed'; error: string }
   | { queryId: string; status: 'cancelled' };
@@ -188,10 +192,10 @@ export interface HistoryItem {
   id: string;
   sql: string;
   connectionId: string;
-  timestamp: Date;
+  timestamp: number;
   executionTimeMs: number;
   success: boolean;
-  errorMessage?: string;
+  errorMessage: string;
   affectedRows: number;
   isFavorite: boolean;
 }

--- a/tests/database/test_postgresql_driver.cpp
+++ b/tests/database/test_postgresql_driver.cpp
@@ -20,7 +20,7 @@ TEST_F(PostgreSqlDriverTest, DisconnectWhenNotConnected) {
 }
 
 TEST_F(PostgreSqlDriverTest, ExecuteThrowsWhenNotConnected) {
-    EXPECT_THROW(driver.execute("SELECT 1"), std::runtime_error);
+    EXPECT_THROW((void)driver.execute("SELECT 1"), std::runtime_error);
 }
 
 TEST_F(PostgreSqlDriverTest, CopyFromStdinThrowsWhenNotConnected) {
@@ -28,7 +28,7 @@ TEST_F(PostgreSqlDriverTest, CopyFromStdinThrowsWhenNotConnected) {
         "COPY t (id) FROM stdin;\n"
         "1\n"
         "\\.";
-    EXPECT_THROW(driver.execute(copySql), std::runtime_error);
+    EXPECT_THROW((void)driver.execute(copySql), std::runtime_error);
 }
 
 // --- CopyBlockDetector detection via driver handler chain ---
@@ -49,8 +49,8 @@ TEST_F(PostgreSqlDriverTest, DISABLED_CopyFromStdinInsertRows) {
     ASSERT_TRUE(driver.connect(
         "host=localhost dbname=testdb user=postgres password=postgres"));
 
-    driver.execute("DROP TABLE IF EXISTS copy_test");
-    driver.execute("CREATE TABLE copy_test (id int, name text)");
+    (void)driver.execute("DROP TABLE IF EXISTS copy_test");
+    (void)driver.execute("CREATE TABLE copy_test (id int, name text)");
 
     std::string copySql =
         "COPY copy_test (id, name) FROM stdin;\n"
@@ -64,7 +64,7 @@ TEST_F(PostgreSqlDriverTest, DISABLED_CopyFromStdinInsertRows) {
     auto selectResult = driver.execute("SELECT count(*) FROM copy_test");
     EXPECT_EQ(selectResult.rows[0].values[0], "2");
 
-    driver.execute("DROP TABLE copy_test");
+    (void)driver.execute("DROP TABLE copy_test");
     driver.disconnect();
 }
 

--- a/tests/parsers/test_sql_parser.cpp
+++ b/tests/parsers/test_sql_parser.cpp
@@ -265,5 +265,69 @@ TEST_F(CopyBlockDetectorTest, ExtractPartsCommandOnly) {
     EXPECT_TRUE(parts.data.empty());
 }
 
+// ===== filterPsqlMetaCommands via splitStatements =====
+
+TEST_F(SQLParserSplitTest, FilterPsqlMetaCommands_PreservesCopyNull) {
+    // \N is NULL in COPY data — must NOT be filtered
+    std::string sql =
+        "COPY t (id, val) FROM stdin;\n"
+        "1\t\\N\n"
+        "2\tdata\n"
+        "\\.\n";
+    auto stmts = SQLParser::splitStatements(sql, pgDetectors);
+    ASSERT_EQ(stmts.size(), 1);
+    EXPECT_NE(stmts[0].find("\\N"), std::string::npos);
+}
+
+TEST_F(SQLParserSplitTest, FilterPsqlMetaCommands_RemovesRestrict) {
+    std::string sql =
+        "\\restrict token\n"
+        "SELECT 1;\n";
+    auto stmts = SQLParser::splitStatements(sql, pgDetectors);
+    ASSERT_EQ(stmts.size(), 1);
+    EXPECT_NE(stmts[0].find("SELECT 1"), std::string::npos);
+    EXPECT_EQ(stmts[0].find("restrict"), std::string::npos);
+}
+
+// ===== isUseStatement performance =====
+
+TEST(SQLParserTest, IsUseStatement_LargeCopyInput) {
+    // 1MB COPY block must return false immediately (no regex/toUpper)
+    std::string largeCopy = "COPY t (id) FROM stdin;\n";
+    largeCopy.append(1024 * 1024, 'x');
+    EXPECT_FALSE(SQLParser::isUseStatement(largeCopy));
+}
+
+TEST(SQLParserTest, IsUseStatementPositive) {
+    EXPECT_TRUE(SQLParser::isUseStatement("USE mydb"));
+    EXPECT_TRUE(SQLParser::isUseStatement("use mydb"));
+    EXPECT_TRUE(SQLParser::isUseStatement("  USE  [mydb]  "));
+}
+
+TEST(SQLParserTest, IsUseStatementNegative) {
+    EXPECT_FALSE(SQLParser::isUseStatement("SELECT 1"));
+    EXPECT_FALSE(SQLParser::isUseStatement("USEFUL"));
+    EXPECT_FALSE(SQLParser::isUseStatement(""));
+}
+
+// ===== pg_dump format integration =====
+
+TEST_F(SQLParserSplitTest, SplitStatements_PgDumpFormat) {
+    std::string sql =
+        "SET statement_timeout = 0;\n"
+        "CREATE TABLE t (id int);\n"
+        "COPY t (id) FROM stdin;\n"
+        "1\n"
+        "2\n"
+        "\\.\n"
+        "ALTER TABLE t ADD CONSTRAINT pk PRIMARY KEY (id);\n";
+    auto stmts = SQLParser::splitStatements(sql, pgDetectors);
+    ASSERT_EQ(stmts.size(), 4);
+    EXPECT_NE(stmts[0].find("SET"), std::string::npos);
+    EXPECT_NE(stmts[1].find("CREATE TABLE"), std::string::npos);
+    EXPECT_NE(stmts[2].find("COPY t"), std::string::npos);
+    EXPECT_NE(stmts[3].find("ALTER TABLE"), std::string::npos);
+}
+
 }  // namespace test
 }  // namespace velocitydb


### PR DESCRIPTION
- 履歴記録: FE addHistory削除→BE QueryProvider/AsyncQueryProviderで記録
- 履歴CRUD: localStorage廃止→BE IPC (remove/clear/setFavorite)
- port結合: bridge.tsのserver+portロジック削除→connection_utils.cppへ移動
- 行truncation: FE truncateRows削除→BE json_utils QUERY_ROW_LIMIT+truncatedフラグ
- timestamp: HistoryItem.timestamp Date→number統一
- C++23最適化: toLowerChar共通化、toUpper rangesパイプライン、firstLine string_view化、isReadOnlyQuery ranges::search化
- デッドコード除去: HistoryRecordable/exportHistory/isLoading削除、executeAndRecord→executeAsync命名修正