### PR TITLE
fix: WebView2レイアウト遅延によるグリッド仮想スクロールの空表示を修正

### DIFF
--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -61,6 +61,19 @@ const preventShiftSelect = (e: MouseEvent) => {
   if (e.shiftKey) e.preventDefault();
 };
 
+/** Extract row/cell info from a bubbled event via data attributes */
+function findCellFromEvent(e: MouseEvent) {
+  const td = (e.target as HTMLElement).closest('td[data-field]') as HTMLElement | null;
+  if (!td) return null;
+  const tr = td.closest('tr[data-row-index]') as HTMLElement | null;
+  if (!tr) return null;
+  const field = td.dataset.field;
+  const rowIndexStr = tr.dataset.rowIndex;
+  const originalIndexStr = tr.dataset.originalIndex;
+  if (!field || rowIndexStr == null || originalIndexStr == null) return null;
+  return { field, rowIndex: Number(rowIndexStr), originalIndex: Number(originalIndexStr) };
+}
+
 function GridTableInner({
   table,
   tableContainerRef,
@@ -148,7 +161,37 @@ function GridTableInner({
             </tr>
           )}
         </thead>
-        <tbody className={styles.tbody}>
+        <tbody
+          className={styles.tbody}
+          onClick={(e) => {
+            const info = findCellFromEvent(e);
+            if (!info) return;
+            const { field, rowIndex } = info;
+            if (isSystemColumn(field)) {
+              e.shiftKey ? callbacks.onRowRangeSelect(rowIndex) : callbacks.onRowToggle(rowIndex);
+            } else {
+              e.shiftKey
+                ? callbacks.onCellRangeSelect(rowIndex, field)
+                : callbacks.onCellClick(rowIndex, field);
+            }
+          }}
+          onContextMenu={(e) => {
+            const info = findCellFromEvent(e);
+            if (!info) return;
+            openCellMenu(e, info.rowIndex, info.field);
+          }}
+          onDoubleClick={(e) => {
+            if (!edit.isEditMode) return;
+            const info = findCellFromEvent(e);
+            if (!info) return;
+            const { field, rowIndex, originalIndex } = info;
+            if (isSystemColumn(field)) return;
+            const row = rows[rowIndex];
+            if (!row) return;
+            const value = row.getValue(field);
+            callbacks.onStartEdit(originalIndex, field, typeof value === 'string' ? value : null);
+          }}
+        >
           {paddingTop > 0 && (
             <tr>
               <td style={{ height: `${paddingTop}px` }} />
@@ -175,11 +218,8 @@ function GridTableInner({
               <tr
                 key={row.id}
                 className={rowClasses}
-                onClick={(e) =>
-                  e.shiftKey
-                    ? callbacks.onRowRangeSelect(rowIndex)
-                    : callbacks.onRowToggle(rowIndex)
-                }
+                data-row-index={rowIndex}
+                data-original-index={originalIndex}
               >
                 {row.getVisibleCells().map((cell) => {
                   const value = cell.getValue();
@@ -193,7 +233,6 @@ function GridTableInner({
                   const isEditing =
                     edit.editingCell?.rowIndex === originalIndex &&
                     edit.editingCell?.columnId === field;
-                  const isEditable = edit.isEditMode && !isSystemColumn(field);
                   const validationError = !isSystemColumn(field)
                     ? edit.getValidationError(originalIndex, field)
                     : null;
@@ -222,25 +261,7 @@ function GridTableInner({
                         width: cell.column.getSize(),
                         textAlign: isNull ? 'center' : align,
                       }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        if (isSystemColumn(field)) {
-                          e.shiftKey
-                            ? callbacks.onRowRangeSelect(rowIndex)
-                            : callbacks.onRowToggle(rowIndex);
-                          return;
-                        }
-                        e.shiftKey
-                          ? callbacks.onCellRangeSelect(rowIndex, field)
-                          : callbacks.onCellClick(rowIndex, field);
-                      }}
-                      onContextMenu={(e) => openCellMenu(e, rowIndex, field)}
-                      onDoubleClick={() => {
-                        if (isEditable) {
-                          const cellValue = typeof value === 'string' ? value : null;
-                          callbacks.onStartEdit(originalIndex, field, cellValue);
-                        }
-                      }}
+                      data-field={field}
                     >
                       {isEditing ? (
                         <input

--- a/frontend/src/components/grid/ResultGrid.module.css
+++ b/frontend/src/components/grid/ResultGrid.module.css
@@ -2,7 +2,6 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  height: 100%;
   min-height: 0;
   overflow: hidden;
 }
@@ -341,9 +340,9 @@
   flex: 1 1 auto;
   overflow: auto;
   width: 100%;
-  height: 100%;
   min-height: 0;
   background-color: var(--bg-primary);
+  contain: strict;
 }
 
 .table {

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -358,10 +358,29 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     getScrollElement: () => tableContainerRef.current,
     estimateSize: () => 32,
     overscan: 10,
+    // WebView2 software compositing delays flex layout resolution,
+    // causing the container's clientHeight to be 0 on first measure.
+    // Provide a non-zero fallback so calculateRange returns items
+    // instead of null while ResizeObserver catches up.
+    initialRect: { width: 0, height: window.innerHeight },
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
   const virtualTotalSize = rowVirtualizer.getTotalSize();
   const lastVirtualIndex = virtualRows[virtualRows.length - 1]?.index ?? -1;
+
+  // --- Force virtualizer re-measure when container size changes ---
+  // WebView2 software compositing may delay layout; the built-in
+  // ResizeObserver inside @tanstack/react-virtual can miss the first
+  // resize if it fires before the element is observed.
+  useEffect(() => {
+    const el = tableContainerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver(() => {
+      rowVirtualizer.measure();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [rowVirtualizer]);
 
   // --- Reset scroll & UI state when switching query tabs ---
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally triggered by targetQueryId change
@@ -370,6 +389,10 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     if (tableContainerRef.current) {
       tableContainerRef.current.scrollLeft = 0;
     }
+    // Re-measure after paint to handle WebView2 layout delay
+    requestAnimationFrame(() => {
+      rowVirtualizer.measure();
+    });
     resetSelection();
     setSorting([]);
     setColumnFilters([]);

--- a/third_party/webview.h
+++ b/third_party/webview.h
@@ -225,7 +225,10 @@ private:
         // compositing prevents partial rendering failures in WebView2.
         auto options = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
         if (options) {
-            options->put_AdditionalBrowserArguments(L"--disable-gpu-compositing");
+            options->put_AdditionalBrowserArguments(
+                L"--disable-gpu-compositing "
+                L"--disable-renderer-backgrounding"
+            );
         }
 
         HRESULT hr = CreateCoreWebView2EnvironmentWithOptions(


### PR DESCRIPTION
- virtualizer initialRect に非ゼロ初期値を設定 (outerSize=0 防止)
- ResizeObserver で WebView2 レイアウト遅延後の再測定を保証
- CSS height:100% 除去でフレックスレイアウトのレース排除
- contain:strict でレイアウト再計算スコープを限定
- tbody イベント委譲で ~5000 ハンドラを 3 に削減
- WebView2 バックグラウンドスロットリング防止フラグ追加