### PR TITLE
fix(view): ビューカラムリネームの例外未捕捉・サブクエリ誤動作を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,130 +6,146 @@ Velocity-DB固有の指示。グローバルルール (`~/.claude/CLAUDE.md`) �
 
 ## プロジェクト概要
 
-Windows専用RDBMS管理ツール（DataGripライクUI）。SQL Server / PostgreSQL / MySQL対応（ODBC経由）。
+Windows専用RDBMS管理ツール。SQL Server / PostgreSQL / MySQL対応（ODBC経由）。
 
 - Backend: C++23 + ODBC + WebView2
-- Frontend: React 18 + TypeScript + TanStack Table
-
-## アーキテクチャ（Big Picture）
-
-### IPC通信フロー
-
-1. Frontend → `window.ipc(method, params)` でメッセージ送信
-2. Backend → `ipc_handler.cpp` でルーティング・JSON解析
-3. Backend → 各機能モジュール（`database/`, `parsers/`, `exporters/`）で処理
-4. Backend → JSON形式で結果を返却
-5. Frontend → `api/bridge.ts` でPromiseラップしてReactで利用
-
-### データベース層の仕組み
-
-- **ConnectionPool**: 最大10接続を維持、非アクティブ接続を自動切断
-- **AsyncQueryExecutor**: 別スレッドでクエリ実行、メインスレッドをブロックしない
-- **ResultCache**: LRUキャッシュ（100MB）、同一クエリの高速化
-- **TransactionManager**: BEGIN/COMMIT/ROLLBACK管理（C++実装済み、UI未実装）
-
-### セッション管理
-
-- `utils/session_manager.cpp` がウィンドウ状態・開いているタブ・接続プロファイルをJSONで永続化
-- アプリ終了時に自動保存、起動時に復元
+- Frontend: React 19 + TypeScript 5.9 + Vite 7 + TanStack Table + Zustand 5
 
 ## ビルドコマンド
 
+統合CLI: `uv run scripts/pdg.py` (ショートカット: `b`uild, `t`est, `l`int, `d`ev, `c`heck)
+
 ```bash
-# 開発時によく使うコマンド
 uv run scripts/pdg.py build backend              # C++ (Release)
-uv run scripts/pdg.py build backend --type Debug # C++ (Debug)
-uv run scripts/pdg.py build backend --clean      # クリーンビルド
-uv run scripts/pdg.py build frontend             # フロントエンド
-uv run scripts/pdg.py build all                  # 全体ビルド
-
-# テスト
-uv run scripts/pdg.py test backend               # C++テスト
-uv run scripts/pdg.py test frontend              # フロントエンドテスト
-uv run scripts/pdg.py test frontend --watch      # Watchモード
-
-# Lint
-uv run scripts/pdg.py lint                       # Frontend + C++
-uv run scripts/pdg.py lint --fix                 # 自動修正
-ruff check scripts/ && ruff format scripts/      # Python
-
-# 開発サーバー
-uv run scripts/pdg.py dev                        # localhost:5173
-
-# リリース
-uv run scripts/pdg.py release                    # 自動バージョン (patch bump)
-uv run scripts/pdg.py release --bump minor       # minor bump (1.2.0 → 1.3.0)
-uv run scripts/pdg.py release --bump major       # major bump (1.2.0 → 2.0.0)
-uv run scripts/pdg.py release 1.3.0              # バージョン直接指定
-uv run scripts/pdg.py release --skip-checks      # チェックをスキップ
-uv run scripts/pdg.py release --draft            # ドラフトリリース
-
-# ショートカット: build → b, test → t, lint → l, dev → d, release → r
-uv run scripts/pdg.py b backend --clean
-uv run scripts/pdg.py t frontend --watch
-uv run scripts/pdg.py l --fix
+uv run scripts/pdg.py build backend --type Debug  # C++ (Debug)
+uv run scripts/pdg.py build frontend              # フロントエンド
+uv run scripts/pdg.py build all                   # 全体ビルド
+uv run scripts/pdg.py test backend                # C++テスト
+uv run scripts/pdg.py test frontend               # フロントエンドテスト
+uv run scripts/pdg.py lint                        # Frontend + C++
+uv run scripts/pdg.py lint --fix                  # 自動修正
+uv run scripts/pdg.py dev                         # 開発サーバー (localhost:5173)
+uv run scripts/pdg.py check Release               # 全チェック (lint + test + build)
+ruff check scripts/ && ruff format scripts/       # Python lint (別途)
 ```
 
