### PR TITLE
docs:
ドキュメントからバージョン番号を削除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,13 @@ Velocity-DB固有の指示。グローバルルール (`~/.claude/CLAUDE.md`) �
 
 ## プロジェクト概要
 
-Windows専用RDBMS管理ツール。SQL Server / PostgreSQL / MySQL対応（ODBC経由）。
+Windows専用RDBMS管理ツール（DataGripライクなUI/UX）。SQL Server / PostgreSQL / MySQL対応（ODBC経由）。
 
-- Backend: C++23 + ODBC + WebView2
-- Frontend: React 19 + TypeScript 5.9 + Vite 7 + TanStack Table + Zustand 5
+- Backend: C++ + ODBC + WebView2
+- Frontend: React + TypeScript + Vite + TanStack Table + Zustand
+- Build Scripts: Python + uv
+- Lint: Biome (Frontend), clang-format (C++), Ruff (Python)
+- Test: Vitest (Frontend unit), Playwright (Frontend E2E), Google Test (C++)
 
 ## ビルドコマンド
 
@@ -20,8 +23,9 @@ uv run scripts/pdg.py build backend              # C++ (Release)
 uv run scripts/pdg.py build backend --type Debug  # C++ (Debug)
 uv run scripts/pdg.py build frontend              # フロントエンド
 uv run scripts/pdg.py build all                   # 全体ビルド
-uv run scripts/pdg.py test backend                # C++テスト
-uv run scripts/pdg.py test frontend               # フロントエンドテスト
+uv run scripts/pdg.py test backend                # C++テスト (Google Test)
+uv run scripts/pdg.py test frontend               # フロントエンドテスト (Vitest)
+uv run scripts/pdg.py test e2e                    # E2Eテスト (Playwright)
 uv run scripts/pdg.py lint                        # Frontend + C++
 uv run scripts/pdg.py lint --fix                  # 自動修正
 uv run scripts/pdg.py dev                         # 開発サーバー (localhost:5173)
@@ -34,7 +38,7 @@ ruff check scripts/ && ruff format scripts/       # Python lint (別途)
 hookが node/npm 直接実行をブロックするため、Docker経由で実行:
 
 ```bash
-# 全テスト
+# 全テスト (Vitest)
 docker run --rm -v "C:/prog/Velocity-DB://app" \
   --mount "type=volume,target=//app/frontend/node_modules" \
   -w "//app/frontend" node:latest \
@@ -51,6 +55,12 @@ docker run --rm -v "C:/prog/Velocity-DB://app" \
   --mount "type=volume,target=//app/frontend/node_modules" \
   -w "//app/frontend" node:latest \
   sh -c 'npm install && npx biome check src/path/to/file.ts'
+
+# E2Eテスト (Playwright)
+docker run --rm -v "C:/prog/Velocity-DB://app" \
+  --mount "type=volume,target=//app/frontend/node_modules" \
+  -w "//app/frontend" node:latest \
+  sh -c 'npm install && npx playwright install --with-deps chromium && npx playwright test'
 ```
 
 `--mount type=volume` で node_modules を隔離（Windows/Linux バイナリ非互換対策）。
@@ -71,35 +81,44 @@ Frontend → window.invoke(JSON) → Backend ipc_handler.cpp → providers/ → 
 Frontend ← api/bridge.ts (Promiseラップ) ←────────────────────────────────────────────────┘
 ```
 
-### Backend 構造 (C++23)
+### Backend 構造 (C++)
 
 ```
 backend/
-├── ipc_handler.cpp          # IPCルーティング (m_routes にルート登録)
-├── interfaces/              # ISP準拠インターフェース (*able.h)
+├── ipc_handler.cpp           # IPCルーティング (m_routes にルート登録)
+├── interfaces/               # ISP準拠インターフェース (*able.h)
 ├── contexts/system_context   # DIコンテナ (全Providerを保持)
