### PR TITLE
fix: FK制約のあるテーブルのDROP/TRUNCATEを自動処理 (#302)

### DIFF
--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useColumnActions, validateIdentifier } from '../../hooks/useColumnActions';
+import { useTableActions } from '../../hooks/useTableActions';
 import { useConnectionStore } from '../../store/connectionStore';
 import type { Connection, DatabaseObject, MenuItem } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
@@ -144,6 +145,19 @@ export function ConnectionTreeSection({
     dbType: connection.dbType,
     isReadOnly: connection.isReadOnly,
     loadColumns,
+    setTreeData,
+  });
+
+  const {
+    tableAction,
+    getTableMenuItems,
+    confirmDrop: confirmTableDrop,
+    confirmTruncate,
+    dismiss: dismissTableAction,
+  } = useTableActions({
+    connectionId: connection.id,
+    dbType: connection.dbType,
+    loadTables,
     setTreeData,
   });
 
@@ -325,6 +339,12 @@ export function ConnectionTreeSection({
             }
           },
         });
+
+        const tableItems = getTableMenuItems(node);
+        if (tableItems.length > 0) {
+          items.push({ label: '', action: () => {}, divider: true });
+          items.push(...tableItems);
+        }
       }
 
       if (node.type === 'database') {
@@ -366,7 +386,14 @@ export function ConnectionTreeSection({
 
       return items;
     },
-    [connection.id, connection.dbType, onTableOpen, loadTables, getColumnMenuItems]
+    [
+      connection.id,
+      connection.dbType,
+      onTableOpen,
+      loadTables,
+      getColumnMenuItems,
+      getTableMenuItems,
+    ]
   );
 
   const connColor = useMemo(
@@ -434,6 +461,38 @@ export function ConnectionTreeSection({
         confirmLabel="削除"
         onConfirm={handleDropConfirm}
         onCancel={dismiss}
+      />
+
+      <QueryConfirmDialog
+        isOpen={tableAction?.type === 'drop-confirm'}
+        title="テーブル削除の確認"
+        message={
+          tableAction?.type === 'drop-confirm'
+            ? `テーブル "${tableAction.tableName}" を削除します。${tableAction.hasFK ? 'FK制約が自動的に削除されます。' : ''}この操作は元に戻せません。`
+            : ''
+        }
+        details={tableAction?.type === 'drop-confirm' ? tableAction.sqls.join(';\n') : undefined}
+        isDestructive
+        confirmLabel="削除"
+        onConfirm={confirmTableDrop}
+        onCancel={dismissTableAction}
+      />
+
+      <QueryConfirmDialog
+        isOpen={tableAction?.type === 'truncate-confirm'}
+        title="テーブルを空にする確認"
+        message={
+          tableAction?.type === 'truncate-confirm'
+            ? `テーブル "${tableAction.tableName}" の全データを削除します。${tableAction.hasFK ? 'FK制約が自動的に処理されます。' : ''}`
+            : ''
+        }
+        details={
+          tableAction?.type === 'truncate-confirm' ? tableAction.sqls.join(';\n') : undefined
+        }
+        isDestructive
+        confirmLabel="実行"
+        onConfirm={confirmTruncate}
+        onCancel={dismissTableAction}
       />
     </div>
   );

--- a/frontend/src/hooks/useTableActions.ts
+++ b/frontend/src/hooks/useTableActions.ts
@@ -1,0 +1,164 @@
+import { useCallback, useState } from 'react';
+import { bridge } from '../api/bridge';
+import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
+import { log } from '../utils/logger';
+import {
+  buildDropTableSql,
+  buildTruncateTableSql,
+  SQL_BEGIN_TRANSACTION,
+} from '../utils/sqlIdentifier';
+
+interface DropConfirm {
+  type: 'drop-confirm';
+  schema: string;
+  tableName: string;
+  sqls: string[];
+  hasFK: boolean;
+}
+
+interface TruncateConfirm {
+  type: 'truncate-confirm';
+  schema: string;
+  tableName: string;
+  sqls: string[];
+  hasFK: boolean;
+}
+
+export type TableActionState = DropConfirm | TruncateConfirm | null;
+
+interface UseTableActionsParams {
+  connectionId: string;
+  dbType?: DatabaseType;
+  loadTables: () => Promise<DatabaseObject[]>;
+  setTreeData: React.Dispatch<React.SetStateAction<DatabaseObject[]>>;
+  onDdlError?: (error: unknown) => void;
+}
+
+function parseTableName(node: DatabaseObject): { schema: string; table: string } {
+  const schema = (node.metadata?.schema as string) ?? 'dbo';
+  const parts = node.name.split('.');
+  const table = parts.length >= 2 ? parts[1] : parts[0];
+  return { schema, table };
+}
+
+export function useTableActions({
+  connectionId,
+  dbType,
+  loadTables,
+  setTreeData,
+  onDdlError,
+}: UseTableActionsParams) {
+  const [tableAction, setTableAction] = useState<TableActionState>(null);
+
+  const requestDrop = useCallback(
+    async (node: DatabaseObject) => {
+      const { schema, table } = parseTableName(node);
+      try {
+        const fks = await bridge.getReferencingForeignKeys(connectionId, node.name);
+        const sqls = buildDropTableSql(schema, table, dbType, fks);
+        setTableAction({
+          type: 'drop-confirm',
+          schema,
+          tableName: table,
+          sqls,
+          hasFK: fks.length > 0,
+        });
+      } catch (error) {
+        log.error(`[useTableActions] Failed to get FK info: ${error}`);
+        onDdlError?.(error);
+      }
+    },
+    [connectionId, dbType, onDdlError]
+  );
+
+  const requestTruncate = useCallback(
+    async (node: DatabaseObject) => {
+      const { schema, table } = parseTableName(node);
+      try {
+        const fks = await bridge.getReferencingForeignKeys(connectionId, node.name);
+        const sqls = buildTruncateTableSql(schema, table, dbType, fks);
+        setTableAction({
+          type: 'truncate-confirm',
+          schema,
+          tableName: table,
+          sqls,
+          hasFK: fks.length > 0,
+        });
+      } catch (error) {
+        log.error(`[useTableActions] Failed to get FK info: ${error}`);
+        onDdlError?.(error);
+      }
+    },
+    [connectionId, dbType, onDdlError]
+  );
+
+  const getTableMenuItems = useCallback(
+    (node: DatabaseObject): MenuItem[] => {
+      if (node.type !== 'table') return [];
+      return [
+        {
+          label: 'テーブルを削除',
+          action: () => requestDrop(node),
+        },
+        {
+          label: 'テーブルを空にする',
+          action: () => requestTruncate(node),
+        },
+      ];
+    },
+    [requestDrop, requestTruncate]
+  );
+
+  const executeSqls = useCallback(
+    async (sqls: string[]) => {
+      const hasTransaction = sqls[0] === SQL_BEGIN_TRANSACTION;
+      try {
+        for (const sql of sqls) {
+          await bridge.executeQuery(connectionId, sql, false);
+        }
+      } catch (error) {
+        if (hasTransaction) {
+          await bridge.executeQuery(connectionId, 'ROLLBACK', false).catch(() => {});
+        }
+        throw error;
+      }
+    },
+    [connectionId]
+  );
+
+  const confirmDrop = useCallback(async () => {
+    if (tableAction?.type !== 'drop-confirm') return;
+    try {
+      await executeSqls(tableAction.sqls);
+      const children = await loadTables();
+      setTreeData((prev) => prev.map((n) => (n.type === 'database' ? { ...n, children } : n)));
+      setTableAction(null);
+    } catch (error) {
+      log.error(`[useTableActions] DROP failed: ${error}`);
+      onDdlError?.(error);
+    }
+  }, [tableAction, executeSqls, loadTables, setTreeData, onDdlError]);
+
+  const confirmTruncate = useCallback(async () => {
+    if (tableAction?.type !== 'truncate-confirm') return;
+    try {
+      await executeSqls(tableAction.sqls);
+      setTableAction(null);
+    } catch (error) {
+      log.error(`[useTableActions] TRUNCATE failed: ${error}`);
+      onDdlError?.(error);
+    }
+  }, [tableAction, executeSqls, onDdlError]);
+
+  const dismiss = useCallback(() => setTableAction(null), []);
+
+  return {
+    tableAction,
+    getTableMenuItems,
+    requestDrop,
+    requestTruncate,
+    confirmDrop,
+    confirmTruncate,
+    dismiss,
+  };
+}

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -1,5 +1,15 @@
+import { bridge as apiBridge } from '../../../api/bridge';
 import type { ResultSet } from '../../../types';
+import { log } from '../../../utils/logger';
 import { getSettings } from '../../../utils/settingsUtils';
+import {
+  buildDropTableSql,
+  buildTruncateTableSql,
+  defaultSchema,
+  parseDropOrTruncate,
+  SQL_BEGIN_TRANSACTION,
+} from '../../../utils/sqlIdentifier';
+import { useConnectionStore } from '../../connectionStore';
 import { executeAsyncWithPolling, toQueryResult } from '../helpers/asyncPolling';
 import { endExecution, failExecution, startExecution } from '../helpers/executionState';
 import { fetchAndUpdateRowCount } from '../helpers/paginationHelper';
@@ -31,6 +41,29 @@ export function createExecuteSlice(
 
   const activeQueryIds = new Map<string, string>();
 
+  async function rewriteWithFkHandling(connectionId: string, sql: string): Promise<string[]> {
+    const parsed = parseDropOrTruncate(sql);
+    if (!parsed) return [sql];
+
+    const conn = useConnectionStore.getState().connections.find((c) => c.id === connectionId);
+    const dbType = conn?.dbType;
+    const schema = parsed.schema || defaultSchema(dbType);
+    const fullName = `${schema}.${parsed.table}`;
+
+    try {
+      const fks = await apiBridge.getReferencingForeignKeys(connectionId, fullName);
+      if (fks.length === 0) return [sql];
+
+      if (parsed.type === 'drop') {
+        return buildDropTableSql(schema, parsed.table, dbType, fks);
+      }
+      return buildTruncateTableSql(schema, parsed.table, dbType, fks);
+    } catch (error) {
+      log.error(`[queryExecuteSlice] FK lookup failed, executing original SQL: ${error}`);
+      return [sql];
+    }
+  }
+
   async function executeAsync(id: string, connectionId: string, sql: string): Promise<void> {
     const controller = new AbortController();
     abort.register(id, controller);
@@ -38,6 +71,38 @@ export function createExecuteSlice(
     set((state) => startExecution(state, id));
 
     try {
+      // FK制約自動処理: DROP/TRUNCATE TABLE検出時のみ非同期でSQL書き換え
+      const parsed = parseDropOrTruncate(sql);
+      if (parsed) {
+        const sqls = await rewriteWithFkHandling(connectionId, sql);
+        if (sqls.length > 1) {
+          const hasTransaction = sqls[0] === SQL_BEGIN_TRANSACTION;
+          try {
+            for (const s of sqls) {
+              await apiBridge.executeQuery(connectionId, s, false);
+            }
+          } catch (error) {
+            if (hasTransaction) {
+              await apiBridge.executeQuery(connectionId, 'ROLLBACK', false).catch(() => {});
+            }
+            throw error;
+          }
+          set((state) => ({
+            ...endExecution(state, id),
+            results: {
+              ...state.results,
+              [id]: {
+                columns: [],
+                rows: [],
+                affectedRows: 0,
+                executionTimeMs: 0,
+                message: `${sqls.length} statements executed successfully`,
+              },
+            },
+          }));
+          return;
+        }
+      }
       const timeoutMs = getSettings().query.timeout;
       const result = await executeAsyncWithPolling(
         bridge,

--- a/frontend/src/utils/sqlIdentifier.ts
+++ b/frontend/src/utils/sqlIdentifier.ts
@@ -77,6 +77,152 @@ export function buildDropColumnSql(
 }
 
 // ---------------------------------------------------------------------------
+// Table DROP / TRUNCATE
+// ---------------------------------------------------------------------------
+
+export interface ReferencingFK {
+  name: string;
+  referencingTable: string;
+  referencingColumns: string[];
+  columns: string[];
+  onDelete: string;
+  onUpdate: string;
+}
+
+const FK_ACTION_MAP: Record<string, string> = {
+  NO_ACTION: 'NO ACTION',
+  CASCADE: 'CASCADE',
+  SET_NULL: 'SET NULL',
+  SET_DEFAULT: 'SET DEFAULT',
+  RESTRICT: 'RESTRICT',
+};
+
+function sanitizeFkAction(action: string): string {
+  return FK_ACTION_MAP[action.toUpperCase()] ?? 'NO ACTION';
+}
+
+export const SQL_BEGIN_TRANSACTION = 'BEGIN TRANSACTION';
+
+function formatQualifiedName(name: string, q: (n: string) => string): string {
+  const parts = name.split('.');
+  return parts.length >= 2 ? `${q(parts[0])}.${q(parts[1])}` : q(parts[0]);
+}
+
+function qualifyTable(schema: string, table: string, q: (n: string) => string): string {
+  return schema ? `${q(schema)}.${q(table)}` : q(table);
+}
+
+/** DROP TABLE SQL生成（FK制約自動処理付き） */
+export function buildDropTableSql(
+  schema: string,
+  table: string,
+  dbType: DatabaseType | undefined,
+  referencingFKs: ReferencingFK[]
+): string[] {
+  const q = (n: string) => quoteIdentifier(n, dbType);
+  const qualifiedTable = qualifyTable(schema, table, q);
+
+  if (referencingFKs.length === 0) {
+    return [`DROP TABLE ${qualifiedTable}`];
+  }
+
+  if (dbType === 'postgresql') {
+    return [`DROP TABLE ${qualifiedTable} CASCADE`];
+  }
+
+  const dropConstraints = referencingFKs.map(
+    (fk) =>
+      `ALTER TABLE ${formatQualifiedName(fk.referencingTable, q)} DROP CONSTRAINT ${q(fk.name)}`
+  );
+
+  return [...dropConstraints, `DROP TABLE ${qualifiedTable}`];
+}
+
+/** TRUNCATE TABLE SQL生成（FK制約自動処理付き） */
+export function buildTruncateTableSql(
+  schema: string,
+  table: string,
+  dbType: DatabaseType | undefined,
+  referencingFKs: ReferencingFK[]
+): string[] {
+  const q = (n: string) => quoteIdentifier(n, dbType);
+  const qualifiedTable = qualifyTable(schema, table, q);
+
+  if (referencingFKs.length === 0) {
+    return [`TRUNCATE TABLE ${qualifiedTable}`];
+  }
+
+  if (dbType === 'postgresql') {
+    return [`TRUNCATE TABLE ${qualifiedTable} CASCADE`];
+  }
+
+  const dropConstraints = referencingFKs.map(
+    (fk) =>
+      `ALTER TABLE ${formatQualifiedName(fk.referencingTable, q)} DROP CONSTRAINT ${q(fk.name)}`
+  );
+
+  const addConstraints = referencingFKs.map((fk) => {
+    const refCols = fk.referencingColumns.map((c) => q(c)).join(', ');
+    const cols = fk.columns.map((c) => q(c)).join(', ');
+    return (
+      `ALTER TABLE ${formatQualifiedName(fk.referencingTable, q)} ` +
+      `WITH CHECK ADD CONSTRAINT ${q(fk.name)} ` +
+      `FOREIGN KEY (${refCols}) REFERENCES ${qualifiedTable} (${cols}) ` +
+      `ON DELETE ${sanitizeFkAction(fk.onDelete)} ON UPDATE ${sanitizeFkAction(fk.onUpdate)}`
+    );
+  });
+
+  return [
+    SQL_BEGIN_TRANSACTION,
+    ...dropConstraints,
+    `TRUNCATE TABLE ${qualifiedTable}`,
+    ...addConstraints,
+    'COMMIT',
+  ];
+}
+
+// 識別子パターン: [name], "name", または裸の名前
+const ID_PATTERN = '(?:\\[[^\\]]+\\]|"[^"]+"|[\\w]+)';
+const DROP_RE = new RegExp(
+  `^DROP\\s+TABLE\\s+(?:IF\\s+EXISTS\\s+)?((?:${ID_PATTERN})\\.)?(?:${ID_PATTERN})\\s*$`,
+  'i'
+);
+const TRUNCATE_RE = new RegExp(
+  `^TRUNCATE\\s+TABLE\\s+((?:${ID_PATTERN})\\.)?(?:${ID_PATTERN})\\s*$`,
+  'i'
+);
+
+function stripQuotes(name: string): string {
+  return name.replace(/^\[|\]$/g, '').replace(/^"|"$/g, '');
+}
+
+/** DROP TABLE / TRUNCATE TABLE 文からスキーマ名とテーブル名を抽出 */
+export function parseDropOrTruncate(
+  sql: string
+): { type: 'drop' | 'truncate'; schema: string; table: string } | null {
+  const trimmed = sql.trim().replace(/;$/, '').trim();
+
+  for (const [re, type] of [
+    [DROP_RE, 'drop'],
+    [TRUNCATE_RE, 'truncate'],
+  ] as const) {
+    const m = trimmed.match(re);
+    if (!m) continue;
+    const schema = m[1] ? stripQuotes(m[1].replace(/\.$/, '')) : '';
+    const tableMatch = trimmed.match(new RegExp(`(${ID_PATTERN})\\s*$`, 'i'));
+    if (!tableMatch) continue;
+    const table = stripQuotes(tableMatch[1]);
+    return { type, schema, table };
+  }
+  return null;
+}
+
+/** スキーマ省略時のデフォルトスキーマを返す */
+export function defaultSchema(dbType: DatabaseType | undefined): string {
+  return dbType === 'postgresql' ? 'public' : 'dbo';
+}
+
+// ---------------------------------------------------------------------------
 // View DDL
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
fix #302

- ObjectTreeコンテキストメニューにDROP/TRUNCATEを追加
- エディタからのSQL実行時もFK制約を自動検出・処理
- SQL Server: FK個別DROP→操作→FK再作成(トランザクション+ROLLBACK)
- PostgreSQL: CASCADEオプション付与
- スキーマ省略時デフォルトスキーマ(dbo/public)自動補完