### PR TITLE
feat(editor): +ボタンをドロップダウン化し新規ER図タブ作成導線を追加

### DIFF
--- a/frontend/src/components/editor/EditorTabs.module.css
+++ b/frontend/src/components/editor/EditorTabs.module.css
@@ -224,6 +224,11 @@
   text-overflow: ellipsis;
 }
 
+/* Add menu dropdown */
+.addMenuWrapper {
+  position: relative;
+}
+
 /* Drag & Drop */
 .dragging {
   opacity: 0.4;

--- a/frontend/src/components/editor/EditorTabs.tsx
+++ b/frontend/src/components/editor/EditorTabs.tsx
@@ -84,14 +84,16 @@ export function EditorTabs() {
       ),
     [connections]
   );
-  const { addQuery, removeQuery, setActive, reorderQuery } = useQueryActions();
+  const { addQuery, removeQuery, setActive, reorderQuery, openERDiagram } = useQueryActions();
   const activeQuery = queries.find((q) => q.id === activeQueryId);
   const activeQueryConnectionId = activeQuery?.connectionId ?? null;
 
   const tabsRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const addMenuRef = useRef<HTMLDivElement>(null);
 
   // DnD state
   const [dragIndex, setDragIndex] = useState<number | null>(null);
@@ -127,18 +129,25 @@ export function EditorTabs() {
     checkOverflow();
   }, [queries.length, checkOverflow]);
 
-  // メニュー外クリックで閉じる
+  // メニュー外クリックで閉じる（各メニュー独立）
   useEffect(() => {
     if (!menuOpen) return;
-
-    const handleClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMenuOpen(false);
-      }
+    const close = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
     };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
   }, [menuOpen]);
+
+  useEffect(() => {
+    if (!addMenuOpen) return;
+    const close = (e: MouseEvent) => {
+      if (addMenuRef.current && !addMenuRef.current.contains(e.target as Node))
+        setAddMenuOpen(false);
+    };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [addMenuOpen]);
 
   // --- DnD handlers ---
   const handleDragStart = useCallback((e: React.DragEvent, index: number) => {
@@ -181,6 +190,18 @@ export function EditorTabs() {
     setDragIndex(null);
     setDropTarget(null);
   }, []);
+
+  const createERDiagram = useCallback(() => {
+    const existingNames = new Set(queries.filter((q) => q.isERDiagram).map((q) => q.name));
+    let idx = 1;
+    let name = 'ER図';
+    while (existingNames.has(name)) {
+      idx++;
+      name = `ER図 ${idx}`;
+    }
+    openERDiagram(name);
+    setAddMenuOpen(false);
+  }, [queries, openERDiagram]);
 
   return (
     <div className={styles.container}>
@@ -264,13 +285,33 @@ export function EditorTabs() {
           )}
         </div>
       )}
