### PR TITLE
perf: ResultCacheにmove semantics・splice・heterogeneous lookupを導入

### DIFF
--- a/backend/database/result_cache.cpp
+++ b/backend/database/result_cache.cpp
@@ -5,6 +5,11 @@
 namespace velocitydb {
 
 void ResultCache::put(std::string_view key, const ResultSet& result) {
+    auto copy = result;
+    put(key, std::move(copy));
+}
+
+void ResultCache::put(std::string_view key, ResultSet&& result) {
     std::lock_guard lock(m_mutex);
 
     auto resultSize = estimateSize(result);
@@ -13,9 +18,7 @@ void ResultCache::put(std::string_view key, const ResultSet& result) {
         return;
     }
 
-    std::string keyStr(key);
-
-    if (auto it = m_cache.find(keyStr); it != m_cache.end()) {
+    if (auto it = m_cache.find(key); it != m_cache.end()) {
         m_currentSizeBytes -= it->second.sizeBytes;
         m_lruList.erase(it->second.lruIt);
         m_cache.erase(it);
@@ -23,31 +26,21 @@ void ResultCache::put(std::string_view key, const ResultSet& result) {
 
     evictIfNeeded(resultSize);
 
-    m_lruList.push_back(keyStr);
+    m_lruList.emplace_back(key);
     auto lruIt = std::prev(m_lruList.end());
-    m_cache[keyStr] = CachedResult{.data = result, .sizeBytes = resultSize, .lruIt = lruIt};
+    m_cache.emplace(std::string(key), CachedResult{.data = std::move(result), .sizeBytes = resultSize, .lruIt = lruIt});
     m_currentSizeBytes += resultSize;
 }
 
-std::optional<ResultSet> ResultCache::get(std::string_view key) {
+bool ResultCache::contains(std::string_view key) {
     std::lock_guard lock(m_mutex);
-
-    std::string keyStr(key);
-    if (auto it = m_cache.find(keyStr); it != m_cache.end()) {
-        m_lruList.erase(it->second.lruIt);
-        m_lruList.push_back(keyStr);
-        it->second.lruIt = std::prev(m_lruList.end());
-        return it->second.data;
-    }
-
-    return std::nullopt;
+    return m_cache.find(key) != m_cache.end();
 }
 
 void ResultCache::invalidate(std::string_view key) {
     std::lock_guard lock(m_mutex);
 
-    std::string keyStr(key);
-    if (auto it = m_cache.find(keyStr); it != m_cache.end()) {
+    if (auto it = m_cache.find(key); it != m_cache.end()) {
         m_currentSizeBytes -= it->second.sizeBytes;
         m_lruList.erase(it->second.lruIt);
         m_cache.erase(it);

--- a/backend/database/result_cache.h
+++ b/backend/database/result_cache.h
@@ -2,14 +2,25 @@
 
 #include "driver_interface.h"
 
+#include <functional>
 #include <list>
 #include <mutex>
-#include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 
 namespace velocitydb {
+
+struct TransparentStringHash {
+    using is_transparent = void;
+    size_t operator()(std::string_view sv) const noexcept { return std::hash<std::string_view>{}(sv); }
+};
+
+struct TransparentStringEqual {
+    using is_transparent = void;
+    bool operator()(std::string_view a, std::string_view b) const noexcept { return a == b; }
+};
 
 struct CachedResult {
     ResultSet data;
@@ -26,7 +37,19 @@ public:
     ResultCache& operator=(const ResultCache&) = delete;
 
     void put(std::string_view key, const ResultSet& result);
-    [[nodiscard]] std::optional<ResultSet> get(std::string_view key);
+    void put(std::string_view key, ResultSet&& result);
+
+    template <typename F>
+    auto getAndApply(std::string_view key, F&& fn) -> std::invoke_result_t<F, const ResultSet&> {
+        std::lock_guard lock(m_mutex);
+        if (auto it = m_cache.find(key); it != m_cache.end()) {
+            m_lruList.splice(m_lruList.end(), m_lruList, it->second.lruIt);
+            return fn(it->second.data);
+        }
+        return {};
+    }
+
+    [[nodiscard]] bool contains(std::string_view key);
     void invalidate(std::string_view key);
     void clear();
 
@@ -40,7 +63,7 @@ private:
     size_t m_maxSizeBytes;
     size_t m_currentSizeBytes = 0;
     mutable std::mutex m_mutex;
-    std::unordered_map<std::string, CachedResult> m_cache;
+    std::unordered_map<std::string, CachedResult, TransparentStringHash, TransparentStringEqual> m_cache;
     std::list<std::string> m_lruList;  // front=oldest, back=newest
 };
 

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -188,20 +188,23 @@ std::string QueryProvider::executeQuery(std::string_view params) {
         cacheKey.append(sqlQuery);
         bool selectQuery = SQLParser::isReadOnlyQuery(sqlQuery);
         if (useCache && selectQuery) {
-            if (auto cachedResult = m_resultCache->get(cacheKey); cachedResult.has_value()) {
-                return JsonUtils::successResponse(JsonUtils::serializeResultSet(*cachedResult, true));
+            if (auto cachedJson = m_resultCache->getAndApply(cacheKey, [](const ResultSet& rs) { return JsonUtils::serializeResultSet(rs, true); }); !cachedJson.empty()) {
+                return JsonUtils::successResponse(cachedJson);
             }
         }
 
         auto queryResult = driver->execute(sqlQuery);
 
-        if (useCache && selectQuery) {
-            m_resultCache->put(cacheKey, queryResult);
-        }
-
         std::string jsonResponse = JsonUtils::serializeResultSet(queryResult, false);
 
-        recordHistory(sqlQuery, connectionId, queryResult.executionTimeMs, true, {}, static_cast<int64_t>(queryResult.affectedRows));
+        if (useCache && selectQuery) {
+            auto execTimeMs = queryResult.executionTimeMs;
+            auto affectedRows = queryResult.affectedRows;
+            m_resultCache->put(cacheKey, std::move(queryResult));
+            recordHistory(sqlQuery, connectionId, execTimeMs, true, {}, affectedRows);
+        } else {
+            recordHistory(sqlQuery, connectionId, queryResult.executionTimeMs, true, {}, queryResult.affectedRows);
+        }
 
         return JsonUtils::successResponse(jsonResponse);
     } catch (const std::exception& e) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(TEST_SOURCES
     providers/test_utility_provider.cpp
     utils/test_sql_validation.cpp
     database/test_thread_pool.cpp
+    database/test_result_cache.cpp
 )
 
 add_executable(VelocityDBTests ${TEST_SOURCES})

--- a/tests/database/test_result_cache.cpp
+++ b/tests/database/test_result_cache.cpp
@@ -1,0 +1,180 @@
+#include <gtest/gtest.h>
+#include "database/result_cache.h"
+
+namespace velocitydb {
+namespace test {
+
+namespace {
+
+ResultSet makeResultSet(int numRows, int numCols) {
+    ResultSet rs;
+    rs.columns.reserve(static_cast<size_t>(numCols));
+    for (int c = 0; c < numCols; ++c) {
+        rs.columns.push_back(ColumnInfo{.name = "col" + std::to_string(c), .type = "VARCHAR"});
+    }
+    rs.rows.reserve(static_cast<size_t>(numRows));
+    for (int r = 0; r < numRows; ++r) {
+        ResultRow row;
+        row.values.reserve(static_cast<size_t>(numCols));
+        row.nullFlags.reserve(static_cast<size_t>(numCols));
+        for (int c = 0; c < numCols; ++c) {
+            row.values.push_back("val_" + std::to_string(r) + "_" + std::to_string(c));
+            row.nullFlags.push_back(false);
+        }
+        rs.rows.push_back(std::move(row));
+    }
+    rs.affectedRows = numRows;
+    return rs;
+}
+
+size_t measureItemSize() {
+    ResultCache probe{1024 * 1024};
+    probe.put("measure", makeResultSet(1, 1));
+    return probe.getCurrentSize();
+}
+
+}  // namespace
+
+class ResultCacheTest : public ::testing::Test {
+protected:
+    ResultCache cache{1024 * 1024};  // 1MB for testing
+};
+
+// #1: put/getAndApplyで値を保存・取得できる
+TEST_F(ResultCacheTest, PutAndGetReturnsStoredValue) {
+    auto rs = makeResultSet(2, 3);
+    cache.put("key1", rs);
+
+    auto colCount = cache.getAndApply("key1", [](const ResultSet& r) { return r.columns.size(); });
+    auto rowCount = cache.getAndApply("key1", [](const ResultSet& r) { return r.rows.size(); });
+    auto firstVal = cache.getAndApply("key1", [](const ResultSet& r) { return r.rows[0].values[0]; });
+
+    EXPECT_EQ(colCount, 3);
+    EXPECT_EQ(rowCount, 2);
+    EXPECT_EQ(firstVal, "val_0_0");
+}
+
+// #2: 存在しないキーは空を返す
+TEST_F(ResultCacheTest, GetMissingKeyReturnsEmpty) {
+    auto result = cache.getAndApply("nonexistent", [](const ResultSet& r) { return r.columns.size(); });
+    EXPECT_EQ(result, 0);
+}
+
+// #3: invalidateでキーを削除
+TEST_F(ResultCacheTest, InvalidateRemovesEntry) {
+    cache.put("key1", makeResultSet(1, 1));
+    ASSERT_TRUE(cache.contains("key1"));
+
+    cache.invalidate("key1");
+    EXPECT_FALSE(cache.contains("key1"));
+}
+
+// #4: clearで全削除
+TEST_F(ResultCacheTest, ClearRemovesAllEntries) {
+    cache.put("a", makeResultSet(1, 1));
+    cache.put("b", makeResultSet(1, 1));
+    cache.put("c", makeResultSet(1, 1));
+
+    cache.clear();
+
+    EXPECT_FALSE(cache.contains("a"));
+    EXPECT_FALSE(cache.contains("b"));
+    EXPECT_FALSE(cache.contains("c"));
+    EXPECT_EQ(cache.getCurrentSize(), 0);
+}
+
+// #5: LRU順でevict（最古が追い出される）
+TEST_F(ResultCacheTest, EvictsOldestEntryWhenFull) {
+    auto itemSize = measureItemSize();
+    ResultCache smallCache{itemSize * 3 - 1};
+    auto rs = makeResultSet(1, 1);
+
+    smallCache.put("first", rs);
+    smallCache.put("second", rs);
+    smallCache.put("third", rs);
+
+    EXPECT_FALSE(smallCache.contains("first"));
+    EXPECT_TRUE(smallCache.contains("third"));
+}
+
+// #6: getAndApplyでアクセス順が更新される
+TEST_F(ResultCacheTest, GetUpdatesLruOrder) {
+    auto itemSize = measureItemSize();
+    ResultCache smallCache{itemSize * 4 - 1};
+    auto rs = makeResultSet(1, 1);
+
+    smallCache.put("A", rs);
+    smallCache.put("B", rs);
+    smallCache.put("C", rs);
+
+    // 3件格納をサイズで確認（LRU順序を変えない）
+    ASSERT_EQ(smallCache.getCurrentSize(), itemSize * 3);
+
+    // AにアクセスしてLRU順更新 → LRU順: B, C, A
+    smallCache.getAndApply("A", [](const ResultSet&) { return true; });
+
+    // 4件目追加 → Bがevict（最古）
+    smallCache.put("D", rs);
+
+    EXPECT_FALSE(smallCache.contains("B"));
+    EXPECT_TRUE(smallCache.contains("A"));
+}
+
+// #7: 同一キー上書き
+TEST_F(ResultCacheTest, PutOverwritesExistingKey) {
+    cache.put("key1", makeResultSet(1, 1));
+    cache.put("key1", makeResultSet(3, 2));
+
+    auto rowCount = cache.getAndApply("key1", [](const ResultSet& r) { return r.rows.size(); });
+    auto colCount = cache.getAndApply("key1", [](const ResultSet& r) { return r.columns.size(); });
+    EXPECT_EQ(rowCount, 3);
+    EXPECT_EQ(colCount, 2);
+}
+
+// #8: サイズ追跡が正確
+TEST_F(ResultCacheTest, CurrentSizeTracksAccurately) {
+    EXPECT_EQ(cache.getCurrentSize(), 0);
+
+    cache.put("key1", makeResultSet(2, 2));
+    EXPECT_GT(cache.getCurrentSize(), 0);
+
+    cache.invalidate("key1");
+    EXPECT_EQ(cache.getCurrentSize(), 0);
+}
+
+// #9: putでResultSetがmoveされる（rvalue渡し）
+TEST_F(ResultCacheTest, PutMovesRvalueResultSet) {
+    auto rs = makeResultSet(5, 3);
+    auto originalSize = rs.rows.size();
+
+    cache.put("moved", std::move(rs));
+
+    // move元が空になったことで検証
+    EXPECT_TRUE(rs.rows.empty());
+
+    auto cachedSize = cache.getAndApply("moved", [](const ResultSet& r) { return r.rows.size(); });
+    EXPECT_EQ(cachedSize, originalSize);
+}
+
+// #10: getAndApplyがロック保持中にコールバック実行
+TEST_F(ResultCacheTest, GetAndApplyExecutesCallbackUnderLock) {
+    cache.put("ref", makeResultSet(2, 2));
+
+    auto result = cache.getAndApply("ref", [](const ResultSet& r) {
+        return std::string(r.rows[0].values[0]);
+    });
+    EXPECT_EQ(result, "val_0_0");
+}
+
+// #11: string_viewで直接検索可能
+TEST_F(ResultCacheTest, FindsWithStringView) {
+    cache.put("sv_test", makeResultSet(1, 1));
+
+    std::string_view sv = "sv_test";
+    EXPECT_TRUE(cache.contains(sv));
+    auto colCount = cache.getAndApply(sv, [](const ResultSet& r) { return r.columns.size(); });
+    EXPECT_EQ(colCount, 1);
+}
+
+}  // namespace test
+}  // namespace velocitydb


### PR DESCRIPTION
- put: rvalueオーバーロード追加でResultSetのO(n*m)コピーをO(1)moveに
- get→getAndApply: コールバック方式でロック保持中にシリアライズ完了（スレッド安全性確保）
- LRU更新: erase+push_back→spliceでノード再利用（alloc/dealloc除去）
- map検索: TransparentStringHash/Equalでstring_view直接検索（temp string除去）
- テスト: test_result_cache.cpp新規追加（11ケース）