### PR TITLE
feat: ER図内検索・Viewport保持・デフォルトロック (#285)

### DIFF
--- a/frontend/src/components/diagram/ERDiagram.module.css
+++ b/frontend/src/components/diagram/ERDiagram.module.css
@@ -100,9 +100,93 @@
   background-color: var(--button-primary-hover);
 }
 
+/* Search */
+.searchWrapper {
+  position: relative;
+  margin-left: auto;
+}
+
+.searchInput {
+  width: 180px;
+  padding: 3px 8px;
+  font-size: 12px;
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  outline: none;
+}
+
+.searchInput:focus {
+  border-color: var(--accent-color, #4a9eff);
+}
+
+.searchInput::placeholder {
+  color: var(--text-tertiary);
+}
+
+.searchDropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 2px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 100;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.searchNoResults {
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.searchItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-primary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+}
+
+.searchItem:hover,
+.searchItemActive {
+  background-color: var(--bg-hover);
+}
+
+.searchItemName {
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.searchItemLogical {
+  color: var(--text-secondary);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.searchItemPage {
+  margin-left: auto;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
 /* Tab bar import button */
 .tabImportButton {
-  margin-left: auto;
   padding: 4px 8px;
   font-size: 14px;
   background: none;

--- a/frontend/src/components/diagram/ERDiagram.tsx
+++ b/frontend/src/components/diagram/ERDiagram.tsx
@@ -6,14 +6,18 @@ import {
   MarkerType,
   type Node,
   ReactFlow,
+  ReactFlowProvider,
   useNodesState,
+  useReactFlow,
 } from '@xyflow/react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import '@xyflow/react/dist/style.css';
 import { useERDiagramContext } from '../../hooks/useERDiagramContext';
+import { useERDiagramStore } from '../../store/erDiagramStore';
 import type { ERRelationEdge, ERShapeNode, ERTableNode } from '../../types';
-import { ALL_PAGES, GRID_LAYOUT } from '../../utils/erDiagramConstants';
+import { ALL_PAGES, DEFAULT_PAGE, GRID_LAYOUT } from '../../utils/erDiagramConstants';
 import styles from './ERDiagram.module.css';
+import { ERDiagramSearch } from './ERDiagramSearch';
 import { ShapeNode } from './ShapeNode';
 import { TableNode } from './TableNode';
 
@@ -91,48 +95,91 @@ function applyGridLayout(tables: ERTableNode[]): ERTableNode[] {
   }));
 }
 
+function toNodes(tables: ERTableNode[], shapes: ERShapeNode[]): Node[] {
+  const shapeNodes: Node[] = shapes.map((shape) => ({
+    id: shape.id,
+    type: 'shape',
+    position: shape.position,
+    data: shape.data,
+    zIndex: -1,
+    selectable: false,
+    draggable: false,
+  }));
+
+  const tableNodes: Node[] = tables.map((table) => ({
+    id: table.id,
+    type: 'table',
+    position: table.position,
+    data: table.data,
+  }));
+
+  return [...shapeNodes, ...tableNodes];
+}
+
 function ERDiagramFlow({
   tables,
   relations,
   shapes,
+  selectedPage,
   onTableClick,
 }: {
   tables: ERTableNode[];
   relations: ERRelationEdge[];
   shapes: ERShapeNode[];
+  selectedPage: string;
   onTableClick?: (tableId: string) => void;
 }) {
-  const initialNodes: Node[] = useMemo(() => {
-    const shapeNodes: Node[] = shapes.map((shape) => ({
-      id: shape.id,
-      type: 'shape',
-      position: shape.position,
-      data: shape.data,
-      zIndex: -1,
-      selectable: false,
-      draggable: false,
-    }));
+  const { setViewport, getViewport, fitView } = useReactFlow();
+  const saveViewport = useERDiagramStore((s) => s.saveViewport);
+  const viewportsRef = useRef(useERDiagramStore.getState().viewports);
+  useEffect(() => {
+    return useERDiagramStore.subscribe((s) => {
+      viewportsRef.current = s.viewports;
+    });
+  }, []);
 
-    const tableNodes: Node[] = tables.map((table) => ({
-      id: table.id,
-      type: 'table',
-      position: table.position,
-      data: table.data,
-    }));
+  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+  const prevPageRef = useRef(selectedPage);
+  const isInitialMount = useRef(true);
 
-    return [...shapeNodes, ...tableNodes];
-  }, [tables, shapes]);
+  // ページ切替時: ノード更新 + viewport復元
+  useEffect(() => {
+    const prevPage = prevPageRef.current;
+    prevPageRef.current = selectedPage;
 
-  const [nodes, , onNodesChange] = useNodesState(initialNodes);
+    setNodes(toNodes(tables, shapes));
+    setEdgePosMap(new Map(tables.map((t) => [t.id, t.position])));
 
-  // エッジ用ポジション: ドラッグ終了時のみ更新（毎フレーム再計算を回避）
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      requestAnimationFrame(() => fitView({ duration: 200 }));
+      return;
+    }
+
+    // 切替前のviewportを保存
+    if (prevPage !== selectedPage) {
+      const currentVp = getViewport();
+      saveViewport(prevPage, currentVp);
+    }
+
+    // 切替先のviewportを復元（なければfitView）
+    const saved = viewportsRef.current[selectedPage];
+    requestAnimationFrame(() => {
+      if (saved && prevPage !== selectedPage) {
+        setViewport(saved, { duration: 200 });
+      } else if (prevPage !== selectedPage) {
+        fitView({ duration: 200 });
+      }
+    });
+  }, [tables, shapes, selectedPage, setNodes, fitView, getViewport, saveViewport, setViewport]);
+
   const [edgePosMap, setEdgePosMap] = useState<PosMap>(
     () => new Map(tables.map((t) => [t.id, t.position]))
   );
 
   const edges: Edge[] = useMemo(() => buildEdges(relations, edgePosMap), [relations, edgePosMap]);
 
-  const handleNodeDragStop = useCallback(
+  const nodeDragStop = useCallback(
     (_event: React.MouseEvent, _node: Node, draggedNodes: Node[]) => {
       setEdgePosMap((prev) => {
         const next = new Map(prev);
@@ -145,7 +192,7 @@ function ERDiagramFlow({
     []
   );
 
-  const handleNodeClick = useCallback(
+  const nodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {
       onTableClick?.(node.id);
     },
@@ -157,10 +204,10 @@ function ERDiagramFlow({
       nodes={nodes}
       edges={edges}
       onNodesChange={onNodesChange}
-      onNodeDragStop={handleNodeDragStop}
-      onNodeClick={handleNodeClick}
+      onNodeDragStop={nodeDragStop}
+      onNodeClick={nodeClick}
       nodeTypes={nodeTypes}
-      fitView
+      nodesDraggable={false}
       minZoom={0.1}
       maxZoom={2}
       defaultViewport={{ x: 0, y: 0, zoom: 0.8 }}
@@ -169,6 +216,52 @@ function ERDiagramFlow({
       <Controls />
     </ReactFlow>
   );
+}
+
+const NODE_CENTER_X = GRID_LAYOUT.nodeWidth / 2;
+const NODE_CENTER_Y = GRID_LAYOUT.nodeHeight / 2;
+const FOCUS_DURATION_MS = 3000;
+
+/** 検索結果選択時にsetCenter + ページ切替を行うブリッジコンポーネント */
+function ERDiagramSearchBridge({
+  allTables,
+  selectedPage,
+  setSelectedPage,
+}: {
+  allTables: ERTableNode[];
+  selectedPage: string;
+  setSelectedPage: (page: string) => void;
+}) {
+  const { setCenter } = useReactFlow();
+  const setFocusedNodeId = useERDiagramStore((s) => s.setFocusedNodeId);
+  const focusTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const selectTable = useCallback(
+    (table: ERTableNode) => {
+      const needPageSwitch =
+        selectedPage !== (table.data.page || DEFAULT_PAGE) && selectedPage !== ALL_PAGES;
+      if (needPageSwitch) {
+        setSelectedPage(table.data.page || DEFAULT_PAGE);
+      }
+      const centerOnNode = () => {
+        setCenter(table.position.x + NODE_CENTER_X, table.position.y + NODE_CENTER_Y, {
+          zoom: 1,
+          duration: 300,
+        });
+      };
+      if (needPageSwitch) {
+        requestAnimationFrame(centerOnNode);
+      } else {
+        centerOnNode();
+      }
+      clearTimeout(focusTimerRef.current);
+      setFocusedNodeId(table.id);
+      focusTimerRef.current = setTimeout(() => setFocusedNodeId(null), FOCUS_DURATION_MS);
+    },
+    [selectedPage, setSelectedPage, setCenter, setFocusedNodeId]
+  );
+
+  return <ERDiagramSearch tables={allTables} onSelect={selectTable} />;
 }
 
 export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) {
@@ -183,6 +276,7 @@ export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) 
     shapes: filteredShapes,
   } = useERDiagramContext();
 
+  const allTables = useERDiagramStore((s) => s.tables);
   const hasData = totalTableCount > 0;
 
   // 「すべて」タブ時はグリッド再配置（ページ間で座標が重複するため）
@@ -198,13 +292,6 @@ export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) 
   );
 
   const showTabs = pages.length > 1;
-
-  // key を変えることで ReactFlow を再マウントし、fitView をリトリガー
-  const flowKey = useMemo(() => {
-    const first = layoutTables[0]?.id ?? '';
-    const last = layoutTables[layoutTables.length - 1]?.id ?? '';
-    return `${selectedPage}-${layoutTables.length}-${layoutShapes.length}-${first}-${last}`;
-  }, [selectedPage, layoutTables, layoutShapes]);
 
   if (!hasData) {
     return (
@@ -223,7 +310,7 @@ export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) 
 
   return (
     <div className={styles.container}>
-      {(showTabs || onOpenImportDialog) && (
+      <ReactFlowProvider>
         <div className={styles.tabBar}>
           {showTabs && (
             <>
@@ -246,6 +333,11 @@ export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) 
               ))}
             </>
           )}
+          <ERDiagramSearchBridge
+            allTables={allTables}
+            selectedPage={selectedPage}
+            setSelectedPage={setSelectedPage}
+          />
           {onOpenImportDialog && (
             <button
               type="button"
@@ -257,16 +349,16 @@ export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) 
             </button>
           )}
         </div>
-      )}
-      <div className={styles.flowContainer}>
-        <ERDiagramFlow
-          key={flowKey}
-          tables={layoutTables}
-          relations={filteredRelations}
-          shapes={layoutShapes}
-          onTableClick={onTableClick}
-        />
-      </div>
+        <div className={styles.flowContainer}>
+          <ERDiagramFlow
+            tables={layoutTables}
+            relations={filteredRelations}
+            shapes={layoutShapes}
+            selectedPage={selectedPage}
+            onTableClick={onTableClick}
+          />
+        </div>
+      </ReactFlowProvider>
     </div>
   );
 }

--- a/frontend/src/components/diagram/ERDiagramSearch.tsx
+++ b/frontend/src/components/diagram/ERDiagramSearch.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react';
+import type { ERTableNode } from '../../types';
+import { filterTablesByQuery } from '../../utils/erDiagramUtils';
+import styles from './ERDiagram.module.css';
+
+const MAX_RESULTS = 10;
+
+interface ERDiagramSearchProps {
+  tables: ERTableNode[];
+  onSelect: (table: ERTableNode) => void;
+}
+
+export function ERDiagramSearch({ tables, onSelect }: ERDiagramSearchProps) {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [isOpen, setIsOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const deferredQuery = useDeferredValue(query);
+
+  const results = useMemo(() => {
+    if (!deferredQuery.trim()) return [];
+    return filterTablesByQuery(tables, deferredQuery).slice(0, MAX_RESULTS);
+  }, [tables, deferredQuery]);
+
+  const showDropdown = isOpen && query.trim().length > 0;
+
+  const selectResult = useCallback(
+    (table: ERTableNode) => {
+      onSelect(table);
+      setQuery('');
+      setIsOpen(false);
+      inputRef.current?.blur();
+    },
+    [onSelect]
+  );
+
+  const keyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === 'Enter' && results.length > 0) {
+        e.preventDefault();
+        selectResult(results[selectedIndex]);
+      } else if (e.key === 'Escape') {
+        setQuery('');
+        setIsOpen(false);
+        inputRef.current?.blur();
+      }
+    },
+    [results, selectedIndex, selectResult]
+  );
+
+  const queryChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+    setSelectedIndex(0);
+    setIsOpen(true);
+  }, []);
+
+  const focusInput = useCallback(() => setIsOpen(true), []);
+
+  const blurInput = useCallback(() => {
+    // ドロップダウンのクリックを拾うため少し遅延
+    setTimeout(() => setIsOpen(false), 150);
+  }, []);
+
+  return (
+    <div className={styles.searchWrapper}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={queryChange}
+        onKeyDown={keyDown}
+        onFocus={focusInput}
+        onBlur={blurInput}
+        placeholder="テーブル検索..."
+        className={styles.searchInput}
+      />
+      {showDropdown && (
+        <div className={styles.searchDropdown}>
+          {results.length === 0 ? (
+            <div className={styles.searchNoResults}>結果なし</div>
+          ) : (
+            results.map((table, index) => (
+              <button
+                type="button"
+                key={table.id}
+                className={`${styles.searchItem} ${index === selectedIndex ? styles.searchItemActive : ''}`}
+                onMouseDown={() => selectResult(table)}
+                onMouseEnter={() => setSelectedIndex(index)}
+              >
+                <span className={styles.searchItemName}>{table.data.tableName}</span>
+                {table.data.logicalName && (
+                  <span className={styles.searchItemLogical}>{table.data.logicalName}</span>
+                )}
+                {table.data.page && (
+                  <span className={styles.searchItemPage}>{table.data.page}</span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/diagram/TableNode.module.css
+++ b/frontend/src/components/diagram/TableNode.module.css
@@ -13,6 +13,22 @@
   box-shadow: 0 0 0 2px var(--accent-color);
 }
 
+.container.focused {
+  border-color: #4a9eff;
+  box-shadow: 0 0 0 2px #4a9eff;
+  animation: focusPulse 1s ease-in-out 3;
+}
+
+@keyframes focusPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 2px #4a9eff;
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(74, 158, 255, 0.4);
+  }
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/frontend/src/components/diagram/TableNode.tsx
+++ b/frontend/src/components/diagram/TableNode.tsx
@@ -1,5 +1,6 @@
 import { Handle, type HandleType, Position } from '@xyflow/react';
 import { memo } from 'react';
+import { useERDiagramStore } from '../../store/erDiagramStore';
 import type { ERColumn } from '../../types';
 import { readableColor } from '../../utils/colorContrast';
 import styles from './TableNode.module.css';
@@ -13,6 +14,7 @@ interface TableNodeData {
 }
 
 interface TableNodeProps {
+  id: string;
   data: TableNodeData;
   selected?: boolean;
 }
@@ -68,7 +70,8 @@ function ColumnRow({ col, isPK }: { col: ERColumn; isPK: boolean }) {
   );
 }
 
-export const TableNode = memo(function TableNode({ data, selected }: TableNodeProps) {
+export const TableNode = memo(function TableNode({ id, data, selected }: TableNodeProps) {
+  const isFocused = useERDiagramStore((s) => s.focusedNodeId === id);
   const { tableName, logicalName, columns, color, bkColor } = data;
 
   const useLogicalTable = !isPlaceholder(logicalName);
@@ -79,7 +82,9 @@ export const TableNode = memo(function TableNode({ data, selected }: TableNodePr
   const regularColumns = columns.filter((c) => !c.isPrimaryKey);
 
   return (
-    <div className={`${styles.container} ${selected ? styles.selected : ''}`}>
+    <div
+      className={`${styles.container}${selected ? ` ${styles.selected}` : ''}${isFocused ? ` ${styles.focused}` : ''}`}
+    >
       {HANDLE_DEFS.map((h) => (
         <Handle key={h.id} type={h.type} position={h.position} id={h.id} style={HIDDEN_HANDLE} />
       ))}

--- a/frontend/src/store/erDiagramStore.ts
+++ b/frontend/src/store/erDiagramStore.ts
@@ -5,6 +5,12 @@ import { DEFAULT_PAGE, GRID_LAYOUT } from '../utils/erDiagramConstants';
 import type { ERDiagramModel } from '../utils/erDiagramParser';
 import { extractPages } from '../utils/erDiagramUtils';
 
+export interface Viewport {
+  x: number;
+  y: number;
+  zoom: number;
+}
+
 interface ERDiagramState {
   tables: ERTableNode[];
   relations: ERRelationEdge[];
@@ -15,6 +21,12 @@ interface ERDiagramState {
   // Page state
   selectedPage: string;
 
+  // Viewport per page (preserved across tab switches)
+  viewports: Record<string, Viewport>;
+
+  // Search highlight
+  focusedNodeId: string | null;
+
   // Actions
   setTables: (tables: ERTableNode[]) => void;
   setRelations: (relations: ERRelationEdge[]) => void;
@@ -23,6 +35,8 @@ interface ERDiagramState {
   removeTable: (id: string) => void;
   clearDiagram: () => void;
   setSelectedPage: (page: string) => void;
+  saveViewport: (page: string, viewport: Viewport) => void;
+  setFocusedNodeId: (id: string | null) => void;
 
   // Reverse engineering
   loadFromDatabase: (connectionId: string, database: string) => Promise<void>;
@@ -41,6 +55,8 @@ export const useERDiagramStore = create<ERDiagramState>((set, get) => ({
   isLoading: false,
   error: null,
   selectedPage: DEFAULT_PAGE,
+  viewports: {},
+  focusedNodeId: null,
 
   setTables: (tables) => set({ tables }),
 
@@ -66,10 +82,25 @@ export const useERDiagramStore = create<ERDiagramState>((set, get) => ({
   },
 
   clearDiagram: () => {
-    set({ tables: [], relations: [], shapes: [], selectedPage: DEFAULT_PAGE });
+    set({
+      tables: [],
+      relations: [],
+      shapes: [],
+      selectedPage: DEFAULT_PAGE,
+      viewports: {},
+      focusedNodeId: null,
+    });
   },
 
   setSelectedPage: (page) => set({ selectedPage: page }),
+
+  saveViewport: (page, viewport) => {
+    set((state) => ({
+      viewports: { ...state.viewports, [page]: viewport },
+    }));
+  },
+
+  setFocusedNodeId: (id) => set({ focusedNodeId: id }),
 
   loadFromERFile: async (filepath) => {
     set({ isLoading: true, error: null });

--- a/frontend/src/tests/diagram/erDiagramUtils.test.ts
+++ b/frontend/src/tests/diagram/erDiagramUtils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { ERTableNode } from '../../types';
+import { filterTablesByQuery } from '../../utils/erDiagramUtils';
+
+function makeTable(
+  id: string,
+  tableName: string,
+  logicalName?: string,
+  page?: string
+): ERTableNode {
+  return {
+    id,
+    type: 'table',
+    data: {
+      tableName,
+      logicalName,
+      page,
+      columns: [],
+    },
+    position: { x: 0, y: 0 },
+  };
+}
+
+const tables: ERTableNode[] = [
+  makeTable('users', 'users', 'ユーザー', 'MAIN'),
+  makeTable('orders', 'orders', '注文', 'MAIN'),
+  makeTable('products', 'products', '商品', 'SUB'),
+  makeTable('categories', 'categories', undefined, 'SUB'),
+];
+
+describe('filterTablesByQuery', () => {
+  it('should match by physical name', () => {
+    const result = filterTablesByQuery(tables, 'user');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('users');
+  });
+
+  it('should match by logical name', () => {
+    const result = filterTablesByQuery(tables, '注文');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('orders');
+  });
+
+  it('should be case-insensitive', () => {
+    const result = filterTablesByQuery(tables, 'PROD');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('products');
+  });
+
+  it('should return empty for no match', () => {
+    const result = filterTablesByQuery(tables, 'nonexistent');
+    expect(result).toHaveLength(0);
+  });
+
+  it('should return all for empty query', () => {
+    // filterTablesByQuery with empty string matches all
+    // (caller should guard against empty query)
+    const result = filterTablesByQuery(tables, '');
+    expect(result).toHaveLength(4);
+  });
+
+  it('should handle tables without logicalName', () => {
+    const result = filterTablesByQuery(tables, 'categ');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('categories');
+  });
+});

--- a/frontend/src/tests/stores/erDiagramStore.test.ts
+++ b/frontend/src/tests/stores/erDiagramStore.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useERDiagramStore } from '../../store/erDiagramStore';
+
+vi.mock('../../api/bridge', () => ({
+  bridge: {},
+  toERDiagramModel: vi.fn(),
+}));
+
+describe('erDiagramStore - viewport & focus', () => {
+  beforeEach(() => {
+    useERDiagramStore.setState({
+      viewports: {},
+      focusedNodeId: null,
+      selectedPage: 'MAIN',
+    });
+  });
+
+  afterEach(() => {
+    useERDiagramStore.setState({
+      viewports: {},
+      focusedNodeId: null,
+    });
+  });
+
+  describe('saveViewport', () => {
+    it('should save viewport for a page', () => {
+      useERDiagramStore.getState().saveViewport('MAIN', { x: 10, y: 20, zoom: 1.5 });
+      expect(useERDiagramStore.getState().viewports.MAIN).toEqual({
+        x: 10,
+        y: 20,
+        zoom: 1.5,
+      });
+    });
+
+    it('should update existing viewport', () => {
+      const { saveViewport } = useERDiagramStore.getState();
+      saveViewport('MAIN', { x: 10, y: 20, zoom: 1.5 });
+      saveViewport('MAIN', { x: 30, y: 40, zoom: 0.5 });
+      expect(useERDiagramStore.getState().viewports.MAIN).toEqual({
+        x: 30,
+        y: 40,
+        zoom: 0.5,
+      });
+    });
+
+    it('should store viewports for multiple pages independently', () => {
+      const { saveViewport } = useERDiagramStore.getState();
+      saveViewport('MAIN', { x: 0, y: 0, zoom: 1 });
+      saveViewport('SUB', { x: 100, y: 200, zoom: 0.8 });
+      const { viewports } = useERDiagramStore.getState();
+      expect(viewports.MAIN).toEqual({ x: 0, y: 0, zoom: 1 });
+      expect(viewports.SUB).toEqual({ x: 100, y: 200, zoom: 0.8 });
+    });
+  });
+
+  describe('setFocusedNodeId', () => {
+    it('should set focused node id', () => {
+      useERDiagramStore.getState().setFocusedNodeId('users');
+      expect(useERDiagramStore.getState().focusedNodeId).toBe('users');
+    });
+
+    it('should clear focused node id with null', () => {
+      useERDiagramStore.getState().setFocusedNodeId('users');
+      useERDiagramStore.getState().setFocusedNodeId(null);
+      expect(useERDiagramStore.getState().focusedNodeId).toBeNull();
+    });
+  });
+
+  describe('clearDiagram', () => {
+    it('should reset viewports and focusedNodeId', () => {
+      const state = useERDiagramStore.getState();
+      state.saveViewport('MAIN', { x: 10, y: 20, zoom: 1 });
+      state.setFocusedNodeId('users');
+      state.clearDiagram();
+      expect(useERDiagramStore.getState().viewports).toEqual({});
+      expect(useERDiagramStore.getState().focusedNodeId).toBeNull();
+    });
+  });
+});

--- a/frontend/src/utils/erDiagramUtils.ts
+++ b/frontend/src/utils/erDiagramUtils.ts
@@ -1,3 +1,4 @@
+import type { ERTableNode } from '../types';
 import { DEFAULT_PAGE } from './erDiagramConstants';
 
 /** テーブル一覧からユニークなページ名を抽出 */
@@ -7,4 +8,14 @@ export function extractPages(tables: { data: { page?: string } }[]): string[] {
     pageSet.add(t.data.page || DEFAULT_PAGE);
   }
   return Array.from(pageSet);
+}
+
+/** 物理名・論理名で部分一致フィルタ */
+export function filterTablesByQuery(tables: ERTableNode[], query: string): ERTableNode[] {
+  const lower = query.toLowerCase();
+  return tables.filter(
+    (t) =>
+      t.data.tableName.toLowerCase().includes(lower) ||
+      t.data.logicalName?.toLowerCase().includes(lower)
+  );
 }


### PR DESCRIPTION
fix #285

- 物理名/論理名でテーブル検索しノードにフォーカス+ハイライト
- タブ切替時のzoom/position保持 (key再マウント廃止→useReactFlow)
- デフォルトでノードドラッグをロック (nodesDraggable=false)