### PR TITLE
chore: Vite 8ビルド警告を解消し不要なMonacoワーカーを除外

### DIFF
--- a/frontend/src/tests/config/monacoWorkerExclude.test.ts
+++ b/frontend/src/tests/config/monacoWorkerExclude.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+const workerManagerRE =
+  /monaco-editor[\\/]esm[\\/]vs[\\/]language[\\/](css|html|json|typescript)[\\/]workerManager\.js$/;
+
+const workerPattern =
+  /new Worker\(new URL\('[^']+\.worker\.js',\s*import\.meta\.url\),\s*\{[^}]*\}\)/g;
+
+describe('monacoWorkerExcludePlugin patterns', () => {
+  it.each(['css', 'html', 'json', 'typescript'])('%s workerManager matches', (lang) => {
+    const id = `node_modules/monaco-editor/esm/vs/language/${lang}/workerManager.js`;
+    expect(workerManagerRE.test(id)).toBe(true);
+  });
+
+  it('editor workerManager does NOT match', () => {
+    expect(workerManagerRE.test('node_modules/monaco-editor/esm/vs/editor/editor.worker.js')).toBe(
+      false
+    );
+  });
+
+  it('replaces new Worker(new URL(...)) pattern', () => {
+    const code = `createWorker: () => new Worker(new URL('css.worker.js', import.meta.url), { type: "module" })`;
+    const result = code.replace(
+      workerPattern,
+      '(() => { throw new Error("Worker not available"); })()'
+    );
+    expect(result).not.toContain('new Worker');
+    expect(result).toContain('throw new Error');
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,32 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
+
+/**
+ * Prevents Vite from bundling unused Monaco language workers (css, html, json, typescript).
+ * Only the base editor.worker is needed for SQL editing.
+ * Runs before vite:worker-import-meta-url to remove the `new Worker(new URL(...))` pattern.
+ */
+function monacoWorkerExcludePlugin(): Plugin {
+  const workerManagerRE =
+    /monaco-editor[\\/]esm[\\/]vs[\\/]language[\\/](css|html|json|typescript)[\\/]workerManager\.js$/;
+  return {
+    name: 'monaco-worker-exclude',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!workerManagerRE.test(id)) return null;
+      const transformed = code.replace(
+        /new Worker\(new URL\('[^']+\.worker\.js',\s*import\.meta\.url\),\s*\{[^}]*\}\)/g,
+        '(() => { throw new Error("Worker not available"); })()'
+      );
+      if (transformed !== code) return { code: transformed, map: null };
+      return null;
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), monacoWorkerExcludePlugin()],
   base: './', // Use relative paths for file:// protocol
   resolve: {
     alias: {
@@ -22,7 +45,7 @@ export default defineConfig({
     outDir: 'dist',
     sourcemap: 'hidden',
     cssMinify: 'lightningcss',
-    minify: 'esbuild',
+    minify: 'oxc',
     target: 'es2020',
     chunkSizeWarningLimit: 5000, // Monaco Editor vendor chunk is ~4.3MB
     rolldownOptions: {
@@ -31,6 +54,13 @@ export default defineConfig({
         entryFileNames: 'assets/[name]-[hash].js',
         chunkFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash].[ext]',
+        minify: {
+          compress: {
+            dropConsole: true,
+            dropDebugger: true,
+          },
+          mangle: true,
+        },
         manualChunks(id) {
           // Split node_modules into vendor chunks
           if (id.includes('node_modules')) {
@@ -62,11 +92,6 @@ export default defineConfig({
         },
       },
     },
-  },
-  esbuild: {
-    logOverride: { 'this-is-undefined-in-esm': 'silent' },
-    // Drop console and debugger in production
-    drop: process.env.NODE_ENV === 'production' ? ['console', 'debugger'] : [],
   },
   server: {
     port: 5173,


### PR DESCRIPTION
- esbuildブロックを削除しoxc/Rolldown minifyオプションに移行
- カスタムプラグインで未使用Monaco言語ワーカー4本を除外 (-10.8MB)
- ビルド時間57%短縮 (14.7s → 6.3s)