### PR TITLE
refactor: SSHトンネルのスレッド安全性とリソース即時解放を改善

### DIFF
--- a/backend/database/async_connection_executor.cpp
+++ b/backend/database/async_connection_executor.cpp
@@ -64,7 +64,8 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
             queryDriverPtr->setConnectionTimeout(task->effectiveParams.connectionTimeoutSeconds);
 
             if (!queryDriverPtr->connect(prepared->connectionString)) {
-                if (task->tunnel) task->tunnel->disconnect();
+                if (task->tunnel)
+                    task->tunnel->disconnect();
                 task->errorMessage = std::format("Connection failed: {}", queryDriverPtr->getLastError());
                 task->status = ConnectStatus::Failed;
                 return;
@@ -72,7 +73,8 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
 
             if (task->cancelled.load(std::memory_order_acquire)) {
                 queryDriverPtr->disconnect();
-                if (task->tunnel) task->tunnel->disconnect();
+                if (task->tunnel)
+                    task->tunnel->disconnect();
                 task->status = ConnectStatus::Cancelled;
                 return;
             }
@@ -84,7 +86,8 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
 
             if (!metadataDriverPtr->connect(prepared->connectionString)) {
                 queryDriverPtr->disconnect();
-                if (task->tunnel) task->tunnel->disconnect();
+                if (task->tunnel)
+                    task->tunnel->disconnect();
                 task->errorMessage = std::format("Metadata connection failed: {}", metadataDriverPtr->getLastError());
                 task->status = ConnectStatus::Failed;
                 return;
@@ -93,7 +96,8 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
             if (task->cancelled.load(std::memory_order_acquire)) {
                 queryDriverPtr->disconnect();
                 metadataDriverPtr->disconnect();
-                if (task->tunnel) task->tunnel->disconnect();
+                if (task->tunnel)
+                    task->tunnel->disconnect();
                 task->status = ConnectStatus::Cancelled;
                 return;
             }
@@ -104,7 +108,8 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
 
             log<LogLevel::DEBUG>("[DB] Async connection completed successfully");
         } catch (const std::exception& e) {
-            if (task->tunnel) task->tunnel->disconnect();
+            if (task->tunnel)
+                task->tunnel->disconnect();
             task->errorMessage = e.what();
             task->status = ConnectStatus::Failed;
         }

--- a/backend/database/async_connection_executor.cpp
+++ b/backend/database/async_connection_executor.cpp
@@ -64,6 +64,7 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
             queryDriverPtr->setConnectionTimeout(task->effectiveParams.connectionTimeoutSeconds);
 
             if (!queryDriverPtr->connect(prepared->connectionString)) {
+                if (task->tunnel) task->tunnel->disconnect();
                 task->errorMessage = std::format("Connection failed: {}", queryDriverPtr->getLastError());
                 task->status = ConnectStatus::Failed;
                 return;
@@ -71,6 +72,7 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
 
             if (task->cancelled.load(std::memory_order_acquire)) {
                 queryDriverPtr->disconnect();
+                if (task->tunnel) task->tunnel->disconnect();
                 task->status = ConnectStatus::Cancelled;
                 return;
             }
@@ -82,6 +84,7 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
 
             if (!metadataDriverPtr->connect(prepared->connectionString)) {
                 queryDriverPtr->disconnect();
+                if (task->tunnel) task->tunnel->disconnect();
                 task->errorMessage = std::format("Metadata connection failed: {}", metadataDriverPtr->getLastError());
                 task->status = ConnectStatus::Failed;
                 return;
@@ -90,6 +93,7 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
             if (task->cancelled.load(std::memory_order_acquire)) {
                 queryDriverPtr->disconnect();
                 metadataDriverPtr->disconnect();
+                if (task->tunnel) task->tunnel->disconnect();
                 task->status = ConnectStatus::Cancelled;
                 return;
             }
@@ -100,6 +104,7 @@ std::string AsyncConnectionExecutor::submitConnect(DatabaseConnectionParams para
 
             log<LogLevel::DEBUG>("[DB] Async connection completed successfully");
         } catch (const std::exception& e) {
+            if (task->tunnel) task->tunnel->disconnect();
             task->errorMessage = e.what();
             task->status = ConnectStatus::Failed;
         }

--- a/backend/network/ssh_tunnel.cpp
+++ b/backend/network/ssh_tunnel.cpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <format>
 #include <fstream>
+#include <mutex>
 #include <thread>
 #include <vector>
 
@@ -33,12 +34,11 @@ inline int closeSocket(socket_t s) {
     return closesocket(s);
 }
 inline void initWsa() {
-    static bool initialized = false;
-    if (!initialized) {
+    static std::once_flag flag;
+    std::call_once(flag, []() {
         WSADATA wsaData;
         WSAStartup(MAKEWORD(2, 2), &wsaData);
-        initialized = true;
-    }
+    });
 }
 inline int getLastSocketError() {
     return WSAGetLastError();


### PR DESCRIPTION
- WSA初期化を`std::call_once`に変更し競合状態を解消
- 非同期接続の失敗/キャンセル/例外パスでトンネルを即座にdisconnect（従来はRAII任せで消費者ポーリングまでプロキシスレッドが稼働継続）