-├── providers/               # IPCハンドラ実装 (*_provider.cpp)
-└── database/                # DB操作
-    ├── driver_interface.h   # 抽象ドライバ
-    ├── sqlserver_driver.cpp + sqlserver_dialect.cpp
-    ├── postgresql_driver.cpp + postgresql_dialect.cpp
-    ├── driver_factory.cpp   # DriverType → 具象クラス生成
+├── providers/                # IPCハンドラ実装
+│   ├── connection_provider   # 接続管理
+│   ├── query_provider        # クエリ実行 (最大モジュール)
+│   ├── schema_provider       # スキーマ情報
+│   ├── settings_provider     # 設定管理
+│   ├── export_provider       # データエクスポート
+│   └── ...                   # transaction, search, io, utility
+└── database/                 # DB操作
+    ├── driver_interface.h    # 抽象ドライバ
+    ├── sqlserver_driver/dialect
+    ├── postgresql_driver/dialect
+    ├── driver_factory.cpp    # DriverType → 具象クラス生成
     ├── connection_registry   # 接続プール管理
     ├── async_query_executor  # 非同期クエリ実行
     ├── result_cache          # LRUキャッシュ (100MB)
     └── schema_inspector      # スキーマ情報取得
 ```
 
-### Frontend 構造 (React 19)
+### Frontend 構造 (React)
 
 ```
-frontend/src/
-├── api/bridge.ts            # IPC通信 (Backend全メソッドのPromiseラッパー)
-├── store/                   # Zustand stores (connectionStore, queryStore, editStore, ...)
-├── components/              # UI (grid/, tree/, editor/, diagram/, dialogs/, ...)
-├── hooks/                   # カスタムhooks (useColumnActions, useCopyToClipboard, ...)
-├── types/                   # 型定義
-└── utils/                   # ユーティリティ (sqlIdentifier, erDiagramParser, ...)
+frontend/
+├── src/
+│   ├── api/bridge.ts         # IPC通信 (Backend全メソッドのPromiseラッパー)
+│   ├── store/                # Zustand stores (connection, query, edit, schema, session, ...)
+│   ├── components/           # UI (grid/, tree/, editor/, diagram/, dialogs/, export/, ...)
+│   ├── hooks/                # カスタムhooks (useDialogKeyboard, useKeyboardHandler, ...)
+│   ├── types/                # 型定義
+│   └── utils/                # ユーティリティ
+├── e2e/                      # Playwright E2Eテスト
+└── src/tests/                # Vitest ユニットテスト
 ```
 
 ### 新しいIPCメソッド追加手順
@@ -117,31 +136,29 @@ frontend/src/
 
 ### C++ (backend/)
 
-- C++23: `std::expected`, `std::format`, `std::ranges`
+- モダンC++: `std::expected`, `std::format`, `std::ranges`
 - RAII + スマートポインタ、変数は基本 `auto`
 - ODBC戻り値は必ず `SQL_SUCCESS` チェック
-- clang-format 21
+- clang-format
 
 ### TypeScript/React (frontend/)
 
 - 非nullアサーション (`!`) 禁止 → 明示的nullチェック
 - CSS Modules、Zustand、memo化 (GridToolbar, GridStatusBar, ResultGrid)
 - biome: lineWidth 100, シングルクォート, セミコロンあり
+- イベントハンドラ名に `handle` 接頭辞禁止（`deleteRow` ✅ / `handleDeleteRow` ❌）
 
 ### Python (scripts/)
 
-- Ruff lint + format、Python 3.14+、型ヒント必須
-
-## 設計参照
-
-- [pre-omusubi architecture](https://github.com/TakumiOkayasu/pre-omusubi/blob/main/docs/architecture.md): ISP, Context Pattern, キャッシュ活用, レイヤー分離
+- Ruff lint + format、型ヒント必須
 
 ## ドキュメント参照
 
 | ファイル | 内容 |
 |----------|------|
-| `docs/ARCHITECTURE.md` | アーキテクチャ、コンポーネント対応表 |
+| `docs/ARCHITECTURE.md` | レイヤー構造、コンポーネント対応表 |
 | `docs/TROUBLESHOOTING.md` | トラブルシューティング |
+| `docs/VISUAL_STUDIO_SETUP.md` | VS2022 でのデバッグ手順 |
 
 ## Claude Code責任範囲
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ INNER JOIN LogisticsDB.dbo.products p ON e.id = p.employee_id;
 - Bun（`powershell -c "irm bun.sh/install.ps1 | iex"`）
 - CMake 3.20以上
 - Ninja（`winget install Ninja-build.Ninja`）
-- Python 3.14+（ビルドスクリプト用）
+- Python（ビルドスクリプト用）
 - uv（`winget install astral-sh.uv`）
 
 #### ビルド手順
@@ -238,6 +238,7 @@ uv run scripts/pdg.py b backend                  # 'build' の代わりに 'b'
 uv run scripts/pdg.py test backend               # バックエンドテスト
 uv run scripts/pdg.py test frontend              # フロントエンドテスト
 uv run scripts/pdg.py test frontend --watch      # Watchモード
+uv run scripts/pdg.py test e2e                   # E2Eテスト (Playwright)
 
 # 短縮形
 uv run scripts/pdg.py t frontend                 # 'test' の代わりに 't'
@@ -289,20 +290,19 @@ bun run typecheck    # 型チェック
 
 # その他
 bun run format       # フォーマット
-bun pm cache rm      # キャッシュ削除
 ```
 
 ### 技術スタック
 