-      <button
-        className={styles.addButton}
-        onClick={() => addQuery(activeQueryConnectionId)}
-        title="新規クエリ (Ctrl+N)"
-      >
-        {PlusIcon}
-      </button>
+      <div className={styles.addMenuWrapper} ref={addMenuRef}>
+        <button
+          className={styles.addButton}
+          onClick={() => setAddMenuOpen((prev) => !prev)}
+          title="新規タブ (Ctrl+N)"
+        >
+          {PlusIcon}
+        </button>
+        {addMenuOpen && (
+          <div className={styles.overflowMenu}>
+            <button
+              className={styles.overflowMenuItem}
+              onClick={() => {
+                addQuery(activeQueryConnectionId);
+                setAddMenuOpen(false);
+              }}
+            >
+              {SqlIcon}
+              <span>新規クエリ</span>
+            </button>
+            <button className={styles.overflowMenuItem} onClick={createERDiagram}>
+              {ERDiagramIcon}
+              <span>新規ER図</span>
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/tests/editor/EditorTabs.test.tsx
+++ b/frontend/src/tests/editor/EditorTabs.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditorTabs } from '../../components/editor/EditorTabs';
+import type { Query } from '../../types';
+
+// --- Mocks ---
+const mockAddQuery = vi.fn();
+const mockRemoveQuery = vi.fn();
+const mockSetActive = vi.fn();
+const mockReorderQuery = vi.fn();
+const mockOpenERDiagram = vi.fn().mockReturnValue('new-er-id');
+let mockQueries: Query[] = [];
+
+vi.mock('../../store/queryStore', () => ({
+  useQueries: () => mockQueries,
+  useQueryStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({ activeQueryId: null }),
+  useQueryActions: () => ({
+    addQuery: mockAddQuery,
+    removeQuery: mockRemoveQuery,
+    setActive: mockSetActive,
+    reorderQuery: mockReorderQuery,
+    openERDiagram: mockOpenERDiagram,
+  }),
+}));
+
+vi.mock('../../store/connectionStore', () => ({
+  useConnectionStore: () => [],
+}));
+
+vi.mock('../../utils/colorContrast', () => ({
+  connectionColor: () => '#000',
+}));
+
+describe('EditorTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueries = [];
+  });
+
+  describe('新規タブメニュー', () => {
+    it('+ボタンクリックでドロップダウンが表示される', () => {
+      render(<EditorTabs />);
+      const addButton = screen.getByTitle('新規タブ (Ctrl+N)');
+
+      fireEvent.click(addButton);
+
+      expect(screen.getByText('新規クエリ')).toBeInTheDocument();
+      expect(screen.getByText('新規ER図')).toBeInTheDocument();
+    });
+
+    it('+ボタン再クリックでドロップダウンが閉じる', () => {
+      render(<EditorTabs />);
+      const addButton = screen.getByTitle('新規タブ (Ctrl+N)');
+
+      fireEvent.click(addButton);
+      expect(screen.getByText('新規クエリ')).toBeInTheDocument();
+
+      fireEvent.click(addButton);
+      expect(screen.queryByText('新規クエリ')).not.toBeInTheDocument();
+    });
+
+    it('「新規クエリ」クリックで addQuery が呼ばれメニューが閉じる', () => {
+      render(<EditorTabs />);
+      fireEvent.click(screen.getByTitle('新規タブ (Ctrl+N)'));
+      fireEvent.click(screen.getByText('新規クエリ'));
+
+      expect(mockAddQuery).toHaveBeenCalledWith(null);
+      expect(screen.queryByText('新規クエリ')).not.toBeInTheDocument();
+    });
+
+    it('ER図が存在しない場合「ER図」で作成される', () => {
+      render(<EditorTabs />);
+      fireEvent.click(screen.getByTitle('新規タブ (Ctrl+N)'));
+      fireEvent.click(screen.getByText('新規ER図'));
+
+      expect(mockOpenERDiagram).toHaveBeenCalledWith('ER図');
+      expect(screen.queryByText('新規ER図')).not.toBeInTheDocument();
+    });
+
+    it('既存ER図がある場合はユニーク名で作成される', () => {
+      mockQueries = [
+        {
+          id: '1',
+          name: 'ER図',
+          content: '',
+          connectionId: null,
+          isDirty: false,
+          isERDiagram: true,
+        },
+      ];
+
+      render(<EditorTabs />);
+      fireEvent.click(screen.getByTitle('新規タブ (Ctrl+N)'));
+      fireEvent.click(screen.getByText('新規ER図'));
+
+      expect(mockOpenERDiagram).toHaveBeenCalledWith('ER図 2');
+    });
+  });
+});


### PR DESCRIPTION
- +ボタンクリックでドロップダウンメニュー表示（新規クエリ / 新規ER図）
- ER図名はユニーク生成（ER図, ER図 2, ER図 3...）
- overflowMenu/overflowMenuItemのCSSクラスを再利用（DRY）
- 外クリック処理を各メニュー独立のuseEffectに分離
- EditorTabsテスト5件追加（メニュー開閉・アクション呼出・ユニーク名）