-詳細: `docs/BUILD_COMMANDS.md`
+## Frontendテスト (Docker必須)
+
+hookが node/npm 直接実行をブロックするため、Docker経由で実行:
+
+```bash
+# 全テスト
+docker run --rm -v "C:/prog/Velocity-DB://app" \
+  --mount "type=volume,target=//app/frontend/node_modules" \
+  -w "//app/frontend" node:latest \
+  sh -c 'npm install && npx vitest run --reporter=verbose'
+
+# 単一テストファイル
+docker run --rm -v "C:/prog/Velocity-DB://app" \
+  --mount "type=volume,target=//app/frontend/node_modules" \
+  -w "//app/frontend" node:latest \
+  sh -c 'npm install && npx vitest run --reporter=verbose src/tests/hooks/useColumnActions.test.ts'
+
+# biome lint (変更ファイルのみ)
+docker run --rm -v "C:/prog/Velocity-DB://app" \
+  --mount "type=volume,target=//app/frontend/node_modules" \
+  -w "//app/frontend" node:latest \
+  sh -c 'npm install && npx biome check src/path/to/file.ts'
+```
+
+`--mount type=volume` で node_modules を隔離（Windows/Linux バイナリ非互換対策）。
 
 ## 作業完了時の必須チェック
 
 ```bash
-uv run scripts/pdg.py lint                        # Frontend + C++
-ruff check scripts/ && ruff format --check scripts/  # Python
+uv run scripts/pdg.py lint
+ruff check scripts/ && ruff format --check scripts/
 ```
 
-## コーディング規約（重要ポイント）
+## アーキテクチャ
+
+### IPC通信フロー
+
+```
+Frontend → window.invoke(JSON) → Backend ipc_handler.cpp → providers/ → database/ → JSON応答
+Frontend ← api/bridge.ts (Promiseラップ) ←────────────────────────────────────────────────┘
+```
+
+### Backend 構造 (C++23)
+
+```
+backend/
+├── ipc_handler.cpp          # IPCルーティング (m_routes にルート登録)
+├── interfaces/              # ISP準拠インターフェース (*able.h)
+├── contexts/system_context   # DIコンテナ (全Providerを保持)
+├── providers/               # IPCハンドラ実装 (*_provider.cpp)
+└── database/                # DB操作
+    ├── driver_interface.h   # 抽象ドライバ
+    ├── sqlserver_driver.cpp + sqlserver_dialect.cpp
+    ├── postgresql_driver.cpp + postgresql_dialect.cpp
+    ├── driver_factory.cpp   # DriverType → 具象クラス生成
+    ├── connection_registry   # 接続プール管理
+    ├── async_query_executor  # 非同期クエリ実行
+    ├── result_cache          # LRUキャッシュ (100MB)
+    └── schema_inspector      # スキーマ情報取得
+```
+
+### Frontend 構造 (React 19)
+
+```
+frontend/src/
+├── api/bridge.ts            # IPC通信 (Backend全メソッドのPromiseラッパー)
+├── store/                   # Zustand stores (connectionStore, queryStore, editStore, ...)
+├── components/              # UI (grid/, tree/, editor/, diagram/, dialogs/, ...)
+├── hooks/                   # カスタムhooks (useColumnActions, useCopyToClipboard, ...)
+├── types/                   # 型定義
+└── utils/                   # ユーティリティ (sqlIdentifier, erDiagramParser, ...)
+```
+
+### 新しいIPCメソッド追加手順
+
+1. `ipc_handler.cpp` の `m_routes` にルート登録
+2. `providers/` の該当Providerにハンドラ実装
+3. `frontend/src/api/bridge.ts` にメソッド追加
+4. 必要に応じて `database/*_dialect.cpp` にSQL方言実装
+
+### セッション管理
+
+`utils/session_manager.cpp` がウィンドウ状態・タブ・接続プロファイルをJSON永続化。アプリ終了時自動保存、起動時復元。
+
+## コーディング規約
 
 ### C++ (backend/)
 
