### PR TITLE
perf: simdjsonパーサーをthread_local化しIPC毎のアロケーションを除去

### DIFF
--- a/backend/database/connection_utils.cpp
+++ b/backend/database/connection_utils.cpp
@@ -89,7 +89,7 @@ std::expected<std::string, std::string> buildConnectionString(const DatabaseConn
 
 std::expected<DatabaseConnectionParams, std::string> extractConnectionParams(std::string_view jsonParams) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(jsonParams);
 
         DatabaseConnectionParams result;
@@ -177,7 +177,7 @@ std::expected<DatabaseConnectionParams, std::string> extractConnectionParams(std
 
 std::expected<std::string, std::string> extractConnectionId(std::string_view jsonParams) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(jsonParams);
         auto result = doc["connectionId"].get_string();
         if (result.error()) {

--- a/backend/database/query_history.cpp
+++ b/backend/database/query_history.cpp
@@ -155,7 +155,7 @@ bool QueryHistory::load(std::string_view filepath) {
     }
 
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(jsonContent);
 
         if (!doc.is_array()) {

--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -120,7 +120,7 @@ void IPCHandler::registerRoutes() {
 
 std::string IPCHandler::dispatchRequest(std::string_view request) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(request);
 
         auto methodResult = doc["method"].get_string();

--- a/backend/providers/async_query_provider.cpp
+++ b/backend/providers/async_query_provider.cpp
@@ -20,7 +20,7 @@ AsyncQueryProvider::~AsyncQueryProvider() = default;
 
 std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -66,7 +66,7 @@ std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
 
 std::string AsyncQueryProvider::getAsyncQueryResult(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto queryIdResult = doc["queryId"].get_string();
@@ -159,7 +159,7 @@ std::string AsyncQueryProvider::getAsyncQueryResult(std::string_view params) {
 
 std::string AsyncQueryProvider::cancelAsyncQuery(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto queryIdResult = doc["queryId"].get_string();
@@ -175,7 +175,7 @@ std::string AsyncQueryProvider::cancelAsyncQuery(std::string_view params) {
 
 std::string AsyncQueryProvider::removeAsyncQuery(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto queryIdResult = doc["queryId"].get_string();

--- a/backend/providers/connection_provider.cpp
+++ b/backend/providers/connection_provider.cpp
@@ -87,7 +87,7 @@ std::string ConnectionProvider::connectAsync(std::string_view params) {
 
 std::string ConnectionProvider::getConnectResult(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
         auto requestIdResult = doc["requestId"].get_string();
         if (requestIdResult.error()) {
@@ -132,7 +132,7 @@ std::string ConnectionProvider::getConnectResult(std::string_view params) {
 
 std::string ConnectionProvider::cancelConnect(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
         auto requestIdResult = doc["requestId"].get_string();
         if (requestIdResult.error()) {

--- a/backend/providers/export_provider.cpp
+++ b/backend/providers/export_provider.cpp
@@ -24,7 +24,7 @@ std::vector<std::string> ExportProvider::getSupportedFormats() const {
 
 std::string ExportProvider::exportWithDriver(std::string_view params, std::string_view format) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();

--- a/backend/providers/io_provider.cpp
+++ b/backend/providers/io_provider.cpp
@@ -24,7 +24,7 @@ constexpr auto kBookmarksPath = "data/bookmarks.json";
 
 std::string IOProvider::writeFrontendLog(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto contentResult = doc["content"].get_string();
@@ -52,7 +52,7 @@ std::string IOProvider::writeFrontendLog(std::string_view params) {
 
 std::string IOProvider::saveQueryToFile(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto contentResult = doc["content"].get_string();
@@ -116,7 +116,7 @@ std::string IOProvider::loadQueryFromFile(std::string_view) {
 
 std::string IOProvider::browseFile(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         std::string filter = "All Files (*.*)\0*.*\0";
@@ -157,7 +157,7 @@ std::string IOProvider::getBookmarks(std::string_view) {
 
 std::string IOProvider::saveBookmark(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto idResult = doc["id"].get_string();
@@ -173,7 +173,7 @@ std::string IOProvider::saveBookmark(std::string_view params) {
         std::filesystem::path bookmarksPath(kBookmarksPath);
         std::filesystem::create_directories(bookmarksPath.parent_path());
 
-        simdjson::dom::parser existingParser;
+        thread_local static simdjson::dom::parser existingParser;
         std::string fileContent;
         simdjson::dom::array bookmarks;
         bool hasExisting = false;
@@ -235,7 +235,7 @@ std::string IOProvider::saveBookmark(std::string_view params) {
 
 std::string IOProvider::deleteBookmark(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto idResult = doc["id"].get_string();
@@ -254,7 +254,7 @@ std::string IOProvider::deleteBookmark(std::string_view params) {
             return JsonUtils::errorResponse(readResult.error());
         }
 
-        simdjson::dom::parser existingParser;
+        thread_local static simdjson::dom::parser existingParser;
         auto existingDoc = existingParser.parse(readResult.value());
         auto arrResult = existingDoc.get_array();
         if (arrResult.error()) [[unlikely]] {

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -47,7 +47,7 @@ std::string QueryProvider::executeQuery(std::string_view params) {
     std::string sqlQuery;
 
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -217,7 +217,7 @@ std::string QueryProvider::executeQuery(std::string_view params) {
 
 std::string QueryProvider::executeQueryPaginated(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -275,7 +275,7 @@ std::string QueryProvider::executeQueryPaginated(std::string_view params) {
 
 std::string QueryProvider::getRowCount(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -320,7 +320,7 @@ std::string QueryProvider::cancelQuery(std::string_view params) {
 
 std::string QueryProvider::filterResultSet(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -409,7 +409,7 @@ std::string QueryProvider::getQueryHistory(std::string_view) {
 
 std::string QueryProvider::removeQueryHistory(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
         auto idResult = doc["id"].get_string();
         if (idResult.error()) [[unlikely]] {
@@ -429,7 +429,7 @@ std::string QueryProvider::clearQueryHistory(std::string_view) {
 
 std::string QueryProvider::setQueryHistoryFavorite(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
         auto idResult = doc["id"].get_string();
         auto isFavoriteResult = doc["isFavorite"].get_bool();
@@ -445,7 +445,7 @@ std::string QueryProvider::setQueryHistoryFavorite(std::string_view params) {
 
 std::string QueryProvider::buildDataViewSql(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -477,7 +477,7 @@ std::string QueryProvider::buildDataViewSql(std::string_view params) {
 
 std::string QueryProvider::buildWhereClause(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -525,7 +525,7 @@ std::string QueryProvider::buildWhereClause(std::string_view params) {
 
 std::string QueryProvider::buildDmlStatements(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();

--- a/backend/providers/schema_provider.cpp
+++ b/backend/providers/schema_provider.cpp
@@ -153,7 +153,7 @@ std::string SchemaProvider::getColumns(std::string_view params) {
         return *cached;
     }
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -186,7 +186,7 @@ std::string SchemaProvider::getColumns(std::string_view params) {
 
 std::string SchemaProvider::getIndexes(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -217,7 +217,7 @@ std::string SchemaProvider::getIndexes(std::string_view params) {
 
 std::string SchemaProvider::getConstraints(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -248,7 +248,7 @@ std::string SchemaProvider::getConstraints(std::string_view params) {
 
 std::string SchemaProvider::getForeignKeys(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -283,7 +283,7 @@ std::string SchemaProvider::getForeignKeys(std::string_view params) {
 
 std::string SchemaProvider::getReferencingForeignKeys(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -318,7 +318,7 @@ std::string SchemaProvider::getReferencingForeignKeys(std::string_view params) {
 
 std::string SchemaProvider::getTriggers(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -350,7 +350,7 @@ std::string SchemaProvider::getTriggers(std::string_view params) {
 
 std::string SchemaProvider::getTableMetadata(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -389,7 +389,7 @@ std::string SchemaProvider::getTableMetadata(std::string_view params) {
 
 std::string SchemaProvider::getTableDDL(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
@@ -452,7 +452,7 @@ std::string SchemaProvider::getTableDDL(std::string_view params) {
 
 std::string SchemaProvider::getExecutionPlan(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();

--- a/backend/providers/search_provider.cpp
+++ b/backend/providers/search_provider.cpp
@@ -17,7 +17,7 @@ SearchProvider::~SearchProvider() = default;
 
 std::string SearchProvider::searchObjects(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -67,7 +67,7 @@ std::string SearchProvider::searchObjects(std::string_view params) {
 
 std::string SearchProvider::quickSearch(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();

--- a/backend/providers/settings_provider.cpp
+++ b/backend/providers/settings_provider.cpp
@@ -172,7 +172,7 @@ std::string SettingsProvider::getSettings() {
 
 std::string SettingsProvider::updateSettings(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         AppSettings settings = m_settingsManager->getSettings();
@@ -249,7 +249,7 @@ std::string SettingsProvider::getConnectionProfiles() {
 
 std::string SettingsProvider::saveConnectionProfile(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         ConnectionProfile profile;
@@ -344,7 +344,7 @@ std::string SettingsProvider::saveConnectionProfile(std::string_view params) {
 
 std::string SettingsProvider::deleteConnectionProfile(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto profileIdResult = doc["id"].get_string();
@@ -363,7 +363,7 @@ std::string SettingsProvider::deleteConnectionProfile(std::string_view params) {
 
 std::string SettingsProvider::getProfilePassword(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto idResult = doc["id"].get_string();
@@ -385,7 +385,7 @@ std::string SettingsProvider::getProfilePassword(std::string_view params) {
 
 std::string SettingsProvider::getSshPassword(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto idResult = doc["id"].get_string();
@@ -407,7 +407,7 @@ std::string SettingsProvider::getSshPassword(std::string_view params) {
 
 std::string SettingsProvider::getSshKeyPassphrase(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto idResult = doc["id"].get_string();
@@ -439,7 +439,7 @@ std::string SettingsProvider::getSessionState() {
 
 std::string SettingsProvider::saveSessionState(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         SessionState state = m_sessionManager->getState();

--- a/backend/providers/transaction_provider.cpp
+++ b/backend/providers/transaction_provider.cpp
@@ -15,7 +15,7 @@ TransactionProvider::~TransactionProvider() = default;
 
 void TransactionProvider::cleanupConnection(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
         auto idResult = doc["connectionId"].get_string();
         if (idResult.error())
@@ -29,7 +29,7 @@ void TransactionProvider::cleanupConnection(std::string_view params) {
 
 std::string TransactionProvider::beginTransaction(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -60,7 +60,7 @@ std::string TransactionProvider::beginTransaction(std::string_view params) {
 
 std::string TransactionProvider::commitTransaction(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();
@@ -85,7 +85,7 @@ std::string TransactionProvider::commitTransaction(std::string_view params) {
 
 std::string TransactionProvider::rollbackTransaction(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto connectionIdResult = doc["connectionId"].get_string();

--- a/backend/providers/utility_provider.cpp
+++ b/backend/providers/utility_provider.cpp
@@ -55,7 +55,7 @@ UtilityProvider& UtilityProvider::operator=(UtilityProvider&&) noexcept = defaul
 
 std::string UtilityProvider::uppercaseKeywords(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         auto sqlResult = doc["sql"].get_string();
@@ -73,7 +73,7 @@ std::string UtilityProvider::uppercaseKeywords(std::string_view params) {
 
 std::string UtilityProvider::parseERDiagram(std::string_view params) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
         std::string content;

--- a/backend/webview_app.cpp
+++ b/backend/webview_app.cpp
@@ -19,7 +19,7 @@ namespace {
 // webview's bind passes arguments as a JSON array, e.g., ["arg1", "arg2"]
 std::string extractFirstArgument(const std::string& jsonArray) {
     try {
-        simdjson::dom::parser parser;
+        thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(jsonArray);
         auto arr = doc.get_array();
         if (arr.error()) {


### PR DESCRIPTION
- 14ファイル52箇所で simdjson::dom::parser のローカル生成を `thread_local static` に変更
- パーサー内部バッファの再利用によりIPC呼び出し毎の `alloc/dealloc` を解消