### PR TITLE
fix: SSH切断リーク修正・接続キャンセル即時有効化

### DIFF
--- a/backend/database/async_connection_executor.cpp
+++ b/backend/database/async_connection_executor.cpp
@@ -28,31 +28,47 @@ AsyncConnectionExecutor::~AsyncConnectionExecutor() {
     }
 }
 
-std::string AsyncConnectionExecutor::submitConnect(PreparedConnectRequest request) {
+std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams params) {
     auto requestId = std::format("conn_{}", m_counter++);
 
     auto task = std::make_shared<ConnectTask>();
-    task->connectionString = std::move(request.connectionString);
-    task->driverType = request.driverType;
-    task->effectiveParams = std::move(request.effectiveParams);
-    task->tunnel = std::move(request.tunnel);
+    task->effectiveParams = std::move(params);
     task->startTime = std::chrono::steady_clock::now();
     task->status = ConnectStatus::Pending;
 
     task->future = std::async(std::launch::async, [task]() {
         try {
+            // Prepare connection (SSH tunnel + connection string) in background
+            auto prepared = prepareConnection(task->effectiveParams);
+            if (!prepared) {
+                task->errorMessage = prepared.error();
+                task->status = ConnectStatus::Failed;
+                return;
+            }
+
+            if (task->cancelled.load(std::memory_order_acquire)) {
+                if (prepared->tunnel) {
+                    prepared->tunnel->disconnect();
+                }
+                task->status = ConnectStatus::Cancelled;
+                return;
+            }
+
+            // Update effective params with SSH-redirected server
+            task->effectiveParams = std::move(prepared->effectiveParams);
+            task->tunnel = std::move(prepared->tunnel);
+
             // Create and connect query driver
-            auto queryDriver = DriverFactory::createDriver(task->driverType);
+            auto queryDriver = DriverFactory::createDriver(prepared->driverType);
             std::shared_ptr<IDatabaseDriver> queryDriverPtr(std::move(queryDriver));
             queryDriverPtr->setConnectionTimeout(task->effectiveParams.connectionTimeoutSeconds);
 
-            if (!queryDriverPtr->connect(task->connectionString)) {
+            if (!queryDriverPtr->connect(prepared->connectionString)) {
                 task->errorMessage = std::format("Connection failed: {}", queryDriverPtr->getLastError());
                 task->status = ConnectStatus::Failed;
                 return;
             }
 
-            // Check cancellation between the two connections
             if (task->cancelled.load(std::memory_order_acquire)) {
                 queryDriverPtr->disconnect();
                 task->status = ConnectStatus::Cancelled;
@@ -60,18 +76,17 @@ std::string AsyncConnectionExecutor::submitConnect(PreparedConnectRequest reques
             }
 
             // Create and connect metadata driver
-            auto metadataDriver = DriverFactory::createDriver(task->driverType);
+            auto metadataDriver = DriverFactory::createDriver(prepared->driverType);
             std::shared_ptr<IDatabaseDriver> metadataDriverPtr(std::move(metadataDriver));
             metadataDriverPtr->setConnectionTimeout(task->effectiveParams.connectionTimeoutSeconds);
 
-            if (!metadataDriverPtr->connect(task->connectionString)) {
+            if (!metadataDriverPtr->connect(prepared->connectionString)) {
                 queryDriverPtr->disconnect();
                 task->errorMessage = std::format("Metadata connection failed: {}", metadataDriverPtr->getLastError());
                 task->status = ConnectStatus::Failed;
                 return;
             }
 
-            // Check cancellation after both connections
             if (task->cancelled.load(std::memory_order_acquire)) {
                 queryDriverPtr->disconnect();
                 metadataDriverPtr->disconnect();

--- a/backend/database/async_connection_executor.h
+++ b/backend/database/async_connection_executor.h
@@ -25,14 +25,6 @@ struct ConnectResult {
     std::string errorMessage;
 };
 
-/// Prepared connection data passed to async executor
-struct PreparedConnectRequest {
-    std::string connectionString;
-    std::unique_ptr<SshTunnel> tunnel;
-    DriverType driverType;
-    DatabaseConnectionParams effectiveParams;
-};
-
 class AsyncConnectionExecutor {
 public:
     AsyncConnectionExecutor() = default;
@@ -43,8 +35,9 @@ public:
     AsyncConnectionExecutor(AsyncConnectionExecutor&&) = delete;
     AsyncConnectionExecutor& operator=(AsyncConnectionExecutor&&) = delete;
 
-    /// Submit an async connection request. Returns requestId immediately.
-    [[nodiscard]] std::string submitConnect(PreparedConnectRequest request);
+    /// Submit an async connection request (SSH + DB connect in background).
+    /// Returns requestId immediately.
+    [[nodiscard]] std::string submitConnect(DatabaseConnectionParams params);
 
     /// Cancel a pending/running connection request.
     bool cancelConnect(std::string_view requestId);
@@ -70,8 +63,6 @@ private:
         std::shared_ptr<IDatabaseDriver> metadataDriver;
         std::unique_ptr<SshTunnel> tunnel;
         DatabaseConnectionParams effectiveParams;
-        std::string connectionString;
-        DriverType driverType;
         std::string errorMessage;
         std::chrono::steady_clock::time_point startTime;
     };

--- a/backend/database/connection_registry.cpp
+++ b/backend/database/connection_registry.cpp
@@ -46,7 +46,9 @@ void ConnectionRegistry::remove(std::string_view id) {
     if (entry.metadataDriver && entry.metadataDriver->isConnected()) {
         entry.metadataDriver->disconnect();
     }
-    // tunnel is destroyed automatically via unique_ptr
+    if (entry.tunnel) {
+        entry.tunnel->disconnect();
+    }
     m_connections.erase(it);
 }
 
@@ -177,6 +179,9 @@ void ConnectionRegistry::clear() {
         if (entry.metadataDriver && entry.metadataDriver->isConnected()) {
             entry.metadataDriver->disconnect();
         }
+        if (entry.tunnel) {
+            entry.tunnel->disconnect();
+        }
     }
     m_connections.clear();
 }
@@ -199,6 +204,9 @@ size_t ConnectionRegistry::evictIdleConnections(std::chrono::minutes maxIdleDura
             }
             if (entry.metadataDriver && entry.metadataDriver->isConnected()) {
                 entry.metadataDriver->disconnect();
+            }
+            if (entry.tunnel) {
+                entry.tunnel->disconnect();
             }
             ++evicted;
             return true;

--- a/backend/database/connection_utils.cpp
+++ b/backend/database/connection_utils.cpp
@@ -1,6 +1,7 @@
 #include "connection_utils.h"
 
 #include "../network/ssh_tunnel.h"
+#include "driver_interface.h"
 #include "odbc_driver_detector.h"
 #include "simdjson.h"
 
@@ -212,6 +213,36 @@ std::expected<std::unique_ptr<SshTunnel>, std::string> establishSshTunnel(const 
         return std::unexpected(std::format("SSH tunnel failed: {}", result.error().message));
     }
     return tunnel;
+}
+
+DriverType toDriverType(DbType dbType) noexcept {
+    switch (dbType) {
+        case DbType::PostgreSQL:
+            return DriverType::PostgreSQL;
+        case DbType::MySQL:
+            return DriverType::MySQL;
+        default:
+            return DriverType::SQLServer;
+    }
+}
+
+std::expected<PreparedConnection, std::string> prepareConnection(const DatabaseConnectionParams& params) {
+    DatabaseConnectionParams effectiveParams = params;
+    std::unique_ptr<SshTunnel> tunnel;
+
+    if (params.ssh.enabled) {
+        auto tunnelResult = establishSshTunnel(params);
+        if (!tunnelResult)
+            return std::unexpected(tunnelResult.error());
+        tunnel = std::move(*tunnelResult);
+        effectiveParams.server = std::format("127.0.0.1,{}", tunnel->getLocalPort());
+    }
+
+    auto connStr = buildConnectionString(effectiveParams);
+    if (!connStr)
+        return std::unexpected(connStr.error());
+
+    return PreparedConnection{std::move(*connStr), std::move(tunnel), toDriverType(params.dbType), effectiveParams};
 }
 
 }  // namespace velocitydb

--- a/backend/database/connection_utils.h
+++ b/backend/database/connection_utils.h
@@ -93,4 +93,23 @@ struct DatabaseConnectionParams {
 /// Establishes an SSH tunnel based on connection parameters.
 [[nodiscard]] std::expected<std::unique_ptr<SshTunnel>, std::string> establishSshTunnel(const DatabaseConnectionParams& params);
 
+// ─── Driver type mapping ───
+
+enum class DriverType;
+
+/// Map DbType (connection params) to DriverType (driver layer).
+[[nodiscard]] DriverType toDriverType(DbType dbType) noexcept;
+
+// ─── Connection preparation ───
+
+struct PreparedConnection {
+    std::string connectionString;
+    std::unique_ptr<SshTunnel> tunnel;
+    DriverType driverType;
+    DatabaseConnectionParams effectiveParams;
+};
+
+/// Prepare a connection: establish SSH tunnel if needed, build connection string.
+[[nodiscard]] std::expected<PreparedConnection, std::string> prepareConnection(const DatabaseConnectionParams& params);
+
 }  // namespace velocitydb

--- a/backend/providers/connection_provider.cpp
+++ b/backend/providers/connection_provider.cpp
@@ -4,61 +4,12 @@
 #include "../database/connection_registry.h"
 #include "../database/connection_utils.h"
 #include "../database/driver_interface.h"
-#include "../network/ssh_tunnel.h"
 #include "../utils/json_utils.h"
-#include "../utils/logger.h"
 #include "simdjson.h"
 
 #include <format>
 
 namespace velocitydb {
-
-namespace {
-
-/// Map DbType (connection params) to DriverType (driver layer)
-[[nodiscard]] constexpr DriverType toDriverType(DbType dbType) noexcept {
-    switch (dbType) {
-        case DbType::PostgreSQL:
-            return DriverType::PostgreSQL;
-        case DbType::MySQL:
-            return DriverType::MySQL;
-        default:
-            return DriverType::SQLServer;
-    }
-}
-
-struct PreparedConnection {
-    std::string connectionString;
-    std::unique_ptr<SshTunnel> tunnel;
-    DriverType driverType;
-    DatabaseConnectionParams effectiveParams;
-};
-
-/// SSH tunnel + connection string construction
-[[nodiscard]] std::expected<PreparedConnection, std::string> prepareConnection(const DatabaseConnectionParams& params) {
-    DatabaseConnectionParams effectiveParams = params;
-    std::unique_ptr<SshTunnel> tunnel;
-
-    if (params.ssh.enabled) {
-        auto tunnelResult = establishSshTunnel(params);
-        if (!tunnelResult)
-            return std::unexpected(tunnelResult.error());
-        tunnel = std::move(*tunnelResult);
-        effectiveParams.server = std::format("127.0.0.1,{}", tunnel->getLocalPort());
-        log<LogLevel::DEBUG>(std::format("[DB] SSH tunnel established, redirecting to: {}", effectiveParams.server));
-    }
-
-    auto connStr = buildConnectionString(effectiveParams);
-    if (!connStr)
-        return std::unexpected(connStr.error());
-    log<LogLevel::DEBUG>(std::format("[DB] Connection target: {}", effectiveParams.server));
-    log<LogLevel::DEBUG>("[DB] Attempting connection...");
-    log_flush();
-
-    return PreparedConnection{std::move(*connStr), std::move(tunnel), toDriverType(params.dbType), effectiveParams};
-}
-
-}  // namespace
 
 ConnectionProvider::ConnectionProvider() : m_registry(std::make_unique<ConnectionRegistry>()), m_asyncExecutor(std::make_unique<AsyncConnectionExecutor>()) {}
 
@@ -126,22 +77,11 @@ std::string ConnectionProvider::connectAsync(std::string_view params) {
         return JsonUtils::errorResponse(connectionParams.error());
     }
 
-    auto prepared = prepareConnection(*connectionParams);
-    if (!prepared) {
-        return JsonUtils::errorResponse(prepared.error());
-    }
-
-    PreparedConnectRequest request{
-        .connectionString = std::move(prepared->connectionString),
-        .tunnel = std::move(prepared->tunnel),
-        .driverType = prepared->driverType,
-        .effectiveParams = std::move(prepared->effectiveParams),
-    };
-
     // Evict idle connections as side-effect
     [[maybe_unused]] auto evicted = m_registry->evictIdleConnections();
 
-    auto requestId = m_asyncExecutor->submitConnect(std::move(request));
+    // Submit raw params — SSH + DB connect happens in background thread
+    auto requestId = m_asyncExecutor->submitConnect(std::move(*connectionParams));
     return JsonUtils::successResponse(std::format(R"({{"requestId":"{}"}})", requestId));
 }
 

--- a/frontend/src/store/connectionStore.ts
+++ b/frontend/src/store/connectionStore.ts
@@ -10,6 +10,7 @@ interface ConnectionState {
   activeConnectionId: string | null;
   isConnecting: boolean;
   connectRequestId: string | null;
+  connectCancelled: boolean;
   error: string | null;
 
   addConnection: (connection: Omit<Connection, 'id' | 'isActive'>) => Promise<void>;
@@ -28,10 +29,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   activeConnectionId: null,
   isConnecting: false,
   connectRequestId: null,
+  connectCancelled: false,
   error: null,
 
   addConnection: async (connection) => {
-    set({ isConnecting: true, error: null, connectRequestId: null });
+    set({ isConnecting: true, error: null, connectRequestId: null, connectCancelled: false });
 
     try {
       const { requestId } = await bridge.connectAsync({
@@ -55,6 +57,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
             }
           : undefined,
       });
+
+      // Check if cancelled while waiting for connectAsync IPC response
+      if (get().connectCancelled) {
+        await bridge.cancelConnect(requestId).catch(() => {});
+        set({ isConnecting: false, connectRequestId: null, connectCancelled: false });
+        return;
+      }
 
       set({ connectRequestId: requestId });
 
@@ -119,12 +128,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         activeConnectionId: result.connectionId,
         isConnecting: false,
         connectRequestId: null,
+        connectCancelled: false,
       }));
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Connection failed';
+      if (message === 'Connection cancelled') {
+        set({ isConnecting: false, connectRequestId: null, connectCancelled: false, error: null });
+        return;
+      }
       set({
         isConnecting: false,
         connectRequestId: null,
-        error: error instanceof Error ? error.message : 'Connection failed',
+        connectCancelled: false,
+        error: message,
       });
       throw error;
     }
@@ -133,8 +149,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   cancelConnection: async () => {
     const { connectRequestId } = get();
     if (connectRequestId) {
-      set({ connectRequestId: null });
+      set({ connectRequestId: null, connectCancelled: false });
       await bridge.cancelConnect(connectRequestId).catch(() => {});
+    } else {
+      // Pre-IPC cancel: flag for addConnection to detect
+      set({ connectCancelled: true });
     }
     set({ isConnecting: false, error: null });
   },


### PR DESCRIPTION
## Summary

- SSH切断時に tunnel->disconnect() 未呼出でスレッドリークする問題を修正
- SSH確立を非同期スレッド内に移動し connectAsync IPC が即座に requestId を返却
- Frontend: connectCancelled フラグで IPC 応答前のキャンセルに対応

## Test plan

- [x] C++ Release ビルド通過
- [x] Vitest 316件通過
- [ ] SSH経由接続でキャンセルボタン即時動作確認
