### PR TITLE
refactor: psqlサブプロセスのキャンセル対応と不要スレッド除去

### DIFF
--- a/backend/database/async_query_executor.cpp
+++ b/backend/database/async_query_executor.cpp
@@ -25,9 +25,10 @@ AsyncQueryExecutor::~AsyncQueryExecutor() {
     for (auto& task : tasks) {
         if (task->future.valid()) {
             // Cancel if still running
-            if (task->status == QueryStatus::Running && task->driver) {
+            if (task->status == QueryStatus::Running) {
                 task->cancelled.store(true, std::memory_order_release);
-                task->driver->cancel();
+                if (task->driver)
+                    task->driver->cancel();
             }
             // Wait for completion (this can block, but we're not holding the mutex)
             task->future.wait();
@@ -130,7 +131,7 @@ std::string AsyncQueryExecutor::submitQuery(std::shared_ptr<IDatabaseDriver> dri
     return queryId;
 }
 
-std::string AsyncQueryExecutor::submitTask(std::function<QueryResultVariant()> task) {
+std::string AsyncQueryExecutor::submitTask(std::function<QueryResultVariant(const std::atomic<bool>&)> task) {
     auto queryId = std::format("query_{}", m_queryIdCounter++);
 
     auto queryTask = std::make_shared<QueryTask>();
@@ -139,7 +140,7 @@ std::string AsyncQueryExecutor::submitTask(std::function<QueryResultVariant()> t
 
     queryTask->future = m_pool.submit([queryTask, fn = std::move(task)]() -> QueryResultVariant {
         try {
-            auto result = fn();
+            auto result = fn(queryTask->cancelled);
             queryTask->endTime = std::chrono::steady_clock::now();
             queryTask->status = QueryStatus::Completed;
             return result;
@@ -218,9 +219,10 @@ std::expected<void, std::string> AsyncQueryExecutor::cancelQuery(std::string_vie
     }
 
     auto& task = iter->second;
-    if (task->status == QueryStatus::Running && task->driver) {
+    if (task->status == QueryStatus::Running) {
         task->cancelled.store(true, std::memory_order_release);
-        task->driver->cancel();
+        if (task->driver)
+            task->driver->cancel();
         task->status = QueryStatus::Cancelled;
         task->endTime = std::chrono::steady_clock::now();
         return {};

--- a/backend/database/async_query_executor.h
+++ b/backend/database/async_query_executor.h
@@ -53,8 +53,9 @@ public:
     /// Uses shared_ptr to ensure driver lifetime extends through async execution
     [[nodiscard]] std::string submitQuery(std::shared_ptr<IDatabaseDriver> driver, std::string_view sql);
 
-    /// Submits an arbitrary task for asynchronous execution (e.g., psql subprocess)
-    [[nodiscard]] std::string submitTask(std::function<QueryResultVariant()> task);
+    /// Submits an arbitrary cancellable task for asynchronous execution (e.g., psql subprocess).
+    /// The task function receives a cancellation flag that it should poll periodically.
+    [[nodiscard]] std::string submitTask(std::function<QueryResultVariant(const std::atomic<bool>& cancelled)> task);
 
     /// Gets the current status and result of a query
     [[nodiscard]] AsyncQueryResult getQueryResult(std::string_view queryId);

--- a/backend/database/psql_subprocess.cpp
+++ b/backend/database/psql_subprocess.cpp
@@ -8,7 +8,6 @@
 #include <cstdlib>
 #include <filesystem>
 #include <format>
-#include <future>
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -245,7 +244,7 @@ PsqlConnectionInfo toPsqlConnectionInfo(const DatabaseConnectionParams& params) 
     };
 }
 
-std::expected<ResultSet, std::string> executePsql(const PsqlConnectionInfo& conn, std::string_view sql) {
+std::expected<ResultSet, std::string> executePsql(const PsqlConnectionInfo& conn, std::string_view sql, const std::atomic<bool>& cancelled) {
     const auto startTime = std::chrono::high_resolution_clock::now();
 
     // Write SQL to temp file (W2: check return values)
@@ -340,24 +339,33 @@ std::expected<ResultSet, std::string> executePsql(const PsqlConnectionInfo& conn
     outWrite.reset();
     errWrite.reset();
 
-    // Wait for process with timeout BEFORE reading pipes.
-    // readPipe blocks until the write-end is closed (process exit or terminate).
+    // Poll for process exit with cancellation support.
+    // readPipe blocks until write-end is closed (process exit or terminate).
     constexpr DWORD kTimeoutMs = 300'000;
-    auto waitResult = WaitForSingleObject(pi.hProcess, kTimeoutMs);
-    if (waitResult == WAIT_TIMEOUT) {
+    constexpr DWORD kPollIntervalMs = 200;
+
+    auto killAndDrain = [&](const char* reason) -> std::unexpected<std::string> {
         TerminateProcess(pi.hProcess, 1);
         WaitForSingleObject(pi.hProcess, 5000);
-        // Drain remaining pipe data to prevent zombie handles
         (void)readPipe(stdoutRead);
         (void)readPipe(stderrRead);
-        return std::unexpected("psql process timed out after 300 seconds");
-    }
+        return std::unexpected<std::string>(reason);
+    };
 
-    // Process has exited — EOF guaranteed. Concurrent read avoids deadlock
-    // if combined stdout+stderr exceed the 64KB pipe buffer.
-    auto stderrFuture = std::async(std::launch::async, readPipe, stderrRead);
+    DWORD waitResult = WAIT_TIMEOUT;
+    for (DWORD elapsed = 0; elapsed < kTimeoutMs; elapsed += kPollIntervalMs) {
+        waitResult = WaitForSingleObject(pi.hProcess, kPollIntervalMs);
+        if (waitResult == WAIT_OBJECT_0)
+            break;
+        if (cancelled.load(std::memory_order_acquire))
+            return killAndDrain("psql process was cancelled");
+    }
+    if (waitResult == WAIT_TIMEOUT)
+        return killAndDrain("psql process timed out after 300 seconds");
+
+    // Process has exited — pipe data is finite. Sequential reads are safe.
     auto stdoutData = readPipe(stdoutRead);
-    auto stderrData = stderrFuture.get();
+    auto stderrData = readPipe(stderrRead);
 
     DWORD exitCode = 1;
     GetExitCodeProcess(pi.hProcess, &exitCode);

--- a/backend/database/psql_subprocess.h
+++ b/backend/database/psql_subprocess.h
@@ -3,6 +3,7 @@
 #include "connection_utils.h"
 #include "driver_interface.h"
 
+#include <atomic>
 #include <expected>
 #include <string>
 #include <string_view>
@@ -20,8 +21,9 @@ struct PsqlConnectionInfo {
 /// Escape a value for CreateProcessW argv parsing (Windows 2n+1 backslash rule)
 [[nodiscard]] std::string shellQuote(std::string_view value);
 
-/// Execute SQL via psql subprocess (for COPY FROM stdin delegation)
-[[nodiscard]] std::expected<ResultSet, std::string> executePsql(const PsqlConnectionInfo& conn, std::string_view sql);
+/// Execute SQL via psql subprocess (for COPY FROM stdin delegation).
+/// If cancelled flag is set during execution, the psql process is terminated.
+[[nodiscard]] std::expected<ResultSet, std::string> executePsql(const PsqlConnectionInfo& conn, std::string_view sql, const std::atomic<bool>& cancelled);
 
 /// Check if psql is available on the system PATH
 [[nodiscard]] bool isPsqlAvailable();

--- a/backend/providers/async_query_provider.cpp
+++ b/backend/providers/async_query_provider.cpp
@@ -45,8 +45,8 @@ std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
                 return JsonUtils::errorResponse("Connection parameters not found for psql delegation");
             }
             auto connInfo = toPsqlConnectionInfo(*connParams);
-            queryId = m_asyncExecutor->submitTask([connInfo = std::move(connInfo), sqlCopy = std::string(sqlQuery)]() -> QueryResultVariant {
-                auto result = executePsql(connInfo, sqlCopy);
+            queryId = m_asyncExecutor->submitTask([connInfo = std::move(connInfo), sqlCopy = std::string(sqlQuery)](const std::atomic<bool>& cancelled) -> QueryResultVariant {
+                auto result = executePsql(connInfo, sqlCopy, cancelled);
                 if (!result)
                     throw std::runtime_error(result.error());
                 return *result;

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -70,7 +70,8 @@ std::string QueryProvider::executeQuery(std::string_view params) {
             if (!connParams) {
                 return JsonUtils::errorResponse("Connection parameters not found for psql delegation");
             }
-            auto psqlResult = executePsql(toPsqlConnectionInfo(*connParams), sqlQuery);
+            static const std::atomic<bool> neverCancelled{false};
+            auto psqlResult = executePsql(toPsqlConnectionInfo(*connParams), sqlQuery, neverCancelled);
             if (psqlResult) {
                 recordHistory(sqlQuery, connectionId, psqlResult->executionTimeMs, true, {}, psqlResult->affectedRows);
                 return JsonUtils::successResponse(JsonUtils::serializeResultSet(*psqlResult, false));

--- a/tests/database/test_psql_subprocess.cpp
+++ b/tests/database/test_psql_subprocess.cpp
@@ -111,7 +111,8 @@ TEST(PsqlSubprocessTest, ExecutePsqlFailsWithBadConnection) {
         .password = "wrong",
     };
 
-    auto result = executePsql(conn, "SELECT 1");
+    std::atomic<bool> cancelled{false};
+    auto result = executePsql(conn, "SELECT 1", cancelled);
     EXPECT_FALSE(result.has_value());
 }
 


### PR DESCRIPTION
- `executePsqlにcancelled` フラグを追加し200msポーリングループでキャンセル検知時に `TerminateProcess` で即座に終了
- `submitTask` がcancelledフラグをタスク関数に渡すよう変更し、`cancelQuery` をdriver不要化してpsqlタスクもキャンセル可能に
- プロセス終了後の `stderr` 読み取りから `std::async` スレッド生成を除去