### PR TITLE
chore(build): Norton誤検知対策でCコンパイラ検出をスキップ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ if(NOT EXISTS "${CMAKE_SOURCE_DIR}/vcpkg.json")
     set(VCPKG_MANIFEST_MODE OFF CACHE BOOL "" FORCE)
 endif()
 
+# Norton false positive workaround: skip C compiler ID exe generation
+# FetchContent dependencies (e.g. Google Test) enable C language, causing
+# CMake to generate CMakeCCompilerId.exe. Norton's heuristic detection
+# quarantines this as Win64:MalwareX-gen. FORCED skips the probe.
+# CXX detection is kept intact — Google Test requires compile feature info.
+set(CMAKE_C_COMPILER_FORCED TRUE)
+
 project(VelocityDB VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)

--- a/scripts/_lib/build.py
+++ b/scripts/_lib/build.py
@@ -115,10 +115,6 @@ def build_backend(build_type: str = "Release", clean: bool = False) -> bool:
         print("\nERROR: CMake configuration failed")
         if stderr:
             print(f"\n{stderr}")
-        if "execution of make failed" in stderr.lower() or "compiler identification" in stderr.lower():
-            print("\n[HINT] アンチウイルスソフト (Norton等) が CMake のコンパイラ検出用")
-            print("       実行ファイルを誤検知・検疫している可能性があります。")
-            print(f"       除外設定に追加: {build_dir.absolute()}")
         return False
 
     # Build


### PR DESCRIPTION
ノートンがカス