### PR TITLE
fix: フロントエンドCSS preloadエラーの修正

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -242,8 +242,10 @@ set_target_properties(VelocityDBCore PROPERTIES
 )
 
 # Copy frontend dist to output directory (if it exists)
+# Clean destination first to remove stale hashed chunks from previous builds
 if(EXISTS "${CMAKE_SOURCE_DIR}/frontend/dist")
     add_custom_command(TARGET VelocityDB POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E rm -rf $<TARGET_FILE_DIR:VelocityDB>/frontend
         COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_SOURCE_DIR}/frontend/dist
         $<TARGET_FILE_DIR:VelocityDB>/frontend

--- a/backend/database/psql_subprocess.cpp
+++ b/backend/database/psql_subprocess.cpp
@@ -348,8 +348,8 @@ std::expected<ResultSet, std::string> executePsql(const PsqlConnectionInfo& conn
         TerminateProcess(pi.hProcess, 1);
         WaitForSingleObject(pi.hProcess, 5000);
         // Drain remaining pipe data to prevent zombie handles
-        readPipe(stdoutRead);
-        readPipe(stderrRead);
+        (void)readPipe(stdoutRead);
+        (void)readPipe(stderrRead);
         return std::unexpected("psql process timed out after 300 seconds");
     }
 

--- a/backend/webview_app.cpp
+++ b/backend/webview_app.cpp
@@ -69,9 +69,9 @@ std::expected<std::filesystem::path, std::string> WebViewApp::locateFrontendDire
     const auto executableDirectory = computeExecutablePath().parent_path();
 
     constexpr std::array<const wchar_t*, 3> searchPaths = {
-        L"frontend/index.html",
+        L"../../frontend/dist/index.html",  // Dev: source dist (always fresh)
+        L"frontend/index.html",             // Release: copied by CMake POST_BUILD
         L"../../../frontend/dist/index.html",
-        L"../../frontend/dist/index.html",
     };
 
     for (const auto* searchPath : searchPaths) {


### PR DESCRIPTION
- CMake POST_BUILDでコピー前にrm -rfして古いハッシュ付きチャンクを除去
- frontend/dist/を最優先検索に変更し開発時の古いコピー参照を防止
- psql readPipeの[[nodiscard]]警告を(void)キャストで抑制
