### PR TITLE
fix: 再接続時にクエリタブのconnectionIdを新IDに移行 (#300)

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useKeyboardHandler } from '../../hooks/useKeyboardHandler';
+import { applyConnectionMigration } from '../../store/connectionMigration';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useQueryStore } from '../../store/queryStore';
 import { useSessionStore } from '../../store/sessionStore';
@@ -143,7 +144,7 @@ export function MainLayout() {
 
   const connectToDatabase = async (config: ConnectionConfig) => {
     try {
-      await addConnection({
+      const result = await addConnection({
         name: config.name,
         server: config.server,
         port: config.port,
@@ -167,6 +168,7 @@ export function MainLayout() {
             }
           : undefined,
       });
+      applyConnectionMigration(result.replaced);
       setIsConnectionDialogOpen(false);
     } catch {
       // Error is displayed in ConnectionDialog via connectionStore.error

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../api/bridge';
+import { applyConnectionMigration } from '../../store/connectionMigration';
 import { useConnectionActions, useConnectionStore } from '../../store/connectionStore';
 import type { ExpandableType } from '../../utils/treeNode';
 import { ConnectionTreeSection } from './ConnectionTreeSection';
@@ -89,7 +90,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
         }
       }
 
-      await addConnection({
+      const result = await addConnection({
         name: confirmingProfile.name,
         server: confirmingProfile.server,
         port: confirmingProfile.port ?? 1433,
@@ -113,6 +114,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
             }
           : undefined,
       });
+      applyConnectionMigration(result.replaced);
       setConfirmingProfile(null);
     } catch (error) {
       console.error('Failed to connect:', error);

--- a/frontend/src/store/connectionMigration.ts
+++ b/frontend/src/store/connectionMigration.ts
@@ -1,0 +1,8 @@
+import { useQueryStore } from './queryStore';
+import { useSchemaStore } from './schemaStore';
+
+export function applyConnectionMigration(replaced?: { oldId: string; newId: string }): void {
+  if (!replaced) return;
+  useQueryStore.getState().migrateConnection(replaced.oldId, replaced.newId);
+  useSchemaStore.getState().migrateConnection(replaced.oldId, replaced.newId);
+}

--- a/frontend/src/store/connectionStore.ts
+++ b/frontend/src/store/connectionStore.ts
@@ -13,7 +13,9 @@ interface ConnectionState {
   connectCancelled: boolean;
   error: string | null;
 
-  addConnection: (connection: Omit<Connection, 'id' | 'isActive'>) => Promise<void>;
+  addConnection: (
+    connection: Omit<Connection, 'id' | 'isActive'>
+  ) => Promise<{ replaced?: { oldId: string; newId: string } }>;
   cancelConnection: () => Promise<void>;
   removeConnection: (id: string) => Promise<void>;
   setActive: (id: string | null) => void;
@@ -62,7 +64,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       if (get().connectCancelled) {
         await bridge.cancelConnect(requestId).catch(() => {});
         set({ isConnecting: false, connectRequestId: null, connectCancelled: false });
-        return;
+        return {};
       }
 
       set({ connectRequestId: requestId });
@@ -116,6 +118,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       };
 
       const existing = get().connections.find((c) => c.name === connection.name);
+      const oldId = existing?.id;
       if (existing) {
         await bridge.disconnect(existing.id).catch(() => {});
       }
@@ -130,11 +133,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         connectRequestId: null,
         connectCancelled: false,
       }));
+
+      return oldId ? { replaced: { oldId, newId: result.connectionId } } : {};
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Connection failed';
       // If already cancelled by cancelConnection(), don't overwrite state
       if (message === 'Connection cancelled' || get().connectCancelled || !get().isConnecting) {
-        return;
+        return {};
       }
       set({
         isConnecting: false,
@@ -142,6 +147,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         connectCancelled: false,
         error: message,
       });
+      return {};
     }
   },
 

--- a/frontend/src/store/query/interfaces/Manageable.ts
+++ b/frontend/src/store/query/interfaces/Manageable.ts
@@ -6,4 +6,5 @@ export interface Manageable {
   renameQuery: (id: string, name: string) => void;
   setActive: (id: string | null) => void;
   reorderQuery: (fromIndex: number, toIndex: number) => void;
+  migrateConnection: (oldId: string, newId: string) => void;
 }

--- a/frontend/src/store/query/queryStore.ts
+++ b/frontend/src/store/query/queryStore.ts
@@ -92,6 +92,7 @@ export const useQueryActions = () =>
       renameQuery: state.renameQuery,
       setActive: state.setActive,
       reorderQuery: state.reorderQuery,
+      migrateConnection: state.migrateConnection,
       executeQuery: state.executeQuery,
       executeSelectedText: state.executeSelectedText,
       cancelQuery: state.cancelQuery,

--- a/frontend/src/store/query/slices/queryManageSlice.ts
+++ b/frontend/src/store/query/slices/queryManageSlice.ts
@@ -84,6 +84,14 @@ export function createManageSlice(set: SetState, get: GetState, deps: ManageSlic
       set({ activeQueryId: id });
     },
 