-- **C++23機能を使用**: `std::expected`, `std::format`, `std::ranges`
-- **STLを積極的に使用**: 自前実装よりライブラリ・標準機能を優先
-- **RAII原則**: スマートポインタ、リソース管理
-- **ODBC戻り値は必ずチェック**: `SQL_SUCCESS`の確認必須
-- **変数は基本`auto`**: 型推論を活用
-- **clang-format 21**: 自動フォーマット
+- C++23: `std::expected`, `std::format`, `std::ranges`
+- RAII + スマートポインタ、変数は基本 `auto`
+- ODBC戻り値は必ず `SQL_SUCCESS` チェック
+- clang-format 21
 
 ### TypeScript/React (frontend/)
 
-- **非nullアサーション (`!`) 禁止**: 明示的なnullチェックを使用
-- **CSS Modules**: スタイル衝突を防止
-- **Zustand**: 状態管理
+- 非nullアサーション (`!`) 禁止 → 明示的nullチェック
+- CSS Modules、Zustand、memo化 (GridToolbar, GridStatusBar, ResultGrid)
+- biome: lineWidth 100, シングルクォート, セミコロンあり
 
 ### Python (scripts/)
 
-- **Ruff**: Lint + Format
-- **型ヒント必須**: Python 3.14+の型システムを活用
-
-詳細: `docs/CODING_STANDARDS.md`
+- Ruff lint + format、Python 3.14+、型ヒント必須
 
 ## 設計参照
 
