### PR TITLE
feat(ui): ダイアログにEscapeキー閉じ機能を追加

### DIFF
--- a/frontend/src/components/dialogs/ConnectionDialog.tsx
+++ b/frontend/src/components/dialogs/ConnectionDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { bridge } from '../../api/bridge';
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import type { DatabaseType, EnvironmentType, SshAuthType } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
 import styles from './ConnectionDialog.module.css';
@@ -62,6 +63,7 @@ export function ConnectionDialog({ isOpen, onClose, onConnect }: ConnectionDialo
     deleteConfirmOpen,
     handleCopyProfile,
   } = useConnectionProfile(isOpen);
+  useDialogKeyboard({ isOpen, onEscape: deleteConfirmOpen ? undefined : onClose });
 
   const [testing, setTesting] = useState(false);
 

--- a/frontend/src/components/dialogs/DmlPreviewDialog.tsx
+++ b/frontend/src/components/dialogs/DmlPreviewDialog.tsx
@@ -1,3 +1,4 @@
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import styles from './DmlPreviewDialog.module.css';
 
 interface DmlPreviewDialogProps {
@@ -15,6 +16,8 @@ export function DmlPreviewDialog({
   onExecute,
   onCancel,
 }: DmlPreviewDialogProps) {
+  useDialogKeyboard({ isOpen, onEscape: isExecuting ? undefined : onCancel });
+
   if (!isOpen) return null;
 
   return (

--- a/frontend/src/components/dialogs/ExecutionPlanDialog.tsx
+++ b/frontend/src/components/dialogs/ExecutionPlanDialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { bridge } from '../../api/bridge';
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import { useConnectionStore } from '../../store/connectionStore';
 import styles from './ExecutionPlanDialog.module.css';
 
@@ -10,6 +11,7 @@ interface ExecutionPlanDialogProps {
 }
 
 export function ExecutionPlanDialog({ isOpen, onClose, sql }: ExecutionPlanDialogProps) {
+  useDialogKeyboard({ isOpen, onEscape: onClose });
   const { activeConnectionId } = useConnectionStore();
   const [planText, setPlanText] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/components/dialogs/QueryConfirmDialog.tsx
+++ b/frontend/src/components/dialogs/QueryConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import styles from './QueryConfirmDialog.module.css';
 
 interface QueryConfirmDialogProps {
@@ -23,6 +24,8 @@ export function QueryConfirmDialog({
   onConfirm,
   onCancel,
 }: QueryConfirmDialogProps) {
+  useDialogKeyboard({ isOpen, onEscape: onCancel });
+
   if (!isOpen) return null;
 
   return (

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../api/bridge';
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import styles from './SettingsDialog.module.css';
 import { type AppSettings, defaultSettings } from './settingsUtils';
 
@@ -9,6 +10,7 @@ interface SettingsDialogProps {
 }
 
 export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
+  useDialogKeyboard({ isOpen, onEscape: onClose });
   const [settings, setSettings] = useState<AppSettings>(defaultSettings);
   const [activeTab, setActiveTab] = useState<'editor' | 'query' | 'appearance' | 'shortcuts'>(
     'editor'

--- a/frontend/src/components/export/ExportDialog.tsx
+++ b/frontend/src/components/export/ExportDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import { useConnectionStore } from '../../store/connectionStore';
 import type { ResultSet } from '../../types';
 import styles from './ExportDialog.module.css';
@@ -16,6 +17,7 @@ interface ExportDialogProps {
 }
 
 export function ExportDialog({ isOpen, onClose, resultSet }: ExportDialogProps) {
+  useDialogKeyboard({ isOpen, onEscape: onClose });
   // W8: .find() returns existing array reference — stable with Zustand's Object.is equality
   const activeConnection = useConnectionStore((s) => {
     const id = s.activeConnectionId;

--- a/frontend/src/tests/dialogs/DmlPreviewDialog.test.tsx
+++ b/frontend/src/tests/dialogs/DmlPreviewDialog.test.tsx
@@ -67,4 +67,18 @@ describe('DmlPreviewDialog', () => {
     fireEvent.click(container.firstChild as Element);
     expect(onCancel).not.toHaveBeenCalled();
   });
+
+  it('Escapeキーでキャンセル発火', () => {
+    const onCancel = vi.fn();
+    render(<DmlPreviewDialog {...defaultProps} onCancel={onCancel} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('isExecuting時にEscapeキーでキャンセルが発火しない', () => {
+    const onCancel = vi.fn();
+    render(<DmlPreviewDialog {...defaultProps} isExecuting={true} onCancel={onCancel} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- 全ダイアログ(6種)にuseDialogKeyboardフックでEscapeキー閉じ機能を追加
- DmlPreviewDialogのユニットテスト追加

Closes #273

## Test plan
- [x] DmlPreviewDialog: Escapeキーでキャンセル発火 (ユニットテスト)
- [x] DmlPreviewDialog: isExecuting時にEscape無効 (ユニットテスト)
- [ ] ConnectionDialog: Escapeで閉じる (deleteConfirmOpen時は無効)
- [ ] SettingsDialog: Escapeで閉じる
- [ ] ExecutionPlanDialog: Escapeで閉じる
- [ ] QueryConfirmDialog: Escapeでキャンセル発火
- [ ] ExportDialog: Escapeで閉じる