### PR TITLE
perf: JSON解析時の `string_view` 活用で `simdjson` → `std::string` コピーを削減

### DIFF
--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -129,9 +129,9 @@ std::string IPCHandler::dispatchRequest(std::string_view request) {
         }
         auto method = methodResult.value();
 
-        std::string params;
+        std::string_view params;
         if (auto paramsResult = doc["params"].get_string(); !paramsResult.error()) {
-            params = std::string(paramsResult.value());
+            params = paramsResult.value();
         }
 
         if (auto route = m_routes.find(std::string(method)); route != m_routes.end()) [[likely]] {

--- a/backend/providers/async_query_provider.cpp
+++ b/backend/providers/async_query_provider.cpp
@@ -28,8 +28,8 @@ std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
         if (connectionIdResult.error() || sqlQueryResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or sql");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto sqlQuery = std::string(sqlQueryResult.value());
+        std::string_view connectionId = connectionIdResult.value();
+        std::string_view sqlQuery = sqlQueryResult.value();
 
         auto driver = m_connections.getQueryDriver(connectionId);
         if (!driver) [[unlikely]] {
@@ -45,8 +45,7 @@ std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
                 return JsonUtils::errorResponse("Connection parameters not found for psql delegation");
             }
             auto connInfo = toPsqlConnectionInfo(*connParams);
-            auto sqlCopy = std::string(sqlQuery);
-            queryId = m_asyncExecutor->submitTask([connInfo = std::move(connInfo), sqlCopy = std::move(sqlCopy)]() -> QueryResultVariant {
+            queryId = m_asyncExecutor->submitTask([connInfo = std::move(connInfo), sqlCopy = std::string(sqlQuery)]() -> QueryResultVariant {
                 auto result = executePsql(connInfo, sqlCopy);
                 if (!result)
                     throw std::runtime_error(result.error());
@@ -57,7 +56,7 @@ std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
         if (queryId.empty())
             queryId = m_asyncExecutor->submitQuery(driver, sqlQuery);
 
-        m_queryMeta[queryId] = {.connectionId = connectionId, .sql = truncateHistorySql(sqlQuery)};
+        m_queryMeta[queryId] = {.connectionId = std::string(connectionId), .sql = truncateHistorySql(sqlQuery)};
         return JsonUtils::successResponse(std::format(R"({{"queryId":"{}"}})", queryId));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
@@ -166,7 +165,7 @@ std::string AsyncQueryProvider::cancelAsyncQuery(std::string_view params) {
         if (queryIdResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required field: queryId");
         }
-        bool cancelled = m_asyncExecutor->cancelQuery(std::string(queryIdResult.value()));
+        bool cancelled = m_asyncExecutor->cancelQuery(queryIdResult.value());
         return JsonUtils::successResponse(std::format(R"({{"cancelled":{}}})", cancelled ? "true" : "false"));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());

--- a/backend/providers/export_provider.cpp
+++ b/backend/providers/export_provider.cpp
@@ -33,9 +33,9 @@ std::string ExportProvider::exportWithDriver(std::string_view params, std::strin
         if (connectionIdResult.error() || filepathResult.error() || sqlQueryResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId, filepath, or sql");
         }
-        auto connectionId = std::string(connectionIdResult.value());
+        std::string_view connectionId = connectionIdResult.value();
         auto filepath = std::string(filepathResult.value());
-        auto sqlQuery = std::string(sqlQueryResult.value());
+        std::string_view sqlQuery = sqlQueryResult.value();
 
         if (!SQLParser::isReadOnlyQuery(sqlQuery)) [[unlikely]] {
             return JsonUtils::errorResponse("Export only supports SELECT queries");

--- a/backend/providers/io_provider.cpp
+++ b/backend/providers/io_provider.cpp
@@ -166,9 +166,9 @@ std::string IOProvider::saveBookmark(std::string_view params) {
         if (idResult.error() || nameResult.error() || contentResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: id, name, or content");
         }
-        auto id = std::string(idResult.value());
-        auto name = std::string(nameResult.value());
-        auto content = std::string(contentResult.value());
+        std::string_view id = idResult.value();
+        std::string_view name = nameResult.value();
+        std::string_view content = contentResult.value();
 
         std::filesystem::path bookmarksPath(kBookmarksPath);
         std::filesystem::create_directories(bookmarksPath.parent_path());
@@ -198,7 +198,7 @@ std::string IOProvider::saveBookmark(std::string_view params) {
                 auto bookmarkIdResult = bookmark["id"].get_string();
                 if (bookmarkIdResult.error())
                     continue;
-                auto bookmarkId = std::string(bookmarkIdResult.value());
+                std::string_view bookmarkId = bookmarkIdResult.value();
 
                 if (!first)
                     json += ",";
@@ -242,7 +242,7 @@ std::string IOProvider::deleteBookmark(std::string_view params) {
         if (idResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required field: id");
         }
-        auto id = std::string(idResult.value());
+        std::string_view id = idResult.value();
 
         std::filesystem::path bookmarksPath(kBookmarksPath);
         if (!std::filesystem::exists(bookmarksPath)) {
@@ -268,7 +268,7 @@ std::string IOProvider::deleteBookmark(std::string_view params) {
             auto bookmarkIdResult = bookmark["id"].get_string();
             if (bookmarkIdResult.error())
                 continue;
-            auto bookmarkId = std::string(bookmarkIdResult.value());
+            std::string_view bookmarkId = bookmarkIdResult.value();
             if (bookmarkId != id) {
                 if (!first)
                     json += ",";

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -31,10 +31,10 @@ QueryProvider::QueryProvider(IConnectionProvider& connections, QueryHistory& que
 
 QueryProvider::~QueryProvider() = default;
 
-void QueryProvider::recordHistory(const std::string& sql, const std::string& connectionId, double execTimeMs, bool success, std::string_view errorMsg, int64_t affectedRows) {
+void QueryProvider::recordHistory(std::string_view sql, std::string_view connectionId, double execTimeMs, bool success, std::string_view errorMsg, int64_t affectedRows) {
     m_queryHistory.add({.id = generateHistoryId(),
                         .sql = truncateHistorySql(sql),
-                        .connectionId = connectionId,
+                        .connectionId = std::string(connectionId),
                         .executionTimeMs = execTimeMs,
                         .success = success,
                         .errorMessage = std::string(errorMsg),
@@ -43,8 +43,8 @@ void QueryProvider::recordHistory(const std::string& sql, const std::string& con
 }
 
 std::string QueryProvider::executeQuery(std::string_view params) {
-    std::string connectionId;
-    std::string sqlQuery;
+    std::string_view connectionId;
+    std::string_view sqlQuery;
 
     try {
         thread_local static simdjson::dom::parser parser;
@@ -55,8 +55,8 @@ std::string QueryProvider::executeQuery(std::string_view params) {
         if (connectionIdResult.error() || sqlQueryResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or sql");
         }
-        connectionId = std::string(connectionIdResult.value());
-        sqlQuery = std::string(sqlQueryResult.value());
+        connectionId = connectionIdResult.value();
+        sqlQuery = sqlQueryResult.value();
 
         auto driver = m_connections.getQueryDriver(connectionId);
         if (!driver) [[unlikely]] {
@@ -225,8 +225,8 @@ std::string QueryProvider::executeQueryPaginated(std::string_view params) {
         if (connectionIdResult.error() || sqlQueryResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or sql");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto sqlQuery = std::string(sqlQueryResult.value());
+        std::string_view connectionId = connectionIdResult.value();
+        std::string_view sqlQuery = sqlQueryResult.value();
 
         int64_t startRow = 0;
         int64_t endRow = 100;
@@ -247,7 +247,7 @@ std::string QueryProvider::executeQueryPaginated(std::string_view params) {
                 if (!colId.error() && !sort.error()) {
                     if (!sortClauses.empty())
                         sortClauses += ", ";
-                    sortClauses += formatter->quoteIdentifier(std::string(colId.value())) + " " + (sort.value() == std::string_view("asc") ? "ASC" : "DESC");
+                    sortClauses += formatter->quoteIdentifier(colId.value()) + " " + (sort.value() == std::string_view("asc") ? "ASC" : "DESC");
                 }
             }
             if (!sortClauses.empty())
@@ -263,7 +263,7 @@ std::string QueryProvider::executeQueryPaginated(std::string_view params) {
         if (orderByClause.empty()) {
             paginatedQuery = formatter->paginateQuery(sqlQuery, startRow, endRow - startRow);
         } else {
-            paginatedQuery = formatter->paginateQuery(sqlQuery + orderByClause, startRow, endRow - startRow);
+            paginatedQuery = formatter->paginateQuery(std::string(sqlQuery) + orderByClause, startRow, endRow - startRow);
         }
 
         auto queryResult = driver->execute(paginatedQuery);
@@ -283,8 +283,8 @@ std::string QueryProvider::getRowCount(std::string_view params) {
         if (connectionIdResult.error() || sqlQueryResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or sql");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto sqlQuery = std::string(sqlQueryResult.value());
+        std::string_view connectionId = connectionIdResult.value();
+        std::string_view sqlQuery = sqlQueryResult.value();
 
         auto driver = m_connections.getQueryDriver(connectionId);
         if (!driver) [[unlikely]] {
@@ -331,10 +331,10 @@ std::string QueryProvider::filterResultSet(std::string_view params) {
         if (connectionIdResult.error() || sqlQueryResult.error() || columnIndexResult.error() || filterTypeResult.error() || filterValueResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId, sql, columnIndex, filterType, or filterValue");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto sqlQuery = std::string(sqlQueryResult.value());
+        std::string_view connectionId = connectionIdResult.value();
+        std::string_view sqlQuery = sqlQueryResult.value();
         auto columnIndex = columnIndexResult.value();
-        auto filterType = std::string(filterTypeResult.value());
+        std::string_view filterType = filterTypeResult.value();
         auto filterValue = std::string(filterValueResult.value());
 
         auto driver = m_connections.getQueryDriver(connectionId);
@@ -454,8 +454,8 @@ std::string QueryProvider::buildDataViewSql(std::string_view params) {
         if (connectionIdResult.error() || tableNameResult.error() || limitResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId, tableName, or limit");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto tableName = std::string(tableNameResult.value());
+        std::string_view connectionId = connectionIdResult.value();
+        std::string_view tableName = tableNameResult.value();
         auto limit = std::max(limitResult.value(), int64_t{0});
 
         auto driverType = m_connections.getDriverType(connectionId);
@@ -485,7 +485,7 @@ std::string QueryProvider::buildWhereClause(std::string_view params) {
         if (connectionIdResult.error() || conditionsResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or conditions");
         }
-        auto connectionId = std::string(connectionIdResult.value());
+        std::string_view connectionId = connectionIdResult.value();
 
         auto driverType = m_connections.getDriverType(connectionId);
         auto formatter = DriverFactory::createSqlFormattable(driverType);
@@ -500,7 +500,7 @@ std::string QueryProvider::buildWhereClause(std::string_view params) {
                 whereClause += " AND ";
             }
 
-            auto quotedCol = formatter->quoteIdentifier(std::string(columnResult.value()));
+            auto quotedCol = formatter->quoteIdentifier(columnResult.value());
 
             // null → IS NULL, string → quoted literal, numeric → unquoted
             auto valueEl = condition["value"];
@@ -534,9 +534,9 @@ std::string QueryProvider::buildDmlStatements(std::string_view params) {
         if (connectionIdResult.error() || tableResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or table");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto schema = schemaResult.error() ? std::string() : std::string(schemaResult.value());
-        auto table = std::string(tableResult.value());
+        std::string_view connectionId = connectionIdResult.value();
+        std::string_view schema = schemaResult.error() ? std::string_view{} : schemaResult.value();
+        std::string_view table = tableResult.value();
 
         auto driverType = m_connections.getDriverType(connectionId);
         auto formatter = DriverFactory::createSqlFormattable(driverType);
@@ -575,7 +575,7 @@ std::string QueryProvider::buildDmlStatements(std::string_view params) {
                 for (auto field : changesObj.value()) {
                     if (!setClauses.empty())
                         setClauses += ", ";
-                    auto col = formatter->quoteIdentifier(std::string(field.key));
+                    auto col = formatter->quoteIdentifier(field.key);
                     if (field.value.is_null()) {
                         setClauses += col + " = NULL";
                     } else if (auto v = field.value.get_string(); !v.error()) {
@@ -590,7 +590,7 @@ std::string QueryProvider::buildDmlStatements(std::string_view params) {
                 auto buildWhere = [&](std::string_view colName) {
                     if (!whereClauses.empty())
                         whereClauses += " AND ";
-                    auto col = formatter->quoteIdentifier(std::string(colName));
+                    auto col = formatter->quoteIdentifier(colName);
                     // Use original value for the WHERE
                     if (!originalObj.error()) {
                         auto origVal = originalObj.value()[colName];
@@ -631,7 +631,7 @@ std::string QueryProvider::buildDmlStatements(std::string_view params) {
                         columns += ", ";
                         values += ", ";
                     }
-                    columns += formatter->quoteIdentifier(std::string(field.key));
+                    columns += formatter->quoteIdentifier(field.key);
                     if (field.value.is_null()) {
                         values += "NULL";
                     } else if (auto v = field.value.get_string(); !v.error()) {
@@ -658,7 +658,7 @@ std::string QueryProvider::buildDmlStatements(std::string_view params) {
                 auto buildWhere = [&](std::string_view colName) {
                     if (!whereClauses.empty())
                         whereClauses += " AND ";
-                    auto col = formatter->quoteIdentifier(std::string(colName));
+                    auto col = formatter->quoteIdentifier(colName);
                     auto val = obj.value()[colName];
                     if (val.is_null() || val.error()) {
                         whereClauses += col + " IS NULL";

--- a/backend/providers/query_provider.h
+++ b/backend/providers/query_provider.h
@@ -41,7 +41,7 @@ public:
     [[nodiscard]] std::string buildDmlStatements(std::string_view params) override;
 
 private:
-    void recordHistory(const std::string& sql, const std::string& connectionId, double execTimeMs, bool success, std::string_view errorMsg = {}, int64_t affectedRows = 0);
+    void recordHistory(std::string_view sql, std::string_view connectionId, double execTimeMs, bool success, std::string_view errorMsg = {}, int64_t affectedRows = 0);
 
     IConnectionProvider& m_connections;
     std::unique_ptr<ResultCache> m_resultCache;

--- a/backend/providers/schema_provider.cpp
+++ b/backend/providers/schema_provider.cpp
@@ -49,11 +49,11 @@ struct TableQueryParams {
     if (connectionIdResult.error() || tableNameResult.error()) [[unlikely]]
         return std::unexpected("Missing required fields: connectionId or table");
 
-    auto tableName = std::string(tableNameResult.value());
+    std::string_view tableName = tableNameResult.value();
     if (!isValidIdentifier(tableName)) [[unlikely]]
         return std::unexpected("Invalid table name");
 
-    auto connectionId = std::string(connectionIdResult.value());
+    std::string_view connectionId = connectionIdResult.value();
     auto driver = connections.getMetadataDriver(connectionId);
     if (!driver) [[unlikely]]
         return std::unexpected(std::format("Connection not found: {}", connectionId));
@@ -460,8 +460,8 @@ std::string SchemaProvider::getExecutionPlan(std::string_view params) {
         if (connectionIdResult.error() || sqlQueryResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or sql");
         }
-        auto connectionId = std::string(connectionIdResult.value());
-        auto sqlQuery = std::string(sqlQueryResult.value());
+        std::string_view connectionId = connectionIdResult.value();
+        std::string_view sqlQuery = sqlQueryResult.value();
         bool actualPlan = false;
         if (auto actual = doc["actual"].get_bool(); !actual.error())
             actualPlan = actual.value();

--- a/backend/providers/search_provider.cpp
+++ b/backend/providers/search_provider.cpp
@@ -25,7 +25,7 @@ std::string SearchProvider::searchObjects(std::string_view params) {
         if (connectionIdResult.error() || patternResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or pattern");
         }
-        auto connectionId = std::string(connectionIdResult.value());
+        std::string_view connectionId = connectionIdResult.value();
         auto pattern = std::string(patternResult.value());
 
         auto driver = m_connections.getMetadataDriver(connectionId);
@@ -75,7 +75,7 @@ std::string SearchProvider::quickSearch(std::string_view params) {
         if (connectionIdResult.error() || prefixResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or prefix");
         }
-        auto connectionId = std::string(connectionIdResult.value());
+        std::string_view connectionId = connectionIdResult.value();
         auto prefix = std::string(prefixResult.value());
         int limit = 20;
         if (auto val = doc["limit"].get_int64(); !val.error())

--- a/backend/providers/utility_provider.cpp
+++ b/backend/providers/utility_provider.cpp
@@ -62,7 +62,7 @@ std::string UtilityProvider::uppercaseKeywords(std::string_view params) {
         if (sqlResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing sql field");
         }
-        std::string sqlQuery = std::string(sqlResult.value());
+        std::string_view sqlQuery = sqlResult.value();
 
         auto uppercasedSQL = m_sqlFormatter->uppercaseKeywords(sqlQuery);
         return JsonUtils::successResponse(std::format(R"({{"sql":"{}"}})", JsonUtils::escapeString(uppercasedSQL)));


### PR DESCRIPTION
thread_localパーサーのバッファ寿命を利用し、`pass-through` 変数約30箇所を `std::string_view` に変更。 `quoteIdentifier` 等の不要な `std::string()` ラップも除去。