### PR TITLE
fix: 接続ダイアログのキャンセル・閉じるボタン動作修正

### DIFF
--- a/frontend/src/components/dialogs/ConnectionDialog.tsx
+++ b/frontend/src/components/dialogs/ConnectionDialog.tsx
@@ -143,7 +143,6 @@ export function ConnectionDialog({
 
   const handleConnect = () => {
     onConnect(config);
-    onClose();
   };
 
   return (
@@ -280,20 +279,21 @@ export function ConnectionDialog({
           <button
             type="button"
             className={styles.cancelButton}
-            onClick={onClose}
-            disabled={isConnecting}
+            onClick={() => {
+              if (isConnecting) onCancelConnect?.();
+              onClose();
+            }}
           >
             キャンセル
           </button>
-          {isConnecting ? (
-            <button type="button" className={styles.connectButton} onClick={onCancelConnect}>
-              接続中止
-            </button>
-          ) : (
-            <button type="button" className={styles.connectButton} onClick={handleConnect}>
-              接続
-            </button>
-          )}
+          <button
+            type="button"
+            className={styles.connectButton}
+            onClick={isConnecting ? onCancelConnect : handleConnect}
+            disabled={false}
+          >
+            {isConnecting ? '接続中止' : '接続'}
+          </button>
         </div>
       </div>
 

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -167,8 +167,9 @@ export function MainLayout() {
             }
           : undefined,
       });
-    } catch (error) {
-      console.error('Connection failed:', error);
+      setIsConnectionDialogOpen(false);
+    } catch {
+      // Error is displayed in ConnectionDialog via connectionStore.error
     }
   };
 
@@ -565,7 +566,10 @@ export function MainLayout() {
         <Suspense fallback={<LoadingFallback />}>
           <ConnectionDialog
             isOpen={isConnectionDialogOpen}
-            onClose={() => setIsConnectionDialogOpen(false)}
+            onClose={() => {
+              if (isConnecting) cancelConnection();
+              setIsConnectionDialogOpen(false);
+            }}
             onConnect={connectToDatabase}
             isConnecting={isConnecting}
             onCancelConnect={cancelConnection}


### PR DESCRIPTION
## Summary

- 接続ボタン押下後にダイアログが即座に閉じる問題を修正
- キャンセルボタンが接続中に無効化される問題を修正
- ダイアログを閉じた際に接続が残り続ける問題を修正

## Test plan

- [x] Vitest 316件通過
- [x] C++ Release ビルド通過
- [ ] 接続ボタン→ダイアログ開いたまま→接続完了後に閉じる
- [ ] 接続中にキャンセル→接続中止→ダイアログ操作可能
- [ ] 接続中にダイアログ閉じる→接続自動キャンセル