-#### ビルドスクリプト（Python 3.14+）
+#### ビルドスクリプト（Python）
 
 | カテゴリ | ツール/技術 |
 |---------|------------|
-| ランタイム | uv |
+| パッケージマネージャ | uv |
 | Lint/Format | Ruff |
 | 設定 | pyproject.toml |
 
-#### バックエンド（C++23）
+#### バックエンド（C++）
 
 | カテゴリ | ライブラリ/技術 |
 |---------|----------------|
@@ -312,22 +312,23 @@ bun pm cache rm      # キャッシュ削除
 | JSON | simdjson |
 | XML | pugixml |
 | 最適化 | SIMD (AVX2)、メモリマップドファイル |
-| Lint/Format | clang-format 21, clang-tidy |
+| Lint/Format | clang-format, clang-tidy |
 
-#### フロントエンド（React + TypeScript）
+#### フロントエンド（React）
 
 | カテゴリ | ライブラリ |
 |---------|-----------|
-| ランタイム | Bun |
+| パッケージマネージャ | Bun |
 | ビルド | Vite |
-| UI | React 19 |
+| UI | React |
 | エディタ | Monaco Editor |
 | テーブル | TanStack Table（仮想スクロール） |
 | スタイル | CSS Modules |
 | 状態管理 | Zustand |
 | ER図 | React Flow |
-| Linter/Formatter | Biome 2.3.8 |
-| テスト | Vitest |
+| Linter/Formatter | Biome |
+| テスト (Unit) | Vitest |
+| テスト (E2E) | Playwright |
 
 ### パフォーマンス目標と実装
 

--- a/docs/PROJECT_INFO.md
+++ b/docs/PROJECT_INFO.md
@@ -9,11 +9,11 @@ Windows専用の高性能RDBMS管理ツール（DataGripライクなUI/UX）。S
 | 領域 | 技術 |
 | ------ | ------ |
 | Backend | C++23 + ODBC + WebView2 |
-| Frontend | React 18 + TypeScript + TanStack Table |
+| Frontend | React + TypeScript + TanStack Table |
 | Build (C++) | CMake + Ninja (MSVC) |
-| Build (Frontend) | Vite + Bun |
-| Lint | Biome (Frontend), clang-format/clang-tidy (C++), Ruff (Python) |
-| Test | Vitest (Frontend), Google Test (C++) |
+| Build (Frontend) | Vite |
+| Lint | Biome (Frontend), clang-format (C++), Ruff (Python) |
+| Test | Vitest (Frontend unit), Playwright (Frontend E2E), Google Test (C++) |
 
 ## プロジェクト構造
 


### PR DESCRIPTION
## Summary
- CLAUDE.md, README.md, docs/PROJECT_INFO.md からバージョン番号を除去
- バージョン陳腐化の防止

## Test plan
- [x] CLAUDE.md: C++23→C++, React 19→React, Python 3.14+→型ヒント必須, clang-format 21→clang-format
- [x] README.md: Python 3.14+→Python, C++23→C++, React 19→React, Biome 2.3.8→Biome
- [x] docs/PROJECT_INFO.md: React 18→React, Bun表記修正
- [x] 既存の動作に影響なし (ドキュメントのみの変更)