### PR TITLE
perf: `unordered_map` の異種キーlookupを導入し `string_view` 検索時のヒープ確保を除去

### DIFF
--- a/backend/database/async_connection_executor.cpp
+++ b/backend/database/async_connection_executor.cpp
@@ -114,7 +114,7 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
 std::expected<void, std::string> AsyncConnectionExecutor::cancelConnect(std::string_view requestId) {
     std::lock_guard lock(m_mutex);
 
-    auto iter = m_tasks.find(std::string(requestId));
+    auto iter = m_tasks.find(requestId);
     if (iter == m_tasks.end()) {
         return std::unexpected(std::format("Connection request not found: {}", requestId));
     }
@@ -133,7 +133,7 @@ std::expected<void, std::string> AsyncConnectionExecutor::cancelConnect(std::str
 std::expected<AsyncConnectionExecutor::ConnectedDrivers, ConnectResult> AsyncConnectionExecutor::getResultAndConsume(std::string_view requestId) {
     std::lock_guard lock(m_mutex);
 
-    auto iter = m_tasks.find(std::string(requestId));
+    auto iter = m_tasks.find(requestId);
     if (iter == m_tasks.end()) {
         return std::unexpected(ConnectResult{
             .requestId = std::string(requestId),

--- a/backend/database/async_connection_executor.h
+++ b/backend/database/async_connection_executor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../utils/transparent_hash.h"
 #include "connection_utils.h"
 #include "driver_interface.h"
 
@@ -68,7 +69,7 @@ private:
     };
 
     mutable std::mutex m_mutex;
-    std::unordered_map<std::string, std::shared_ptr<ConnectTask>> m_tasks;
+    std::unordered_map<std::string, std::shared_ptr<ConnectTask>, TransparentStringHash, TransparentStringEqual> m_tasks;
     std::atomic<int> m_counter{1};
 };
 

--- a/backend/database/async_query_executor.cpp
+++ b/backend/database/async_query_executor.cpp
@@ -162,7 +162,7 @@ AsyncQueryResult AsyncQueryExecutor::getQueryResult(std::string_view queryId) {
     // Lock only to find and copy the task pointer
     {
         std::lock_guard lock(m_mutex);
-        auto iter = m_queries.find(std::string(queryId));
+        auto iter = m_queries.find(queryId);
         if (iter == m_queries.end()) {
             return AsyncQueryResult{.queryId = std::string(queryId), .status = QueryStatus::Failed, .errorMessage = "Query not found"};
         }
@@ -212,7 +212,7 @@ AsyncQueryResult AsyncQueryExecutor::getQueryResult(std::string_view queryId) {
 std::expected<void, std::string> AsyncQueryExecutor::cancelQuery(std::string_view queryId) {
     std::lock_guard lock(m_mutex);
 
-    auto iter = m_queries.find(std::string(queryId));
+    auto iter = m_queries.find(queryId);
     if (iter == m_queries.end()) {
         return std::unexpected(std::format("Query not found: {}", queryId));
     }
@@ -232,7 +232,7 @@ std::expected<void, std::string> AsyncQueryExecutor::cancelQuery(std::string_vie
 bool AsyncQueryExecutor::isQueryRunning(std::string_view queryId) const {
     std::lock_guard lock(m_mutex);
 
-    auto iter = m_queries.find(std::string(queryId));
+    auto iter = m_queries.find(queryId);
     if (iter == m_queries.end()) {
         return false;
     }
@@ -242,7 +242,7 @@ bool AsyncQueryExecutor::isQueryRunning(std::string_view queryId) const {
 
 std::expected<void, std::string> AsyncQueryExecutor::removeQuery(std::string_view queryId) {
     std::lock_guard lock(m_mutex);
-    auto it = m_queries.find(std::string(queryId));
+    auto it = m_queries.find(queryId);
     if (it == m_queries.end()) {
         return std::unexpected(std::format("Query not found: {}", queryId));
     }

--- a/backend/database/async_query_executor.h
+++ b/backend/database/async_query_executor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../utils/transparent_hash.h"
 #include "driver_interface.h"
 #include "thread_pool.h"
 
@@ -91,7 +92,7 @@ private:
 
     ThreadPool m_pool;
     mutable std::mutex m_mutex;
-    std::unordered_map<std::string, std::shared_ptr<QueryTask>> m_queries;
+    std::unordered_map<std::string, std::shared_ptr<QueryTask>, TransparentStringHash, TransparentStringEqual> m_queries;
     std::chrono::steady_clock::time_point m_lastEvictTime{};  // guarded by m_mutex
     std::atomic<int> m_queryIdCounter{1};
 };

--- a/backend/database/connection_registry.cpp
+++ b/backend/database/connection_registry.cpp
@@ -32,9 +32,8 @@ std::string ConnectionRegistry::add(DriverPtr queryDriver, DriverPtr metadataDri
 
 void ConnectionRegistry::remove(std::string_view id) {
     std::lock_guard lock(m_mutex);
-    auto idStr = std::string(id);
 
-    auto it = m_connections.find(idStr);
+    auto it = m_connections.find(id);
     if (it == m_connections.end()) {
         return;
     }
@@ -55,7 +54,7 @@ void ConnectionRegistry::remove(std::string_view id) {
 std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::getQueryDriver(std::string_view id) {
     std::lock_guard lock(m_mutex);
 
-    auto it = m_connections.find(std::string(id));
+    auto it = m_connections.find(id);
     if (it != m_connections.end()) {
         it->second.lastUsed = std::chrono::steady_clock::now();
         return it->second.queryDriver;
@@ -66,7 +65,7 @@ std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::ge
 std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::getMetadataDriver(std::string_view id) {
     std::lock_guard lock(m_mutex);
 
-    auto it = m_connections.find(std::string(id));
+    auto it = m_connections.find(id);
     if (it != m_connections.end()) {
         it->second.lastUsed = std::chrono::steady_clock::now();
         return it->second.metadataDriver;
@@ -81,7 +80,7 @@ std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::ge
 std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::getQueryDriverChecked(std::string_view id) {
     std::lock_guard lock(m_mutex);
 
-    auto it = m_connections.find(std::string(id));
+    auto it = m_connections.find(id);
     if (it == m_connections.end()) {
         return std::unexpected(std::format("Connection '{}' not found", id));
     }
@@ -118,7 +117,7 @@ std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::ge
 
 std::expected<DriverType, std::string> ConnectionRegistry::getDriverType(std::string_view id) const {
     std::shared_lock lock(m_mutex);
-    auto it = m_connections.find(std::string(id));
+    auto it = m_connections.find(id);
     if (it != m_connections.end()) {
         return it->second.driverType;
     }
@@ -127,7 +126,7 @@ std::expected<DriverType, std::string> ConnectionRegistry::getDriverType(std::st
 
 bool ConnectionRegistry::exists(std::string_view id) const {
     std::shared_lock lock(m_mutex);
-    return m_connections.contains(std::string(id));
+    return m_connections.contains(id);
 }
 
 size_t ConnectionRegistry::count() const {
@@ -137,7 +136,7 @@ size_t ConnectionRegistry::count() const {
 
 void ConnectionRegistry::attachTunnel(std::string_view connectionId, std::unique_ptr<SshTunnel> tunnel) {
     std::lock_guard lock(m_mutex);
-    auto it = m_connections.find(std::string(connectionId));
+    auto it = m_connections.find(connectionId);
     if (it != m_connections.end()) {
         it->second.tunnel = std::move(tunnel);
     }
@@ -145,7 +144,7 @@ void ConnectionRegistry::attachTunnel(std::string_view connectionId, std::unique
 
 void ConnectionRegistry::storeParams(std::string_view connectionId, const DatabaseConnectionParams& params) {
     std::lock_guard lock(m_mutex);
-    auto it = m_connections.find(std::string(connectionId));
+    auto it = m_connections.find(connectionId);
     if (it != m_connections.end()) {
         it->second.params = params;
     }
@@ -153,7 +152,7 @@ void ConnectionRegistry::storeParams(std::string_view connectionId, const Databa
 
 std::optional<DatabaseConnectionParams> ConnectionRegistry::getParams(std::string_view connectionId) const {
     std::shared_lock lock(m_mutex);
-    auto it = m_connections.find(std::string(connectionId));
+    auto it = m_connections.find(connectionId);
     if (it != m_connections.end()) {
         return it->second.params;
     }
@@ -162,7 +161,7 @@ std::optional<DatabaseConnectionParams> ConnectionRegistry::getParams(std::strin
 
 SshTunnel* ConnectionRegistry::getTunnel(std::string_view connectionId) const {
     std::shared_lock lock(m_mutex);
-    auto it = m_connections.find(std::string(connectionId));
+    auto it = m_connections.find(connectionId);
     if (it != m_connections.end()) {
         return it->second.tunnel.get();
     }

--- a/backend/database/connection_registry.h
+++ b/backend/database/connection_registry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../network/ssh_tunnel.h"
+#include "../utils/transparent_hash.h"
 #include "connection_utils.h"
 #include "driver_interface.h"
 
@@ -86,7 +87,7 @@ private:
     };
 
     mutable std::shared_mutex m_mutex;
-    std::unordered_map<std::string, ConnectionEntry> m_connections;
+    std::unordered_map<std::string, ConnectionEntry, TransparentStringHash, TransparentStringEqual> m_connections;
     std::atomic<int> m_counter{1};
 };
 

--- a/backend/database/result_cache.h
+++ b/backend/database/result_cache.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../utils/transparent_hash.h"
 #include "driver_interface.h"
 
 #include <functional>
@@ -11,16 +12,6 @@
 #include <unordered_map>
 
 namespace velocitydb {
-
-struct TransparentStringHash {
-    using is_transparent = void;
-    size_t operator()(std::string_view sv) const noexcept { return std::hash<std::string_view>{}(sv); }
-};
-
-struct TransparentStringEqual {
-    using is_transparent = void;
-    bool operator()(std::string_view a, std::string_view b) const noexcept { return a == b; }
-};
 
 struct CachedResult {
     ResultSet data;

--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -134,7 +134,7 @@ std::string IPCHandler::dispatchRequest(std::string_view request) {
             params = paramsResult.value();
         }
 
-        if (auto route = m_routes.find(std::string(method)); route != m_routes.end()) [[likely]] {
+        if (auto route = m_routes.find(method); route != m_routes.end()) [[likely]] {
             return route->second(params);
         }
 

--- a/backend/ipc_handler.h
+++ b/backend/ipc_handler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "utils/transparent_hash.h"
+
 #include <functional>
 #include <string>
 #include <string_view>
@@ -27,7 +29,7 @@ private:
     void registerRoutes();
 
     using Handler = std::function<std::string(std::string_view)>;
-    std::unordered_map<std::string, Handler> m_routes;
+    std::unordered_map<std::string, Handler, TransparentStringHash, TransparentStringEqual> m_routes;
     ISystemContext& m_ctx;
 };
 

--- a/backend/utils/transparent_hash.h
+++ b/backend/utils/transparent_hash.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string_view>
+
+namespace velocitydb {
+
+/// Transparent hash/equal for heterogeneous lookup on unordered_map<std::string, ...>.
+/// Avoids constructing temporary std::string when looking up by std::string_view.
+struct TransparentStringHash {
+    using is_transparent = void;
+    size_t operator()(std::string_view sv) const noexcept { return std::hash<std::string_view>{}(sv); }
+};
+
+struct TransparentStringEqual {
+    using is_transparent = void;
+    bool operator()(std::string_view a, std::string_view b) const noexcept { return a == b; }
+};
+
+}  // namespace velocitydb


### PR DESCRIPTION
`TransparentStringHash/Equal` を共通ヘッダに抽出し、`IPCHandler` / `AsyncQueryExecutor` / `AsyncConnectionExecutor` / `ConnectionRegistry` の4つの `unordered_map` に適用。 `find/contains` 計15箇所で `std::string` 一時生成を削減。