-アーキテクチャ設計時は以下を参考にすること:
-
-- [pre-omusubi architecture](https://github.com/TakumiOkayasu/pre-omusubi/blob/main/docs/architecture.md)
-  - ISP（インターフェース分離原則）: 単一責任のインターフェース
-  - Context Pattern: DIコンテナとして機能、テスト時のモック差し替え容易
-  - パフォーマンス最適化: キャッシュ活用、冗長計算の回避
-  - 関心事の分離: レイヤー構造による責務の明確化
+- [pre-omusubi architecture](https://github.com/TakumiOkayasu/pre-omusubi/blob/main/docs/architecture.md): ISP, Context Pattern, キャッシュ活用, レイヤー分離
 
 ## ドキュメント参照
-
-必要に応じて以下を読み込んで情報を提供:
 
 | ファイル | 内容 |
 |----------|------|
 | `TODO.md` | 残タスク一覧（作業前に確認） |
 | `docs/ARCHITECTURE.md` | アーキテクチャ、コンポーネント対応表 |
-| `docs/PROJECT_INFO.md` | 技術スタック、構造、ショートカット |
 | `docs/BUILD_COMMANDS.md` | ビルドコマンド詳細 |
 | `docs/CODING_STANDARDS.md` | コーディング規約 |
 | `docs/TROUBLESHOOTING.md` | トラブルシューティング |
 
 ## Claude Code責任範囲
 
-### UI問題発生時
-
-1. `log/frontend.log` と `log/backend.log` を確認
-2. エラー原因を特定して修正
-3. ユーザーは問題を報告するだけでOK
+UI問題発生時: `log/frontend.log` と `log/backend.log` を確認 → エラー原因特定 → 修正。

--- a/frontend/src/hooks/useColumnActions.ts
+++ b/frontend/src/hooks/useColumnActions.ts
@@ -2,7 +2,13 @@ import { useCallback, useState } from 'react';
 import { bridge } from '../api/bridge';
 import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
 import { log } from '../utils/logger';
-import { buildDropColumnSql, buildRenameColumnSql, quoteIdentifier } from '../utils/sqlIdentifier';
+import {
+  buildAlterViewSql,
+  buildDropColumnSql,
+  buildRenameColumnSql,
+  fetchViewDefinition,
+  quoteIdentifier,
+} from '../utils/sqlIdentifier';
 import { updateNodeChildren } from '../utils/treeNode';
 
 // --- Discriminated union for dialog state ---
@@ -12,6 +18,7 @@ interface RenameInput {
   colName: string;
   schema: string;
   tableName: string;
+  isView: boolean;
 }
 
 interface RenameConfirm {
@@ -109,9 +116,9 @@ export function useColumnActions({
         { label: '', action: () => {}, divider: true },
         {
           label: 'カラム名を変更',
-          disabled: isReadOnly || missingMeta || isView,
+          disabled: isReadOnly || missingMeta,
           action: () => {
-            setColumnAction({ type: 'rename-input', colName, schema, tableName: tblName });
+            setColumnAction({ type: 'rename-input', colName, schema, tableName: tblName, isView });
           },
         },
         {
@@ -129,23 +136,31 @@ export function useColumnActions({
 
   // Dialog event handlers
   const handleRenameInput = useCallback(
-    (newName: string) => {
+    async (newName: string) => {
       if (columnAction?.type !== 'rename-input') return;
-      const sql = buildRenameColumnSql(
-        columnAction.schema,
-        columnAction.tableName,
-        columnAction.colName,
-        newName,
-        dbType
-      );
-      setColumnAction({
-        type: 'rename-confirm',
-        sql,
-        schema: columnAction.schema,
-        tableName: columnAction.tableName,
-      });
+      const { schema, tableName, colName, isView } = columnAction;
+
+      try {
+        let sql: string;
+        if (isView) {
+          const viewDef = await fetchViewDefinition(connectionId, schema, tableName, dbType);
+          if (!viewDef) {
+            onDdlError?.(new Error('ビュー定義を取得できませんでした'));
+            setColumnAction(null);
+            return;
+          }
+          sql = buildAlterViewSql(viewDef, colName, newName, dbType);
+        } else {
+          sql = buildRenameColumnSql(schema, tableName, colName, newName, dbType);
+        }
+
+        setColumnAction({ type: 'rename-confirm', sql, schema, tableName });
+      } catch (error) {
+        onDdlError?.(error);
+        setColumnAction(null);
+      }
     },
-    [columnAction, dbType]
+    [columnAction, connectionId, dbType, onDdlError]
   );
 
   const handleRenameConfirm = useCallback(async () => {

--- a/frontend/src/tests/hooks/useColumnActions.test.ts
+++ b/frontend/src/tests/hooks/useColumnActions.test.ts
@@ -13,8 +13,18 @@ vi.mock('../../utils/logger', () => ({
   log: { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
 
-import { renderHook } from '@testing-library/react';
+// Partial mock: fetchViewDefinition だけをモック (他は実装を維持)
+vi.mock('../../utils/sqlIdentifier', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../../utils/sqlIdentifier')>();
+  return {
+    ...orig,
+    fetchViewDefinition: vi.fn().mockResolvedValue(''),
+  };
+});
+
+import { act, renderHook } from '@testing-library/react';
 import { useColumnActions } from '../../hooks/useColumnActions';
+import { fetchViewDefinition } from '../../utils/sqlIdentifier';
 
 function makeColumnNode(overrides: Partial<DatabaseObject> = {}): DatabaseObject {
   return {
@@ -93,12 +103,12 @@ describe('useColumnActions', () => {
       expect(where?.disabled).toBeFalsy();
     });
 
-    it('リネームが無効', () => {
+    it('リネームが有効 (ALTER VIEWで定義書き換え)', () => {
       const { result } = renderHook(() => useColumnActions(createParams()));
       const items = result.current.getColumnMenuItems(makeViewColumnNode());
       const rename = items.find((i) => i.label === 'カラム名を変更');
 
-      expect(rename?.disabled).toBe(true);
+      expect(rename?.disabled).toBeFalsy();
     });
 
     it('削除が無効', () => {
@@ -107,6 +117,28 @@ describe('useColumnActions', () => {
       const drop = items.find((i) => i.label === 'カラムを削除');
 
       expect(drop?.disabled).toBe(true);
+    });
+
+    it('fetchViewDefinition が throw した場合 onDdlError に委譲', async () => {
+      const networkError = new Error('Network failure');
+      vi.mocked(fetchViewDefinition).mockRejectedValueOnce(networkError);
+
+      const onDdlError = vi.fn();
+      const params = { ...createParams(), onDdlError };
+      const { result } = renderHook(() => useColumnActions(params));
+
+      // Set rename-input state for a view column
+      const items = result.current.getColumnMenuItems(makeViewColumnNode());
+      const rename = items.find((i) => i.label === 'カラム名を変更');
+      await act(() => rename?.action());
+
+      expect(result.current.columnAction?.type).toBe('rename-input');
+
+      // handleRenameInput should catch the error
+      await act(() => result.current.handleRenameInput('new_name'));
+
+      expect(onDdlError).toHaveBeenCalledWith(networkError);
+      expect(result.current.columnAction).toBeNull();
     });
   });
 });

--- a/frontend/src/tests/utils/sqlIdentifier.test.ts
+++ b/frontend/src/tests/utils/sqlIdentifier.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { buildAlterViewSql, buildGetViewDefinitionSql } from '../../utils/sqlIdentifier';
+
+describe('buildGetViewDefinitionSql', () => {
+  it('SQL Server: OBJECT_DEFINITION を使用', () => {
+    const sql = buildGetViewDefinitionSql('dbo', 'vw_Users', 'sqlserver');
+    expect(sql).toContain('OBJECT_DEFINITION');
+    expect(sql).toContain('dbo.vw_Users');
+  });
+
+  it('PostgreSQL: pg_get_viewdef を使用', () => {
+    const sql = buildGetViewDefinitionSql('public', 'vw_Users', 'postgresql');
+    expect(sql).toContain('pg_get_viewdef');
+    expect(sql).toContain('public.vw_Users');
+  });
+
+  it('MySQL: INFORMATION_SCHEMA を使用', () => {
+    const sql = buildGetViewDefinitionSql('mydb', 'vw_Users', 'mysql');
+    expect(sql).toContain('INFORMATION_SCHEMA.VIEWS');
+    expect(sql).toContain('mydb');
+    expect(sql).toContain('vw_Users');
+  });
+
+  it('SQLインジェクション対策: シングルクォートをエスケープ', () => {
+    const sql = buildGetViewDefinitionSql('dbo', "vw_O'Brien", 'sqlserver');
+    expect(sql).not.toContain("O'B");
+    expect(sql).toContain("O''B");
+  });
+});
+
+describe('buildAlterViewSql', () => {
+  it('SQL Server: CREATE VIEW → ALTER VIEW に変換しカラムにエイリアス追加', () => {
+    const viewDef = 'CREATE VIEW [dbo].[vw_Users] AS\nSELECT id, name, email FROM [dbo].[Users]';
+    const result = buildAlterViewSql(viewDef, 'name', 'user_name', 'sqlserver');
+    expect(result).toMatch(/^ALTER VIEW/);
+    expect(result).toContain('[user_name]');
+    expect(result).not.toMatch(/CREATE VIEW/);
+  });
+
+  it('PostgreSQL: CREATE OR REPLACE VIEW に変換', () => {
+    const viewDef = 'CREATE VIEW public.vw_users AS\nSELECT id, name FROM users';
+    const result = buildAlterViewSql(viewDef, 'name', 'user_name', 'postgresql');
+    expect(result).toMatch(/^CREATE OR REPLACE VIEW/);
+    expect(result).toContain('"user_name"');
+  });
+
+  it('MySQL: ALTER VIEW に変換しバッククォートでエイリアス', () => {
+    const viewDef = 'CREATE VIEW `vw_users` AS\nSELECT id, name FROM users';
+    const result = buildAlterViewSql(viewDef, 'name', 'user_name', 'mysql');
+    expect(result).toMatch(/^ALTER VIEW/);
+    expect(result).toContain('`user_name`');
+  });
+
+  it('既存エイリアスを置換', () => {
+    const viewDef =
+      'CREATE VIEW [dbo].[vw_Users] AS\nSELECT id, name AS [old_alias] FROM [dbo].[Users]';
+    const result = buildAlterViewSql(viewDef, 'name', 'user_name', 'sqlserver');
+    expect(result).toContain('[user_name]');
+    expect(result).not.toContain('[old_alias]');
+  });
+
+  it('テーブルプレフィックス付きカラムを処理', () => {
+    const viewDef = 'CREATE VIEW [dbo].[vw_Users] AS\nSELECT u.id, u.name FROM [dbo].[Users] u';
+    const result = buildAlterViewSql(viewDef, 'name', 'user_name', 'sqlserver');
+    expect(result).toContain('[user_name]');
+  });
+
+  it('カラムが見つからない場合はエイリアスなしで変換のみ', () => {
+    const viewDef = 'CREATE VIEW [dbo].[vw_Users] AS\nSELECT id FROM [dbo].[Users]';
+    const result = buildAlterViewSql(viewDef, 'nonexistent', 'new_name', 'sqlserver');
+    expect(result).toMatch(/^ALTER VIEW/);
+    expect(result).not.toContain('new_name');
+  });
+
+  it('CREATE OR REPLACE VIEW が既にある場合そのまま維持 (PostgreSQL)', () => {
+    const viewDef = 'CREATE OR REPLACE VIEW public.vw_users AS\nSELECT id, name FROM users';
+    const result = buildAlterViewSql(viewDef, 'name', 'user_name', 'postgresql');
+    expect(result).toMatch(/^CREATE OR REPLACE VIEW/);
+    // CREATE OR REPLACE CREATE OR REPLACE のように二重にならない
+    expect(result).not.toMatch(/CREATE OR REPLACE.*CREATE OR REPLACE/);
+  });
+
+  it('サブクエリ内の FROM に惑わされずカラムを正しくリネーム', () => {
+    const viewDef =
+      'CREATE VIEW [dbo].[vw_Test] AS\nSELECT (SELECT x FROM t1) AS sub, name FROM [dbo].[Main]';
+    const result = buildAlterViewSql(viewDef, 'name', 'new_name', 'sqlserver');
+    expect(result).toContain('[new_name]');
+    // sub カラムは変更されない
+    expect(result).toContain('(SELECT x FROM t1) AS sub');
+  });
+
+  it('複数サブクエリがある場合でも最後のFROMまでの範囲で処理', () => {
+    const viewDef =
+      'CREATE VIEW [dbo].[vw_Multi] AS\nSELECT (SELECT a FROM t1) AS c1, (SELECT b FROM t2) AS c2, name FROM [dbo].[Main]';
+    const result = buildAlterViewSql(viewDef, 'name', 'renamed', 'sqlserver');
+    expect(result).toContain('[renamed]');
+    expect(result).toContain('(SELECT a FROM t1) AS c1');
+    expect(result).toContain('(SELECT b FROM t2) AS c2');
+  });
+});

--- a/frontend/src/utils/sqlIdentifier.ts
+++ b/frontend/src/utils/sqlIdentifier.ts
@@ -75,3 +75,118 @@ export function buildDropColumnSql(
       return `ALTER TABLE ${q(schema)}.${q(table)} DROP COLUMN ${q(column)}`;
   }
 }
+
+// ---------------------------------------------------------------------------
+// View DDL
+// ---------------------------------------------------------------------------
+
+/** ビュー定義取得SQL生成 */
+export function buildGetViewDefinitionSql(
+  schema: string,
+  viewName: string,
+  dbType?: DatabaseType
+): string {
+  const s = escapeSqlLiteral(schema);
+  const v = escapeSqlLiteral(viewName);
+
+  switch (dbType) {
+    case 'postgresql':
+      return `SELECT pg_get_viewdef('${s}.${v}', true)`;
+    case 'mysql':
+      return `SELECT VIEW_DEFINITION FROM INFORMATION_SCHEMA.VIEWS WHERE TABLE_SCHEMA = '${s}' AND TABLE_NAME = '${v}'`;
+    default:
+      return `SELECT OBJECT_DEFINITION(OBJECT_ID(N'${s}.${v}'))`;
+  }
+}
+
+/** ビュー定義を取得 (空文字列 = 取得失敗) */
+export async function fetchViewDefinition(
+  connectionId: string,
+  schema: string,
+  viewName: string,
+  dbType?: DatabaseType
+): Promise<string> {
+  const { bridge } = await import('../api/bridge');
+  const defQuery = buildGetViewDefinitionSql(schema, viewName, dbType);
+  const result = await bridge.executeQuery(connectionId, defQuery);
+  return result.rows[0]?.[0] ?? '';
+}
+
+/** 正規表現メタ文字のエスケープ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * SELECT句とFROM句を括弧深度を追跡して分割する。
+ * サブクエリ内の FROM を無視し、トップレベルの FROM で分割。
+ * 戻り値: [selectPart, fromAndRest] または null (FROM未検出)
+ */
+function splitSelectFrom(body: string): [string, string] | null {
+  let depth = 0;
+  const upper = body.toUpperCase();
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === '(') {
+      depth++;
+    } else if (body[i] === ')') {
+      depth--;
+    } else if (depth === 0 && upper.startsWith('FROM', i)) {
+      // 単語境界チェック: FROM の前後が英数字でないこと
+      const before = i > 0 ? upper[i - 1] : ' ';
+      const after = i + 4 < upper.length ? upper[i + 4] : ' ';
+      if (/\w/.test(before) || /\w/.test(after)) continue;
+      return [body.slice(0, i), body.slice(i)];
+    }
+  }
+  return null;
+}
+
+/** ビュー定義を書き換えてカラム名を変更するALTER VIEW SQL生成 */
+export function buildAlterViewSql(
+  viewDefinition: string,
+  oldCol: string,
+  newCol: string,
+  dbType?: DatabaseType
+): string {
+  const q = (n: string) => quoteIdentifier(n, dbType);
+  let sql = viewDefinition;
+
+  // CREATE VIEW → ALTER VIEW (PostgreSQL は CREATE OR REPLACE VIEW)
+  if (dbType === 'postgresql') {
+    sql = sql.replace(/^CREATE\s+(OR\s+REPLACE\s+)?VIEW/i, 'CREATE OR REPLACE VIEW');
+  } else {
+    sql = sql.replace(/^CREATE\s+VIEW/i, 'ALTER VIEW');
+  }
+
+  // SELECT [TOP N|DISTINCT] ... FROM の間でカラムを探してエイリアスを付与/置換
+  const selectIdx = sql.search(/\bSELECT\s/i);
+  if (selectIdx === -1) return sql;
+
+  const afterSelect = sql.slice(selectIdx).replace(/^SELECT\s+/i, '');
+  const prefixMatch = afterSelect.match(/^(TOP\s+\d+\s+|DISTINCT\s+)/i);
+  const selectPrefix = prefixMatch?.[0] ?? '';
+  const bodyAfterPrefix = afterSelect.slice(selectPrefix.length);
+
+  const split = splitSelectFrom(bodyAfterPrefix);
+  if (!split) return sql;
+
+  const [selectPart, fromAndRest] = split;
+  const selectFromStart = sql.slice(0, selectIdx);
+  const escapedCol = escapeRegex(oldCol);
+
+  // 名前付きパーツで正規表現を構築
+  const tablePrefix = '(?:\\w+\\.)?';
+  const quotedCol = `\\[?${escapedCol}\\]?`;
+  const colBoundary = '(?=\\s*[,\\s]|\\s+AS\\b)';
+  const aliasValue = '\\[[^\\]]*\\]|"[^"]*"|`[^`]*`|\\w+';
+  const existingAlias = `(\\s+AS\\s+(?:${aliasValue}))`;
+
+  const colPattern = new RegExp(`(${tablePrefix}${quotedCol})${colBoundary}${existingAlias}?`, 'i');
+
+  if (colPattern.test(selectPart)) {
+    const newSelectPart = selectPart.replace(colPattern, `$1 AS ${q(newCol)}`);
+    sql = `${selectFromStart}SELECT ${selectPrefix}${newSelectPart}${fromAndRest}`;
+  }
+
+  return sql;
+}


### PR DESCRIPTION
- handleRenameInput に try-catch 追加し fetchViewDefinition の例外を onDdlError に委譲
- buildAlterViewSql の non-greedy regex を括弧深度追跡の splitSelectFrom に置換
- 分割代入済み変数の冗長な再参照を修正