### PR TITLE
feat(er,grid): ShapeNode文字色修正・ダイアログ縮小・列選択コピー機能

### DIFF
--- a/frontend/src/components/diagram/ERDiagram.module.css
+++ b/frontend/src/components/diagram/ERDiagram.module.css
@@ -68,3 +68,52 @@
   border: 1px solid var(--border-color);
   border-radius: 4px;
 }
+
+/* Empty state */
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  gap: 16px;
+}
+
+.emptyText {
+  color: var(--text-secondary);
+  font-size: 14px;
+  margin: 0;
+}
+
+.importButton {
+  padding: 8px 20px;
+  background-color: var(--button-primary-bg);
+  border: none;
+  border-radius: 6px;
+  color: white;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.importButton:hover {
+  background-color: var(--button-primary-hover);
+}
+
+/* Tab bar import button */
+.tabImportButton {
+  margin-left: auto;
+  padding: 4px 8px;
+  font-size: 14px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  line-height: 1;
+}
+
+.tabImportButton:hover {
+  background-color: var(--bg-hover);
+  color: var(--text-primary);
+}

--- a/frontend/src/components/diagram/ERDiagram.tsx
+++ b/frontend/src/components/diagram/ERDiagram.tsx
@@ -19,6 +19,7 @@ import { TableNode } from './TableNode';
 
 interface ERDiagramProps {
   onTableClick?: (tableId: string) => void;
+  onOpenImportDialog?: () => void;
 }
 
 type XY = { x: number; y: number };
@@ -170,16 +171,19 @@ function ERDiagramFlow({
   );
 }
 
-export function ERDiagram({ onTableClick }: ERDiagramProps) {
+export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) {
   const {
     pages,
     selectedPage,
     setSelectedPage,
     pageCounts,
+    totalTableCount,
     tables: filteredTables,
     relations: filteredRelations,
     shapes: filteredShapes,
   } = useERDiagramContext();
+
+  const hasData = totalTableCount > 0;
 
   // 「すべて」タブ時はグリッド再配置（ページ間で座標が重複するため）
   const layoutTables = useMemo(
@@ -202,27 +206,56 @@ export function ERDiagram({ onTableClick }: ERDiagramProps) {
     return `${selectedPage}-${layoutTables.length}-${layoutShapes.length}-${first}-${last}`;
   }, [selectedPage, layoutTables, layoutShapes]);
 
+  if (!hasData) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.emptyState}>
+          <p className={styles.emptyText}>ER図データがありません</p>
+          {onOpenImportDialog && (
+            <button type="button" className={styles.importButton} onClick={onOpenImportDialog}>
+              ER図ファイルを読み込む
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={styles.container}>
-      {showTabs && (
+      {(showTabs || onOpenImportDialog) && (
         <div className={styles.tabBar}>
-          <button
-            type="button"
-            className={`${styles.tab} ${selectedPage === ALL_PAGES ? styles.tabActive : ''}`}
-            onClick={() => setSelectedPage(ALL_PAGES)}
-          >
-            すべて ({pageCounts.get(ALL_PAGES) ?? 0})
-          </button>
-          {pages.map((page) => (
+          {showTabs && (
+            <>
+              <button
+                type="button"
+                className={`${styles.tab} ${selectedPage === ALL_PAGES ? styles.tabActive : ''}`}
+                onClick={() => setSelectedPage(ALL_PAGES)}
+              >
+                すべて ({pageCounts.get(ALL_PAGES) ?? 0})
+              </button>
+              {pages.map((page) => (
+                <button
+                  type="button"
+                  key={page}
+                  className={`${styles.tab} ${selectedPage === page ? styles.tabActive : ''}`}
+                  onClick={() => setSelectedPage(page)}
+                >
+                  {page} ({pageCounts.get(page) ?? 0})
+                </button>
+              ))}
+            </>
+          )}
+          {onOpenImportDialog && (
             <button
               type="button"
-              key={page}
-              className={`${styles.tab} ${selectedPage === page ? styles.tabActive : ''}`}
-              onClick={() => setSelectedPage(page)}
+              className={styles.tabImportButton}
+              onClick={onOpenImportDialog}
+              title="ER図ファイルをインポート"
             >
-              {page} ({pageCounts.get(page) ?? 0})
+              {'\uD83D\uDCE5'}
             </button>
-          ))}
+          )}
         </div>
       )}
       <div className={styles.flowContainer}>

--- a/frontend/src/components/diagram/ShapeNode.tsx
+++ b/frontend/src/components/diagram/ShapeNode.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { hexToRgba, readableColor } from '../../utils/colorContrast';
+import { blendWithBackground, hexToRgba, readableColor } from '../../utils/colorContrast';
 import styles from './ShapeNode.module.css';
 
 interface ShapeNodeData {
@@ -25,8 +25,11 @@ export const ShapeNode = memo(function ShapeNode({ data }: ShapeNodeProps) {
 
   const backgroundColor = fillColor ? hexToRgba(fillColor, fillAlpha) : 'transparent';
 
-  const effectiveBg = fillColor ?? CANVAS_BG;
-  const textColor = readableColor(effectiveBg, fontColor);
+  // fontColorが指定されていればそのまま使用（A5:SQL互換）
+  // 未指定の場合のみ、ブレンド後のeffectiveBgでauto計算
+  const textColor =
+    fontColor ??
+    readableColor(fillColor ? blendWithBackground(fillColor, fillAlpha, CANVAS_BG) : CANVAS_BG);
 
   return (
     <div

--- a/frontend/src/components/dialogs/ERImportDialog.module.css
+++ b/frontend/src/components/dialogs/ERImportDialog.module.css
@@ -15,7 +15,7 @@
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 12px;
-  width: 680px;
+  width: 480px;
   max-width: 90vw;
   max-height: 80vh;
   display: flex;
@@ -30,7 +30,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 16px 20px;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--border-color);
   flex-shrink: 0;
 }
@@ -64,7 +64,7 @@
 .content {
   flex: 1;
   overflow-y: auto;
-  padding: 20px;
+  padding: 16px;
 }
 
 /* File input */
@@ -148,7 +148,7 @@
 
 /* Table list */
 .tableList {
-  max-height: 160px;
+  max-height: 120px;
   overflow-y: auto;
   background-color: var(--bg-primary);
   border: 1px solid var(--border-color);
@@ -244,7 +244,7 @@
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  padding: 16px 20px;
+  padding: 12px 16px;
   border-top: 1px solid var(--border-color);
   flex-shrink: 0;
 }

--- a/frontend/src/components/dialogs/ERImportDialog.tsx
+++ b/frontend/src/components/dialogs/ERImportDialog.tsx
@@ -59,7 +59,10 @@ export function ERImportDialog({ isOpen, onClose, onImport }: ERImportDialogProp
       className={styles.overlay}
       onClick={onClose}
       onKeyDown={(e) => {
-        if (e.key === 'Escape') onClose();
+        if (e.key === 'Escape') {
+          e.stopPropagation();
+          onClose();
+        }
       }}
       role="presentation"
     >
@@ -67,7 +70,10 @@ export function ERImportDialog({ isOpen, onClose, onImport }: ERImportDialogProp
         className={styles.dialog}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
-          if (e.key === 'Escape') onClose();
+          if (e.key === 'Escape') {
+            e.stopPropagation();
+            onClose();
+          }
         }}
         role="dialog"
         aria-modal="true"
@@ -124,20 +130,22 @@ export function ERImportDialog({ isOpen, onClose, onImport }: ERImportDialogProp
             </div>
           )}
 
-          <div className={styles.ddlSection}>
-            <div className={styles.ddlHeader}>
-              <h3>生成されたDDL</h3>
-              <button type="button" onClick={() => setShowDDL(!showDDL)}>
-                {showDDL ? '非表示' : '表示'}
-              </button>
-              {generatedDDL && (
-                <button type="button" onClick={handleCopyDDL}>
-                  コピー
+          {parsedModel && (
+            <div className={styles.ddlSection}>
+              <div className={styles.ddlHeader}>
+                <h3>生成されたDDL</h3>
+                <button type="button" onClick={() => setShowDDL(!showDDL)}>
+                  {showDDL ? '非表示' : '表示'}
                 </button>
-              )}
+                {generatedDDL && (
+                  <button type="button" onClick={handleCopyDDL}>
+                    コピー
+                  </button>
+                )}
+              </div>
+              {showDDL && generatedDDL && <pre className={styles.ddlContent}>{generatedDDL}</pre>}
             </div>
-            {showDDL && generatedDDL && <pre className={styles.ddlContent}>{generatedDDL}</pre>}
-          </div>
+          )}
         </div>
 
         <div className={styles.footer}>

--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -27,8 +27,10 @@ interface GridTableCallbacks {
   onSetEditValue: (value: string) => void;
   onStartEdit: (originalIndex: number, field: string, value: string | null) => void;
   onCommitEdit: () => void;
-  onRowClick: (rowIndex: number) => void;
+  onRowToggle: (rowIndex: number) => void;
+  onRowRangeSelect: (rowIndex: number) => void;
   onCellClick: (rowIndex: number, field: string) => void;
+  onColumnSelect: (columnId: string) => void;
   onUpdateCell?: (
     rowIndex: number,
     field: string,
@@ -85,18 +87,24 @@ function GridTableInner({
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className={styles.theadRow}>
               {headerGroup.headers.map((header) => {
-                const canSort = header.column.getCanSort();
                 const sortDirection = header.column.getIsSorted();
+                const isColumnSelected = selection.selectedColumn === header.column.id;
                 return (
                   <th
                     key={header.id}
-                    className={[styles.th, canSort && styles.sortable].filter(Boolean).join(' ')}
+                    className={[
+                      styles.th,
+                      styles.clickable,
+                      isColumnSelected && styles.selectedColumnHeader,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
                     style={{
                       width: header.getSize(),
                       minWidth: header.column.columnDef.minSize,
                       maxWidth: header.column.columnDef.maxSize,
                     }}
-                    onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                    onClick={() => callbacks.onColumnSelect(header.column.id)}
                     onContextMenu={(e) => openHeaderMenu(e, header.column.id)}
                   >
                     <div className={styles.thContent}>
@@ -155,7 +163,11 @@ function GridTableInner({
               <tr
                 key={row.id}
                 className={rowClasses}
-                onClick={() => callbacks.onRowClick(rowIndex)}
+                onClick={(e) =>
+                  e.shiftKey
+                    ? callbacks.onRowRangeSelect(rowIndex)
+                    : callbacks.onRowToggle(rowIndex)
+                }
               >
                 {row.getVisibleCells().map((cell) => {
                   const value = cell.getValue();

--- a/frontend/src/components/grid/ResultGrid.module.css
+++ b/frontend/src/components/grid/ResultGrid.module.css
@@ -343,13 +343,18 @@
   border-right: none;
 }
 
-.th.sortable {
+.th.clickable {
   cursor: pointer;
   user-select: none;
 }
 
-.th.sortable:hover {
+.th.clickable:hover {
   background-color: var(--bg-hover);
+}
+
+.th.selectedColumnHeader {
+  background-color: var(--selection-bg, rgba(58, 109, 140, 0.4));
+  color: var(--selection-text, #fff);
 }
 
 .thContent {

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -4,6 +4,7 @@ import {
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
+  type Row,
   type SortingState,
   useReactTable,
 } from '@tanstack/react-table';
@@ -67,6 +68,9 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState<Set<number>>(new Set());
   const [selectedColumn, setSelectedColumn] = useState<string | null>(null);
+  const lastClickedRowRef = useRef<number | null>(null);
+  const rowsLengthRef = useRef(0);
+  const viewRowsRef = useRef<Row<RowData>[]>([]);
   const [activeResultIndex, setActiveResultIndex] = useState(0);
   const [valueEditorState, setValueEditorState] = useState<{
     isOpen: boolean;
@@ -216,12 +220,18 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     [valueEditorState, updateCell]
   );
 
+  const getRowByViewIndex = useCallback(
+    (viewIndex: number): RowData | undefined => viewRowsRef.current[viewIndex]?.original,
+    []
+  );
+
   const { editingCell, editValue, setEditValue, startEdit, commitEdit } = useGridKeyboard({
     isEditMode,
     selectedRows,
     selectedColumn,
     columns,
     rowData,
+    getRowByViewIndex,
     tableContainerRef,
     updateCell,
     onDeleteRow: deleteRow,
@@ -250,6 +260,8 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   });
 
   const { rows } = table.getRowModel();
+  rowsLengthRef.current = rows.length;
+  viewRowsRef.current = rows;
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => tableContainerRef.current,
@@ -287,18 +299,39 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   );
 
   // --- Callbacks for sub-components ---
-  const selectRow = useCallback((rowIndex: number) => {
+  const toggleRow = useCallback((rowIndex: number) => {
     setSelectedRows((prev) => {
       const next = new Set(prev);
       if (next.has(rowIndex)) next.delete(rowIndex);
       else next.add(rowIndex);
       return next;
     });
+    lastClickedRowRef.current = rowIndex;
+    setSelectedColumn(null);
+  }, []);
+
+  const rangeSelectRow = useCallback((rowIndex: number) => {
+    if (lastClickedRowRef.current === null) return;
+    const start = Math.min(lastClickedRowRef.current, rowIndex);
+    const end = Math.max(lastClickedRowRef.current, rowIndex);
+    const range = new Set<number>();
+    for (let i = start; i <= end; i++) range.add(i);
+    setSelectedRows(range);
+    setSelectedColumn(null);
   }, []);
 
   const selectCell = useCallback((rowIndex: number, field: string) => {
     setSelectedRows(new Set([rowIndex]));
     setSelectedColumn(field);
+    lastClickedRowRef.current = rowIndex;
+  }, []);
+
+  const selectColumn = useCallback((columnId: string) => {
+    setSelectedColumn(columnId);
+    const allRows = new Set<number>();
+    for (let i = 0; i < rowsLengthRef.current; i++) allRows.add(i);
+    setSelectedRows(allRows);
+    lastClickedRowRef.current = null;
   }, []);
 
   const gridCallbacks = useMemo(
@@ -306,11 +339,22 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
       onSetEditValue: setEditValue,
       onStartEdit: startEdit,
       onCommitEdit: commitEdit,
-      onRowClick: selectRow,
+      onRowToggle: toggleRow,
+      onRowRangeSelect: rangeSelectRow,
       onCellClick: selectCell,
+      onColumnSelect: selectColumn,
       onUpdateCell: updateCell,
     }),
-    [setEditValue, startEdit, commitEdit, selectRow, selectCell, updateCell]
+    [
+      setEditValue,
+      startEdit,
+      commitEdit,
+      toggleRow,
+      rangeSelectRow,
+      selectCell,
+      selectColumn,
+      updateCell,
+    ]
   );
 
   const whereKeyDown = useCallback(

--- a/frontend/src/components/grid/hooks/useGridKeyboard.ts
+++ b/frontend/src/components/grid/hooks/useGridKeyboard.ts
@@ -15,6 +15,8 @@ interface UseGridKeyboardOptions {
   selectedColumn: string | null;
   columns: ColumnDef<RowData>[];
   rowData: RowData[];
+  /** ソート/フィルタ後のビュー順でrowを取得 */
+  getRowByViewIndex: (viewIndex: number) => RowData | undefined;
   tableContainerRef: React.RefObject<HTMLDivElement | null>;
   updateCell: (
     rowIndex: number,
@@ -47,6 +49,7 @@ export function useGridKeyboard({
   selectedColumn,
   columns,
   rowData,
+  getRowByViewIndex,
   tableContainerRef,
   updateCell,
   onDeleteRow,
@@ -64,6 +67,18 @@ export function useGridKeyboard({
     const selectedRowIndices = Array.from(selectedRows).sort((a, b) => a - b);
     if (selectedRowIndices.length === 0) return;
 
+    // 列選択モード: 選択列の値のみコピー（ソート/フィルタ後の表示順）
+    if (selectedColumn) {
+      const values = selectedRowIndices.map((viewIndex) => {
+        const row = getRowByViewIndex(viewIndex);
+        if (!row) return 'NULL';
+        const value = row[selectedColumn];
+        return value === null ? 'NULL' : value;
+      });
+      await copyToClipboard(values.join('\n'), `${values.length}件の値をコピーしました`);
+      return;
+    }
+
     const headerRow = columns.map((col) => String(col.header));
     const dataRows = selectedRowIndices.map((rowIndex) => {
       const row = rowData[rowIndex];
@@ -75,7 +90,7 @@ export function useGridKeyboard({
 
     const tsv = [headerRow, ...dataRows].map((row) => row.join('\t')).join('\n');
     await copyToClipboard(tsv, `${selectedRowIndices.length}行をコピーしました`);
-  }, [selectedRows, columns, rowData, copyToClipboard]);
+  }, [selectedRows, selectedColumn, columns, rowData, getRowByViewIndex, copyToClipboard]);
 
   const copySqlInsert = useCallback(async () => {
     const selectedRowIndices = Array.from(selectedRows).sort((a, b) => a - b);

--- a/frontend/src/components/layout/CenterPanel.tsx
+++ b/frontend/src/components/layout/CenterPanel.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useCallback, useMemo } from 'react';
+import { useERImport } from '../../hooks/useERImport';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useActiveQuery, useQueryStore } from '../../store/queryStore';
 import { connectionColor } from '../../utils/colorContrast';
@@ -16,6 +17,9 @@ const ResultGrid = lazy(() =>
 const ERDiagramView = lazy(() =>
   import('../diagram/ERDiagram').then((module) => ({ default: module.ERDiagram }))
 );
+const ERImportDialog = lazy(() =>
+  import('../dialogs/ERImportDialog').then((module) => ({ default: module.ERImportDialog }))
+);
 
 // Loading fallback for Monaco Editor
 function EditorLoadingFallback() {
@@ -31,6 +35,7 @@ export function CenterPanel() {
   const activeQuery = useActiveQuery();
   const connections = useConnectionStore((s) => s.connections);
   const updateQueryConnection = useQueryStore((s) => s.updateQueryConnection);
+  const erImport = useERImport();
   const isDataView = activeQuery?.isDataView === true;
   const isERDiagram = activeQuery?.isERDiagram === true;
 
@@ -87,7 +92,7 @@ export function CenterPanel() {
       <div className={styles.editorContainer}>
         <Suspense fallback={<EditorLoadingFallback />}>
           {isERDiagram ? (
-            <ERDiagramView />
+            <ERDiagramView onOpenImportDialog={erImport.open} />
           ) : isDataView ? (
             <ResultGrid queryId={activeQuery?.id} />
           ) : (
@@ -95,6 +100,15 @@ export function CenterPanel() {
           )}
         </Suspense>
       </div>
+      {erImport.isOpen && (
+        <Suspense fallback={null}>
+          <ERImportDialog
+            isOpen={erImport.isOpen}
+            onClose={erImport.close}
+            onImport={erImport.importModel}
+          />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -2,7 +2,6 @@ import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { bridge } from '../../api/bridge';
 import { useKeyboardHandler } from '../../hooks/useKeyboardHandler';
 import { useConnectionStore } from '../../store/connectionStore';
-import { useERDiagramStore } from '../../store/erDiagramStore';
 import { useQueryStore } from '../../store/queryStore';
 import { useSessionStore } from '../../store/sessionStore';
 import {
@@ -31,10 +30,6 @@ const SearchDialog = lazy(() =>
 const SettingsDialog = lazy(() =>
   import('../dialogs/SettingsDialog').then((module) => ({ default: module.SettingsDialog }))
 );
-const ERImportDialog = lazy(() =>
-  import('../dialogs/ERImportDialog').then((module) => ({ default: module.ERImportDialog }))
-);
-
 // Simple loading fallback
 function LoadingFallback() {
   return <div style={{ display: 'none' }} />;
@@ -62,12 +57,6 @@ const Icons = {
   format: (
     <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
       <path d="M2 3h12M2 6h8M2 9h12M2 12h8" />
-    </svg>
-  ),
-  import: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <path d="M8 2v8M5 7l3 3 3-3" />
-      <path d="M2 11v2a1 1 0 001 1h10a1 1 0 001-1v-2" />
     </svg>
   ),
   sidebar: (
@@ -115,7 +104,6 @@ export function MainLayout() {
   const [isConnectionDialogOpen, setIsConnectionDialogOpen] = useState(false);
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
   const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
-  const [isERImportDialogOpen, setIsERImportDialogOpen] = useState(false);
   const [queryConfirmDialog, setQueryConfirmDialog] = useState<{
     isOpen: boolean;
     title: string;
@@ -135,9 +123,7 @@ export function MainLayout() {
     cancelQuery,
     formatQuery,
     isExecuting,
-    openERDiagram,
   } = useQueryStore();
-  const { loadFromParsedModel } = useERDiagramStore();
   const activeQuery = queries.find((q) => q.id === activeQueryId);
   const activeQueryConnectionId = activeQuery?.connectionId ?? null;
   const activeQueryConnection = connections.find((c) => c.id === activeQueryConnectionId);
@@ -317,8 +303,7 @@ export function MainLayout() {
 
   // Note: isBottomPanelVisible is NOT persisted - it's always hidden on startup
 
-  const hasOpenDialog =
-    isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen || isERImportDialogOpen;
+  const hasOpenDialog = isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen;
 
   // Keyboard shortcuts
   useKeyboardHandler((e: KeyboardEvent) => {
@@ -443,16 +428,6 @@ export function MainLayout() {
             title="SQLフォーマット (Ctrl+Shift+F)"
           >
             {Icons.format}
-          </button>
-        </div>
-
-        <div className={styles.toolbarDivider} />
-
-        {/* Import */}
-        <div className={styles.toolbarGroup}>
-          <button onClick={() => setIsERImportDialogOpen(true)} title="ER図ファイルをインポート">
-            {Icons.import}
-            <span>インポート</span>
           </button>
         </div>
 
@@ -611,19 +586,6 @@ export function MainLayout() {
           <SettingsDialog
             isOpen={isSettingsDialogOpen}
             onClose={() => setIsSettingsDialogOpen(false)}
-          />
-        </Suspense>
-      )}
-
-      {isERImportDialogOpen && (
-        <Suspense fallback={<LoadingFallback />}>
-          <ERImportDialog
-            isOpen={isERImportDialogOpen}
-            onClose={() => setIsERImportDialogOpen(false)}
-            onImport={(model) => {
-              loadFromParsedModel(model);
-              openERDiagram(model.name || 'ER Diagram');
-            }}
           />
         </Suspense>
       )}

--- a/frontend/src/hooks/useERDiagramContext.ts
+++ b/frontend/src/hooks/useERDiagramContext.ts
@@ -9,6 +9,7 @@ export interface ERDiagramContextValue {
   selectedPage: string;
   setSelectedPage: (page: string) => void;
   pageCounts: Map<string, number>;
+  totalTableCount: number;
   tables: ERTableNode[];
   relations: ERRelationEdge[];
   shapes: ERShapeNode[];
@@ -66,6 +67,7 @@ export function useERDiagramContext(): ERDiagramContextValue {
     selectedPage,
     setSelectedPage,
     pageCounts,
+    totalTableCount: allTables.length,
     tables,
     relations,
     shapes,

--- a/frontend/src/hooks/useERImport.ts
+++ b/frontend/src/hooks/useERImport.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from 'react';
+import { useERDiagramStore } from '../store/erDiagramStore';
+import { useQueryStore } from '../store/queryStore';
+import type { ERDiagramModel } from '../utils/erDiagramParser';
+
+export function useERImport() {
+  const [isOpen, setIsOpen] = useState(false);
+  const loadFromParsedModel = useERDiagramStore((s) => s.loadFromParsedModel);
+  const openERDiagram = useQueryStore((s) => s.openERDiagram);
+
+  const importModel = useCallback(
+    (model: ERDiagramModel) => {
+      loadFromParsedModel(model);
+      openERDiagram(model.name || 'ER Diagram');
+    },
+    [loadFromParsedModel, openERDiagram]
+  );
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return { isOpen, open, close, importModel };
+}

--- a/frontend/src/tests/utils/colorContrast.test.ts
+++ b/frontend/src/tests/utils/colorContrast.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { blendWithBackground } from '../../utils/colorContrast';
+
+describe('blendWithBackground', () => {
+  it('fully opaque returns foreground', () => {
+    expect(blendWithBackground('#ff0000', 255, '#0000ff')).toBe('#ff0000');
+  });
+
+  it('fully transparent returns background', () => {
+    expect(blendWithBackground('#ff0000', 0, '#0000ff')).toBe('#0000ff');
+  });
+
+  it('50% alpha blends correctly', () => {
+    // 128/255 ≈ 0.502; red channel: round(255*0.502 + 0*0.498) = 128 = 0x80
+    expect(blendWithBackground('#ff0000', 128, '#000000')).toBe('#800000');
+  });
+
+  it('invalid foreground hex returns background', () => {
+    expect(blendWithBackground('invalid', 128, '#000000')).toBe('#000000');
+  });
+
+  it('invalid background hex returns background string', () => {
+    expect(blendWithBackground('#ff0000', 128, 'invalid')).toBe('invalid');
+  });
+});

--- a/frontend/src/utils/colorContrast.ts
+++ b/frontend/src/utils/colorContrast.ts
@@ -47,6 +47,16 @@ export function readableColor(bgHex: string, preferred?: string): string {
   return relativeLuminance(bgHex) > 0.179 ? '#1e1e1e' : '#ffffff';
 }
 
+/** Blend a foreground color with a background using alpha (0-255) */
+export function blendWithBackground(fgHex: string, alpha: number, bgHex: string): string {
+  const fg = parseHex(fgHex);
+  const bg = parseHex(bgHex);
+  if (!fg || !bg) return bgHex;
+  const a = Math.max(0, Math.min(1, alpha / 255));
+  const blend = (f: number, b: number) => Math.round(f * a + b * (1 - a));
+  return `#${blend(fg[0], bg[0]).toString(16).padStart(2, '0')}${blend(fg[1], bg[1]).toString(16).padStart(2, '0')}${blend(fg[2], bg[2]).toString(16).padStart(2, '0')}`;
+}
+
 /** Convert hex color + alpha (0-255) to CSS rgba() string */
 export function hexToRgba(hex: string, alpha: number): string {
   const rgb = parseHex(hex);


### PR DESCRIPTION
- ShapeNode: fontColor優先+alpha blend対応でA5:SQL互換の文字色表示
- ERImportDialog: 480px幅に縮小、DDL条件レンダリング、Escape stopPropagation
- インポートボタン: MainLayout→CenterPanel/ERDiagram移動（useERImport hook抽出）
- グリッド列選択: ヘッダークリックで列全選択、Shift+Clickで行範囲選択
- 列コピー: Ctrl+C で選択列の値をコピー（getRowByViewIndexでソート/フィルタ対応）
- Intent命名: onRowClick→onRowToggle/onRowRangeSelect, onHeaderClick→onColumnSelect