+    migrateConnection: (oldId, newId) => {
+      set((state) => ({
+        queries: state.queries.map((q) =>
+          q.connectionId === oldId ? { ...q, connectionId: newId } : q
+        ),
+      }));
+    },
+
     reorderQuery: (fromIndex, toIndex) => {
       set((state) => {
         if (

--- a/frontend/src/store/schemaStore.ts
+++ b/frontend/src/store/schemaStore.ts
@@ -25,6 +25,7 @@ interface SchemaState {
   getTableColumns: (connectionId: string, tableName: string) => Column[] | undefined;
   getTables: (connectionId: string) => TableSchema[];
   clearSchema: (connectionId: string) => void;
+  migrateConnection: (oldId: string, newId: string) => void;
 }
 
 export const useSchemaStore = create<SchemaState>((set, get) => ({
@@ -187,6 +188,14 @@ export const useSchemaStore = create<SchemaState>((set, get) => ({
     set((state) => {
       const newSchemas = new Map(state.schemas);
       newSchemas.delete(connectionId);
+      return { schemas: newSchemas };
+    });
+  },
+
+  migrateConnection: (oldId: string, _newId: string) => {
+    set((state) => {
+      const newSchemas = new Map(state.schemas);
+      newSchemas.delete(oldId);
       return { schemas: newSchemas };
     });
   },

--- a/frontend/src/tests/stores/connectionStore.test.ts
+++ b/frontend/src/tests/stores/connectionStore.test.ts
@@ -145,6 +145,35 @@ describe('connectionStore', () => {
       expect(state.connections[0].id).toBe('db_2');
       expect(mockDisconnect).toHaveBeenCalledWith('db_1');
     });
+
+    it('同名接続置換時に replaced を返す', async () => {
+      mockConnectAsync.mockResolvedValue({ requestId: 'req_1' });
+      mockGetConnectResult.mockResolvedValue({
+        status: 'connected',
+        connectionId: 'db_new',
+      });
+      mockDisconnect.mockResolvedValue(undefined);
+
+      useConnectionStore.setState({
+        connections: [{ ...baseConnection, id: 'db_old', isActive: true }],
+      });
+
+      const result = await useConnectionStore.getState().addConnection(baseConnection);
+
+      expect(result.replaced).toEqual({ oldId: 'db_old', newId: 'db_new' });
+    });
+
+    it('新規接続では replaced が undefined', async () => {
+      mockConnectAsync.mockResolvedValue({ requestId: 'req_1' });
+      mockGetConnectResult.mockResolvedValue({
+        status: 'connected',
+        connectionId: 'db_1',
+      });
+
+      const result = await useConnectionStore.getState().addConnection(baseConnection);
+
+      expect(result.replaced).toBeUndefined();
+    });
   });
 
   describe('cancelConnection', () => {

--- a/frontend/src/tests/stores/queryStore.test.ts
+++ b/frontend/src/tests/stores/queryStore.test.ts
@@ -379,4 +379,40 @@ describe('queryStore', () => {
       expect(mockedBridge.removeAsyncQuery).toHaveBeenCalledWith('async_2');
     });
   });
+
+  describe('migrateConnection', () => {
+    it('該当タブの connectionId が newId に更新される', () => {
+      const { addQuery } = useQueryStore.getState();
+      addQuery('conn_1');
+      addQuery('conn_1');
+
+      useQueryStore.getState().migrateConnection('conn_1', 'conn_2');
+
+      const updated = useQueryStore.getState().queries;
+      expect(updated[0].connectionId).toBe('conn_2');
+      expect(updated[1].connectionId).toBe('conn_2');
+    });
+
+    it('該当しないタブの connectionId は変更されない', () => {
+      const { addQuery } = useQueryStore.getState();
+      addQuery('conn_1');
+      addQuery('conn_other');
+
+      useQueryStore.getState().migrateConnection('conn_1', 'conn_2');
+
+      const updated = useQueryStore.getState().queries;
+      expect(updated[0].connectionId).toBe('conn_2');
+      expect(updated[1].connectionId).toBe('conn_other');
+    });
+
+    it('oldId に該当するタブが無い場合、何も変更されない', () => {
+      const { addQuery } = useQueryStore.getState();
+      addQuery('conn_x');
+
+      useQueryStore.getState().migrateConnection('conn_1', 'conn_2');
+
+      const updated = useQueryStore.getState().queries;
+      expect(updated[0].connectionId).toBe('conn_x');
+    });
+  });
 });

--- a/frontend/src/tests/stores/schemaStore.test.ts
+++ b/frontend/src/tests/stores/schemaStore.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSchemaStore } from '../../store/schemaStore';
+
+vi.mock('../../api/bridge', () => ({
+  bridge: {
+    getTables: vi.fn(),
+    getColumns: vi.fn(),
+  },
+}));
+
+describe('schemaStore', () => {
+  beforeEach(() => {
+    useSchemaStore.setState({ schemas: new Map() });
+  });
+
+  describe('migrateConnection', () => {
+    it('旧IDのキャッシュが削除される', () => {
+      // Seed cache for conn_1
+      const schemas = new Map();
+      schemas.set('conn_1', {
+        tables: [{ name: 'users', schema: 'dbo', type: 'TABLE' as const, columnsLoaded: false }],
+        tablesLoaded: true,
+        loadingTables: false,
+        loadingColumns: new Set<string>(),
+      });
+      useSchemaStore.setState({ schemas });
+
+      useSchemaStore.getState().migrateConnection('conn_1', 'conn_2');
+
+      const result = useSchemaStore.getState().schemas;
+      expect(result.has('conn_1')).toBe(false);
+      expect(result.has('conn_2')).toBe(false); // lazy-load, not copied
+    });
+  });
+});


### PR DESCRIPTION
fix #300

