### PR TITLE
refactor: ファイルI/O・非同期操作のbool戻り値を `std::expected` に統一

### DIFF
--- a/backend/database/async_connection_executor.cpp
+++ b/backend/database/async_connection_executor.cpp
@@ -111,12 +111,12 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
     return requestId;
 }
 
-bool AsyncConnectionExecutor::cancelConnect(std::string_view requestId) {
+std::expected<void, std::string> AsyncConnectionExecutor::cancelConnect(std::string_view requestId) {
     std::lock_guard lock(m_mutex);
 
     auto iter = m_tasks.find(std::string(requestId));
     if (iter == m_tasks.end()) {
-        return false;
+        return std::unexpected(std::format("Connection request not found: {}", requestId));
     }
 
     auto& task = iter->second;
@@ -124,10 +124,10 @@ bool AsyncConnectionExecutor::cancelConnect(std::string_view requestId) {
     if (status == ConnectStatus::Pending) {
         task->cancelled.store(true, std::memory_order_release);
         task->status = ConnectStatus::Cancelled;
-        return true;
+        return {};
     }
 
-    return false;
+    return std::unexpected("Connection request is not pending");
 }
 
 std::expected<AsyncConnectionExecutor::ConnectedDrivers, ConnectResult> AsyncConnectionExecutor::getResultAndConsume(std::string_view requestId) {

--- a/backend/database/async_connection_executor.h
+++ b/backend/database/async_connection_executor.h
@@ -40,7 +40,7 @@ public:
     [[nodiscard]] std::string submitConnect(DatabaseConnectionParams params);
 
     /// Cancel a pending/running connection request.
-    bool cancelConnect(std::string_view requestId);
+    [[nodiscard]] std::expected<void, std::string> cancelConnect(std::string_view requestId);
 
     /// Get the connected drivers (query + metadata) after successful connection.
     struct ConnectedDrivers {

--- a/backend/database/async_query_executor.cpp
+++ b/backend/database/async_query_executor.cpp
@@ -209,12 +209,12 @@ AsyncQueryResult AsyncQueryExecutor::getQueryResult(std::string_view queryId) {
     return result;
 }
 
-bool AsyncQueryExecutor::cancelQuery(std::string_view queryId) {
+std::expected<void, std::string> AsyncQueryExecutor::cancelQuery(std::string_view queryId) {
     std::lock_guard lock(m_mutex);
 
     auto iter = m_queries.find(std::string(queryId));
     if (iter == m_queries.end()) {
-        return false;
+        return std::unexpected(std::format("Query not found: {}", queryId));
     }
 
     auto& task = iter->second;
@@ -223,10 +223,10 @@ bool AsyncQueryExecutor::cancelQuery(std::string_view queryId) {
         task->driver->cancel();
         task->status = QueryStatus::Cancelled;
         task->endTime = std::chrono::steady_clock::now();
-        return true;
+        return {};
     }
 
-    return false;
+    return std::unexpected("Query is not running");
 }
 
 bool AsyncQueryExecutor::isQueryRunning(std::string_view queryId) const {
@@ -240,18 +240,18 @@ bool AsyncQueryExecutor::isQueryRunning(std::string_view queryId) const {
     return iter->second->status == QueryStatus::Running;
 }
 
-bool AsyncQueryExecutor::removeQuery(std::string_view queryId) {
+std::expected<void, std::string> AsyncQueryExecutor::removeQuery(std::string_view queryId) {
     std::lock_guard lock(m_mutex);
     auto it = m_queries.find(std::string(queryId));
     if (it == m_queries.end()) {
-        return false;
+        return std::unexpected(std::format("Query not found: {}", queryId));
     }
     auto status = it->second->status.load();
     if (status == QueryStatus::Pending || status == QueryStatus::Running) {
-        return false;
+        return std::unexpected("Cannot remove a running query");
     }
     m_queries.erase(it);
-    return true;
+    return {};
 }
 
 std::vector<std::string> AsyncQueryExecutor::getActiveQueryIds() const {

--- a/backend/database/async_query_executor.h
+++ b/backend/database/async_query_executor.h
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <expected>
 #include <functional>
 #include <future>
 #include <memory>
@@ -58,13 +59,13 @@ public:
     [[nodiscard]] AsyncQueryResult getQueryResult(std::string_view queryId);
 
     /// Cancels a running query
-    bool cancelQuery(std::string_view queryId);
+    [[nodiscard]] std::expected<void, std::string> cancelQuery(std::string_view queryId);
 
     /// Checks if a query is still running
     [[nodiscard]] bool isQueryRunning(std::string_view queryId) const;
 
-    /// Removes completed query from tracking (cleanup). Returns true if the query existed.
-    [[nodiscard]] bool removeQuery(std::string_view queryId);
+    /// Removes completed query from tracking (cleanup)
+    [[nodiscard]] std::expected<void, std::string> removeQuery(std::string_view queryId);
 
     /// Gets all active query IDs
     [[nodiscard]] std::vector<std::string> getActiveQueryIds() const;

--- a/backend/database/query_history.cpp
+++ b/backend/database/query_history.cpp
@@ -97,14 +97,14 @@ void QueryHistory::clear() {
     std::erase_if(m_history, [](const HistoryItem& h) { return !h.isFavorite; });
 }
 
-bool QueryHistory::save(std::string_view filepath) const {
+std::expected<void, std::string> QueryHistory::save(std::string_view filepath) const {
     std::lock_guard lock(m_mutex);
 
     auto path = std::string(filepath);
     std::ofstream outFile;
     outFile.open(path);
     if (!outFile.is_open()) [[unlikely]] {
-        return false;
+        return std::unexpected(std::format("Failed to open history file for writing: {}", filepath));
     }
 
     outFile << "[\n";
@@ -134,16 +134,19 @@ bool QueryHistory::save(std::string_view filepath) const {
     }
     outFile << "]\n";
 
-    return true;
+    if (!outFile.good()) [[unlikely]] {
+        return std::unexpected(std::format("Failed to write history file: {}", filepath));
+    }
+    return {};
 }
 
-bool QueryHistory::load(std::string_view filepath) {
+std::expected<void, std::string> QueryHistory::load(std::string_view filepath) {
     std::lock_guard lock(m_mutex);
 
     std::string path(filepath);
     std::ifstream inFile(path);
     if (!inFile.is_open()) [[unlikely]] {
-        return false;
+        return std::unexpected(std::format("Failed to open history file: {}", filepath));
     }
 
     std::stringstream buffer;
@@ -151,7 +154,7 @@ bool QueryHistory::load(std::string_view filepath) {
     std::string jsonContent = buffer.str();
 
     if (jsonContent.empty()) {
-        return true;  // Empty file is valid
+        return {};  // Empty file is valid
     }
 
     try {
@@ -159,7 +162,7 @@ bool QueryHistory::load(std::string_view filepath) {
         auto doc = parser.parse(jsonContent);
 
         if (!doc.is_array()) {
-            return false;
+            return std::unexpected("Invalid history file: expected JSON array");
         }
 
         m_history.clear();
@@ -198,9 +201,9 @@ bool QueryHistory::load(std::string_view filepath) {
             m_history.push_back(std::move(historyItem));
         }
 
-        return true;
-    } catch (...) {
-        return false;
+        return {};
+    } catch (const std::exception& e) {
+        return std::unexpected(std::format("Failed to parse history file: {}", e.what()));
     }
 }
 

--- a/backend/database/query_history.h
+++ b/backend/database/query_history.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <expected>
 #include <format>
 #include <mutex>
 #include <optional>
@@ -61,8 +62,8 @@ public:
     void remove(std::string_view id);
     void clear();
 
-    [[nodiscard]] bool save(std::string_view filepath) const;
-    [[nodiscard]] bool load(std::string_view filepath);
+    [[nodiscard]] std::expected<void, std::string> save(std::string_view filepath) const;
+    [[nodiscard]] std::expected<void, std::string> load(std::string_view filepath);
 
 private:
     size_t m_maxItems;

--- a/backend/providers/async_query_provider.cpp
+++ b/backend/providers/async_query_provider.cpp
@@ -165,7 +165,7 @@ std::string AsyncQueryProvider::cancelAsyncQuery(std::string_view params) {
         if (queryIdResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required field: queryId");
         }
-        bool cancelled = m_asyncExecutor->cancelQuery(queryIdResult.value());
+        bool cancelled = m_asyncExecutor->cancelQuery(queryIdResult.value()).has_value();
         return JsonUtils::successResponse(std::format(R"({{"cancelled":{}}})", cancelled ? "true" : "false"));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
@@ -182,7 +182,7 @@ std::string AsyncQueryProvider::removeAsyncQuery(std::string_view params) {
             return JsonUtils::errorResponse("Missing required field: queryId");
         }
         auto qid = std::string(queryIdResult.value());
-        bool removed = m_asyncExecutor->removeQuery(qid);
+        bool removed = m_asyncExecutor->removeQuery(qid).has_value();
         m_queryMeta.erase(qid);
         return JsonUtils::successResponse(std::format(R"({{"removed":{}}})", removed ? "true" : "false"));
     } catch (const std::exception& e) {

--- a/backend/providers/connection_provider.cpp
+++ b/backend/providers/connection_provider.cpp
@@ -139,7 +139,7 @@ std::string ConnectionProvider::cancelConnect(std::string_view params) {
             return JsonUtils::errorResponse("Missing requestId field");
         }
 
-        m_asyncExecutor->cancelConnect(std::string(requestIdResult.value()));
+        (void)m_asyncExecutor->cancelConnect(requestIdResult.value());
         return JsonUtils::successResponse("{}");
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());

--- a/backend/providers/settings_provider.cpp
+++ b/backend/providers/settings_provider.cpp
@@ -152,8 +152,8 @@ namespace {
 }  // namespace
 
 SettingsProvider::SettingsProvider() : m_settingsManager(std::make_unique<SettingsManager>()), m_sessionManager(std::make_unique<SessionManager>()) {
-    m_settingsManager->load();
-    m_sessionManager->load();
+    (void)m_settingsManager->load();
+    (void)m_sessionManager->load();
 }
 
 SettingsProvider::~SettingsProvider() = default;
@@ -229,7 +229,7 @@ std::string SettingsProvider::updateSettings(std::string_view params) {
         }
 
         m_settingsManager->updateSettings(settings);
-        m_settingsManager->save();
+        (void)m_settingsManager->save();
 
         return JsonUtils::successResponse(R"({"saved":true})");
     } catch (const std::exception& e) {
@@ -334,7 +334,7 @@ std::string SettingsProvider::saveConnectionProfile(std::string_view params) {
             }
         }
 
-        m_settingsManager->save();
+        (void)m_settingsManager->save();
 
         return JsonUtils::successResponse(std::format(R"({{"id":"{}"}})", JsonUtils::escapeString(profile.id)));
     } catch (const std::exception& e) {
@@ -353,7 +353,7 @@ std::string SettingsProvider::deleteConnectionProfile(std::string_view params) {
         }
         auto profileId = std::string(profileIdResult.value());
         m_settingsManager->removeConnectionProfile(profileId);
-        m_settingsManager->save();
+        (void)m_settingsManager->save();
 
         return JsonUtils::successResponse(R"({"deleted":true})");
     } catch (const std::exception& e) {
@@ -495,7 +495,7 @@ std::string SettingsProvider::saveSessionState(std::string_view params) {
         }
 
         m_sessionManager->updateState(state);
-        m_sessionManager->save();
+        (void)m_sessionManager->save();
 
         return JsonUtils::successResponse(R"({"saved":true})");
     } catch (const std::exception& e) {

--- a/backend/utils/session_manager.cpp
+++ b/backend/utils/session_manager.cpp
@@ -28,40 +28,46 @@ SessionManager::SessionManager() {
     m_sessionPath /= "session.json";
 }
 
-bool SessionManager::load() {
+std::expected<void, std::string> SessionManager::load() {
     std::lock_guard lock(m_mutex);
 
     if (!std::filesystem::exists(m_sessionPath)) {
-        return true;  // No session to restore, use defaults
+        return {};  // No session to restore, use defaults
     }
 
     std::ifstream file(m_sessionPath);
     if (!file.is_open()) {
-        return false;
+        return std::unexpected(std::format("Failed to open session file: {}", m_sessionPath.string()));
     }
 
     std::stringstream buffer;
     buffer << file.rdbuf();
-    return deserializeSession(buffer.str());
+    if (!deserializeSession(buffer.str())) {
+        return std::unexpected("Failed to parse session file");
+    }
+    return {};
 }
 
-bool SessionManager::save() {
+std::expected<void, std::string> SessionManager::save() {
     std::lock_guard lock(m_mutex);
 
     m_state.lastSaved = std::chrono::system_clock::now();
 
     auto json = serializeSession();
     if (json.empty()) {
-        return false;  // Serialization failed — preserve existing file
+        return std::unexpected("Serialization failed — preserving existing file");
     }
 
     std::ofstream file(m_sessionPath);
     if (!file.is_open()) {
-        return false;
+        return std::unexpected(std::format("Failed to open session file for writing: {}", m_sessionPath.string()));
     }
 
     file << json;
-    return file.good();
+    if (!file.good()) {
+        return std::unexpected(std::format("Failed to write session file: {}", m_sessionPath.string()));
+    }
+    return {};
 }
 
 void SessionManager::updateState(const SessionState& state) {

--- a/backend/utils/session_manager.h
+++ b/backend/utils/session_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <expected>
 #include <filesystem>
 #include <mutex>
 #include <string>
@@ -46,10 +47,10 @@ public:
     SessionManager& operator=(const SessionManager&) = delete;
 
     /// Load session state from disk
-    bool load();
+    [[nodiscard]] std::expected<void, std::string> load();
 
     /// Save session state to disk
-    bool save();
+    [[nodiscard]] std::expected<void, std::string> save();
 
     /// Get current session state
     [[nodiscard]] const SessionState& getState() const { return m_state; }

--- a/backend/utils/settings_manager.cpp
+++ b/backend/utils/settings_manager.cpp
@@ -31,44 +31,52 @@ SettingsManager::SettingsManager() {
     m_settingsPath /= "settings.json";
 }
 
-bool SettingsManager::load() {
+std::expected<void, std::string> SettingsManager::load() {
     std::lock_guard lock(m_mutex);
 
     if (!std::filesystem::exists(m_settingsPath)) {
-        // Create default settings file (without lock - saveInternal handles it)
         std::ofstream file(m_settingsPath);
         if (!file.is_open()) {
-            return false;
+            return std::unexpected(std::format("Failed to create default settings file: {}", m_settingsPath.string()));
         }
         file << serializeSettings();
-        return file.good();
+        if (!file.good()) {
+            return std::unexpected(std::format("Failed to write default settings file: {}", m_settingsPath.string()));
+        }
+        return {};
     }
 
     std::ifstream file(m_settingsPath);
     if (!file.is_open()) {
-        return false;
+        return std::unexpected(std::format("Failed to open settings file: {}", m_settingsPath.string()));
     }
 
     std::stringstream buffer;
     buffer << file.rdbuf();
-    return deserializeSettings(buffer.str());
+    if (!deserializeSettings(buffer.str())) {
+        return std::unexpected("Failed to parse settings file");
+    }
+    return {};
 }
 
-bool SettingsManager::save() {
+std::expected<void, std::string> SettingsManager::save() {
     std::lock_guard lock(m_mutex);
 
     auto json = serializeSettings();
     if (json.empty()) {
-        return false;  // Serialization failed — preserve existing file
+        return std::unexpected("Serialization failed — preserving existing file");
     }
 
     std::ofstream file(m_settingsPath);
     if (!file.is_open()) {
-        return false;
+        return std::unexpected(std::format("Failed to open settings file for writing: {}", m_settingsPath.string()));
     }
 
     file << json;
-    return file.good();
+    if (!file.good()) {
+        return std::unexpected(std::format("Failed to write settings file: {}", m_settingsPath.string()));
+    }
+    return {};
 }
 
 void SettingsManager::updateSettings(const AppSettings& settings) {

--- a/backend/utils/settings_manager.h
+++ b/backend/utils/settings_manager.h
@@ -101,10 +101,10 @@ public:
     SettingsManager& operator=(const SettingsManager&) = delete;
 
     /// Load settings from disk
-    bool load();
+    [[nodiscard]] std::expected<void, std::string> load();
 
     /// Save settings to disk
-    bool save();
+    [[nodiscard]] std::expected<void, std::string> save();
 
     /// Get current settings
     [[nodiscard]] const AppSettings& getSettings() const { return m_settings; }

--- a/backend/webview_app.cpp
+++ b/backend/webview_app.cpp
@@ -47,8 +47,8 @@ WebViewApp::WebViewApp(HINSTANCE hInstance)
     , m_ipcHandler(std::make_unique<IPCHandler>(*m_systemContext))
     , m_webview(nullptr)
     , m_settingsManager(std::make_unique<SettingsManager>()) {
-    // Load settings
-    m_settingsManager->load();
+    // Load settings (best-effort — defaults used on failure)
+    (void)m_settingsManager->load();
 }
 
 WebViewApp::~WebViewApp() = default;


### PR DESCRIPTION
`QueryHistory` / `SettingsManager` / `SessionManager` の `load/save` と `AsyncQueryExecutor` / `AsyncConnectionExecutor` の `cancel/remove` を `std::expected<void, std::string>` に変更しエラー理由を伝播可能にした。