### PR TITLE
feat(tree): ビューノードのカラム展開対応

### DIFF
--- a/frontend/src/components/layout/LeftPanel.tsx
+++ b/frontend/src/components/layout/LeftPanel.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useQueryActions } from '../../store/queryStore';
+import type { ExpandableType } from '../../utils/treeNode';
 import { ObjectTree } from '../tree/ObjectTree';
 import styles from './LeftPanel.module.css';
 
@@ -29,7 +30,7 @@ export function LeftPanel({ width }: LeftPanelProps) {
   const { openTableData } = useQueryActions();
 
   const handleTableOpen = useCallback(
-    (tableName: string, _tableType: 'table' | 'view', connectionId?: string) => {
+    (tableName: string, _tableType: ExpandableType, connectionId?: string) => {
       // Use the provided connectionId (from the clicked table) or fall back to activeConnectionId
       const targetConnectionId = connectionId || activeConnectionId;
       if (targetConnectionId) {

--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -6,7 +6,12 @@ import type { Connection, DatabaseObject, MenuItem } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
 import { log } from '../../utils/logger';
 import { buildSelectSql } from '../../utils/sqlIdentifier';
-import { parseTableNodeId, shouldLoadColumns, updateNodeChildren } from '../../utils/treeNode';
+import {
+  type ExpandableType,
+  parseTableNodeId,
+  shouldLoadColumns,
+  updateNodeChildren,
+} from '../../utils/treeNode';
 import { InputDialog } from '../dialogs/InputDialog';
 import { QueryConfirmDialog } from '../dialogs/QueryConfirmDialog';
 import { ContextMenu } from './ContextMenu';
@@ -16,7 +21,7 @@ import { TreeNode } from './TreeNode';
 interface ConnectionTreeSectionProps {
   connection: Connection;
   filter: string;
-  onTableOpen?: (tableName: string, tableType: 'table' | 'view', connectionId?: string) => void;
+  onTableOpen?: (tableName: string, tableType: ExpandableType, connectionId?: string) => void;
 }
 
 export function ConnectionTreeSection({
@@ -262,7 +267,7 @@ export function ConnectionTreeSection({
   const filteredData = filterTree(treeData);
 
   const handleTableOpen = useCallback(
-    (nodeId: string, tableName: string, tableType: 'table' | 'view') => {
+    (nodeId: string, tableName: string, tableType: ExpandableType) => {
       setSelectedNodeId(nodeId);
       if (onTableOpen) {
         // Pass the connection ID along with table info
@@ -299,7 +304,7 @@ export function ConnectionTreeSection({
           label: 'データを開く',
           action: () => {
             if (onTableOpen) {
-              onTableOpen(node.name, node.type as 'table' | 'view', connection.id);
+              onTableOpen(node.name, node.type as ExpandableType, connection.id);
             }
           },
         });

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useConnectionActions, useConnectionStore } from '../../store/connectionStore';
+import type { ExpandableType } from '../../utils/treeNode';
 import { ConnectionTreeSection } from './ConnectionTreeSection';
 import styles from './ObjectTree.module.css';
 
@@ -29,7 +30,7 @@ interface SavedProfile {
 
 interface ObjectTreeProps {
   filter: string;
-  onTableOpen?: (tableName: string, tableType: 'table' | 'view', connectionId?: string) => void;
+  onTableOpen?: (tableName: string, tableType: ExpandableType, connectionId?: string) => void;
 }
 
 export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {

--- a/frontend/src/components/tree/TreeNode.tsx
+++ b/frontend/src/components/tree/TreeNode.tsx
@@ -1,5 +1,6 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import type { DatabaseObject } from '../../types';
+import { type ExpandableType, isExpandableType } from '../../utils/treeNode';
 import styles from './TreeNode.module.css';
 
 interface TreeNodeProps {
@@ -10,7 +11,7 @@ interface TreeNodeProps {
   selectedNodeId?: string | null;
   connectionColor?: string;
   onToggle: (id: string, node: DatabaseObject) => void;
-  onTableOpen?: (nodeId: string, tableName: string, tableType: 'table' | 'view') => void;
+  onTableOpen?: (nodeId: string, tableName: string, tableType: ExpandableType) => void;
   onContextMenu?: (e: React.MouseEvent, node: DatabaseObject) => void;
 }
 
@@ -103,6 +104,9 @@ const getIcon = (
   }
 };
 
+const EXPANDER_VISIBLE = { visibility: 'visible' as const };
+const EXPANDER_HIDDEN = { visibility: 'hidden' as const };
+
 const getIconClass = (type: DatabaseObject['type'] | 'folder'): string => {
   switch (type) {
     case 'database':
@@ -130,14 +134,14 @@ export const TreeNode = memo(function TreeNode({
   onContextMenu,
 }: TreeNodeProps) {
   const hasChildren = node.children && node.children.length > 0;
-  const canExpand = hasChildren || node.type === 'table'; // Tables can lazy-load columns
+  const canExpand = hasChildren || isExpandableType(node.type);
   const isExpanded = expandedNodes.has(node.id);
   const isLoading = loadingNodes?.has(node.id);
   const isSelected = selectedNodeId === node.id;
 
   const handleClick = () => {
     // For tables/views, single click opens data; arrow click expands columns
-    if ((node.type === 'table' || node.type === 'view') && onTableOpen) {
+    if (isExpandableType(node.type) && onTableOpen) {
       onTableOpen(node.id, node.name, node.type);
     } else if (canExpand) {
       onToggle(node.id, node);
@@ -157,24 +161,23 @@ export const TreeNode = memo(function TreeNode({
     onContextMenu?.(e, node);
   };
 
-  const nodeClasses = [
-    styles.node,
-    isLoading ? styles.loading : '',
-    isSelected ? styles.selected : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
+  const nodeClasses = `${styles.node}${isLoading ? ` ${styles.loading}` : ''}${isSelected ? ` ${styles.selected}` : ''}`;
+
+  const nodeStyle = useMemo(
+    () => ({
+      paddingLeft: `${level * 12 + 4}px`,
+      ...(node.type === 'database' && connColor
+        ? ({ '--connection-color': connColor } as React.CSSProperties)
+        : {}),
+    }),
+    [level, node.type, connColor]
+  );
 
   return (
     <div className={styles.container}>
       <div
         className={nodeClasses}
-        style={{
-          paddingLeft: `${level * 12 + 4}px`,
-          ...(node.type === 'database' && connColor
-            ? ({ '--connection-color': connColor } as React.CSSProperties)
-            : {}),
-        }}
+        style={nodeStyle}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
       >
@@ -183,7 +186,7 @@ export const TreeNode = memo(function TreeNode({
           onClick={handleExpanderClick}
           role="button"
           tabIndex={-1}
-          style={{ visibility: canExpand ? 'visible' : 'hidden' }}
+          style={canExpand ? EXPANDER_VISIBLE : EXPANDER_HIDDEN}
         >
           {isLoading ? Icons.loading : isExpanded ? Icons.chevronDown : Icons.chevronRight}
         </span>

--- a/frontend/src/tests/tree/TreeNode.test.tsx
+++ b/frontend/src/tests/tree/TreeNode.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TreeNode } from '../../components/tree/TreeNode';
+import type { DatabaseObject } from '../../types';
+
+const createNode = (overrides: Partial<DatabaseObject> = {}): DatabaseObject => ({
+  id: 'test-1',
+  name: 'TestNode',
+  type: 'table',
+  ...overrides,
+});
+
+const createBaseProps = () => ({
+  level: 0,
+  expandedNodes: new Set<string>(),
+  onToggle: vi.fn(),
+});
+
+describe('TreeNode canExpand', () => {
+  it('テーブルノードに展開矢印が表示される', () => {
+    render(<TreeNode {...createBaseProps()} node={createNode({ type: 'table' })} />);
+    const expander = screen.getByRole('button');
+    expect(expander).toBeVisible();
+  });
+
+  it('ビューノードに展開矢印が表示される', () => {
+    render(
+      <TreeNode {...createBaseProps()} node={createNode({ type: 'view', name: 'v_users' })} />
+    );
+    const expander = screen.getByRole('button');
+    expect(expander).toBeVisible();
+  });
+
+  it('ビューノード展開時にonToggleが呼ばれる', () => {
+    const onToggle = vi.fn();
+    const viewNode = createNode({ type: 'view', name: 'v_users' });
+    render(<TreeNode {...createBaseProps()} node={viewNode} onToggle={onToggle} />);
+    const expander = screen.getByRole('button');
+    fireEvent.click(expander);
+    expect(onToggle).toHaveBeenCalledWith(viewNode.id, viewNode);
+  });
+
+  it('カラムノードには展開矢印が非表示', () => {
+    render(<TreeNode {...createBaseProps()} node={createNode({ type: 'column', name: 'id' })} />);
+    const expander = screen.getByRole('button', { hidden: true });
+    expect(expander).not.toBeVisible();
+  });
+});

--- a/frontend/src/utils/treeNode.ts
+++ b/frontend/src/utils/treeNode.ts
@@ -27,12 +27,17 @@ export function parseTableNodeId(
   return { schema: rest.slice(0, dotIdx), tableName: rest.slice(dotIdx + 1) };
 }
 
+export type ExpandableType = 'table' | 'view';
+
+const EXPANDABLE_TYPES: ReadonlySet<string> = new Set<ExpandableType>(['table', 'view']);
+
+export function isExpandableType(type: DatabaseObject['type']): type is ExpandableType {
+  return EXPANDABLE_TYPES.has(type);
+}
+
 /** カラム遅延読み込みの対象ノードか判定 */
 export function shouldLoadColumns(
   node: DatabaseObject
 ): node is DatabaseObject & { type: 'table' | 'view' } {
-  return (
-    (node.type === 'table' || node.type === 'view') &&
-    (!node.children || node.children.length === 0)
-  );
+  return isExpandableType(node.type) && (!node.children || node.children.length === 0);
 }


### PR DESCRIPTION
- canExpand判定にviewタイプを追加
- ExpandableType型ガードでDRY化（shouldLoadColumns・onTableOpen統一）
- useMemoでstyle object安定化、expander style定数化
- nodeClasses簡素化
- TreeNodeテスト4件追加