### PR TITLE
refactor: ビルドスクリプトのバナー出力を統一しclang-formatを一括実行に変更

### DIFF
--- a/scripts/_lib/build.py
+++ b/scripts/_lib/build.py
@@ -10,11 +10,8 @@ def build_frontend(clean: bool = False) -> bool:
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
-    print(f"\n{'#' * 60}")
-    print("#  Building Frontend")
-    if clean:
-        print("#  Mode: Clean Build")
-    print(f"{'#' * 60}")
+    subtitles = ("Mode: Clean Build",) if clean else ()
+    utils.print_header("Building Frontend", *subtitles)
 
     # Clear caches if --clean
     if clean:
@@ -54,9 +51,7 @@ def build_frontend(clean: bool = False) -> bool:
     total_size = sum(f.stat().st_size for f in dist_dir.rglob("*") if f.is_file())
     file_count = sum(1 for _ in dist_dir.rglob("*") if _.is_file())
 
-    print(f"\n{'=' * 60}")
-    print("  BUILD SUCCESSFUL")
-    print(f"{'=' * 60}")
+    utils.print_footer("BUILD SUCCESSFUL")
     print(f"\n  Output: {dist_dir}")
     print(f"  Size: {total_size / 1024 / 1024:.2f} MB")
     print(f"  Files: {file_count}")
@@ -77,11 +72,8 @@ def build_backend(build_type: str = "Release", clean: bool = False) -> bool:
     build_dir = project_root / "build"
     preset = build_type.lower()  # "debug" or "release"
 
-    print(f"\n{'#' * 60}")
-    print(f"#  Building Backend ({build_type})")
-    if clean:
-        print("#  Mode: Clean Build")
-    print(f"{'#' * 60}")
+    subtitles = ("Mode: Clean Build",) if clean else ()
+    utils.print_header(f"Building Backend ({build_type})", *subtitles)
 
     # Clean build directory if requested
     if clean and build_dir.exists():
@@ -124,9 +116,7 @@ def build_backend(build_type: str = "Release", clean: bool = False) -> bool:
             exe_path = exe
             break
 
-    print(f"\n{'=' * 60}")
-    print("  BUILD SUCCESSFUL")
-    print(f"{'=' * 60}")
+    utils.print_footer("BUILD SUCCESSFUL")
     if exe_path.exists():
         print(f"\n  Executable: {exe_path}")
         print(f"  Size: {exe_path.stat().st_size / 1024 / 1024:.2f} MB")
@@ -155,11 +145,8 @@ def build_backend(build_type: str = "Release", clean: bool = False) -> bool:
 
     # Final output: Show binary location
     if exe_path.exists():
-        print(f"\n{'=' * 60}")
-        print("  BINARY LOCATION")
-        print(f"{'=' * 60}")
-        print(f"\n  {exe_path.absolute()}")
-        print()
+        utils.print_footer("BINARY LOCATION")
+        print(f"\n  {exe_path.absolute()}\n")
 
     return True
 
@@ -169,9 +156,7 @@ def build_all(build_type: str = "Release", clean: bool = False) -> bool:
     project_root = utils.get_project_root()
     build_dir = project_root / "build"
 
-    print(f"\n{'=' * 60}")
-    print("  Building All (Frontend + Backend)")
-    print(f"{'=' * 60}")
+    utils.print_footer("Building All (Frontend + Backend)")
 
     # Build frontend first
     if not build_frontend(clean=clean):
@@ -181,9 +166,7 @@ def build_all(build_type: str = "Release", clean: bool = False) -> bool:
     if not build_backend(build_type=build_type, clean=clean):
         return False
 
-    print(f"\n{'=' * 60}")
-    print("  ALL BUILDS SUCCESSFUL")
-    print(f"{'=' * 60}")
+    utils.print_footer("ALL BUILDS SUCCESSFUL")
 
     # Show final binary location
     exe_path = build_dir / build_type / "VelocityDB.exe"

--- a/scripts/_lib/lint.py
+++ b/scripts/_lib/lint.py
@@ -11,12 +11,11 @@ def lint_frontend(fix: bool = False, unsafe: bool = False) -> bool:
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
-    print(f"\n{'#' * 60}")
-    print("#  Linting Frontend")
     if fix:
         mode = "Auto-fix (safe + unsafe)" if unsafe else "Auto-fix (safe only)"
-        print(f"#  Mode: {mode}")
-    print(f"{'#' * 60}")
+        utils.print_header("Linting Frontend", f"Mode: {mode}")
+    else:
+        utils.print_header("Linting Frontend")
 
     # Ensure dependencies
     pkg_info = utils.ensure_frontend_deps()
@@ -54,11 +53,8 @@ def lint_cpp(fix: bool = False) -> bool:
     project_root = utils.get_project_root()
     src_dir = project_root / "backend"
 
-    print(f"\n{'#' * 60}")
-    print("#  Linting C++")
-    if fix:
-        print("#  Mode: Auto-fix")
-    print(f"{'#' * 60}")
+    subtitles = ("Mode: Auto-fix",) if fix else ()
+    utils.print_header("Linting C++", *subtitles)
 
     # Check for clang-format
     clang_format = shutil.which("clang-format")
@@ -85,36 +81,35 @@ def lint_cpp(fix: bool = False) -> bool:
 
     print(f"\nFound {len(cpp_files)} C++ files")
 
-    # Format files
-    errors = 0
-    for file in cpp_files:
-        if fix:
-            # Auto-fix
-            result = subprocess.run(
-                [clang_format, "-i", "-style=file", str(file)], capture_output=True
-            )
-            if result.returncode != 0:
-                print(f"  [FAIL] {file.relative_to(project_root)}")
-                errors += 1
-            else:
-                print(f"  [OK] {file.relative_to(project_root)}")
-        else:
-            # Check only
-            result = subprocess.run(
-                [clang_format, "--style=file", "--dry-run", "--Werror", str(file)],
-                capture_output=True,
-            )
-            if result.returncode != 0:
-                print(f"  [FAIL] {file.relative_to(project_root)}")
-                errors += 1
-
-    if errors > 0:
-        print(f"\n[FAIL] {errors} file(s) need formatting")
-        if not fix:
-            print("Run with --fix to auto-format")
-        return False
+    # Run clang-format on all files at once (much faster than one-by-one)
+    file_args = [str(f) for f in cpp_files]
+    if fix:
+        cmd = [clang_format, "-i", "-style=file", "--verbose"] + file_args
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.stderr:
+            print(result.stderr.strip())
+        if result.returncode != 0:
+            print("\n[FAIL] clang-format failed")
+            return False
+        print(f"\n[OK] {len(cpp_files)} files formatted!")
+        return True
     else:
-        print("\n[OK] All files properly formatted!")
+        cmd = [clang_format, "--style=file", "--dry-run", "--Werror"] + file_args
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            if result.stderr:
+                # Extract filenames from warnings
+                seen: set[str] = set()
+                for line in result.stderr.splitlines():
+                    for f in cpp_files:
+                        rel = str(f.relative_to(project_root))
+                        if str(f) in line and rel not in seen:
+                            print(f"  [FAIL] {rel}")
+                            seen.add(rel)
+            print(f"\n[FAIL] {len(seen) if result.stderr else '?'} file(s) need formatting")
+            print("Run with --fix to auto-format")
+            return False
+        print(f"\n[OK] All {len(cpp_files)} files properly formatted!")
         return True
 
 
@@ -123,11 +118,8 @@ def lint_python(fix: bool = False) -> bool:
     project_root = utils.get_project_root()
     scripts_dir = project_root / "scripts"
 
-    print(f"\n{'#' * 60}")
-    print("#  Linting Python")
-    if fix:
-        print("#  Mode: Auto-fix")
-    print(f"{'#' * 60}")
+    subtitles = ("Mode: Auto-fix",) if fix else ()
+    utils.print_header("Linting Python", *subtitles)
 
     # Check for ruff
     ruff = shutil.which("ruff")
@@ -191,20 +183,10 @@ def lint_python(fix: bool = False) -> bool:
 
 def lint_all(fix: bool = False, unsafe: bool = False) -> bool:
     """Lint frontend and C++ code (product code only)."""
-    print(f"\n{'=' * 60}")
-    print("  Linting All (Frontend + C++)")
-    print(f"{'=' * 60}")
+    utils.print_footer("Linting All (Frontend + C++)")
 
     success1 = lint_frontend(fix=fix, unsafe=unsafe)
     success2 = lint_cpp(fix=fix)
 
-    if success1 and success2:
-        print(f"\n{'=' * 60}")
-        print("  ALL LINTS PASSED")
-        print(f"{'=' * 60}")
-        return True
-    else:
-        print(f"\n{'=' * 60}")
-        print("  SOME LINTS FAILED")
-        print(f"{'=' * 60}")
-        return False
+    utils.print_footer("ALL LINTS PASSED" if (success1 and success2) else "SOME LINTS FAILED")
+    return success1 and success2

--- a/scripts/_lib/test.py
+++ b/scripts/_lib/test.py
@@ -8,11 +8,8 @@ def test_frontend(watch: bool = False) -> bool:
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
-    print(f"\n{'#' * 60}")
-    print("#  Running Frontend Tests")
-    if watch:
-        print("#  Mode: Watch")
-    print(f"{'#' * 60}")
+    subtitles = ("Mode: Watch",) if watch else ()
+    utils.print_header("Running Frontend Tests", *subtitles)
 
     # Ensure dependencies
     pkg_info = utils.ensure_frontend_deps()
@@ -44,9 +41,7 @@ def test_e2e() -> bool:
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
-    print(f"\n{'#' * 60}")
-    print("#  Running E2E Tests (Playwright)")
-    print(f"{'#' * 60}")
+    utils.print_header("Running E2E Tests (Playwright)")
 
     pkg_info = utils.ensure_frontend_deps()
     if not pkg_info:
@@ -78,9 +73,7 @@ def test_backend(build_type: str = "Release") -> bool:
     project_root = utils.get_project_root()
     build_dir = project_root / "build"
 
-    print(f"\n{'#' * 60}")
-    print(f"#  Running Backend Tests ({build_type})")
-    print(f"{'#' * 60}")
+    utils.print_header(f"Running Backend Tests ({build_type})")
 
     if not build_dir.exists():
         print("\nERROR: Build directory not found")

--- a/scripts/_lib/utils.py
+++ b/scripts/_lib/utils.py
@@ -8,6 +8,24 @@ from pathlib import Path
 
 PackageManager = tuple[str, Path]
 
+_BANNER_WIDTH = 60
+
+
+def print_header(title: str, *subtitles: str) -> None:
+    """Print a section header (e.g. '#  Building Backend (Debug)')."""
+    print(f"\n{'#' * _BANNER_WIDTH}")
+    print(f"#  {title}")
+    for s in subtitles:
+        print(f"#  {s}")
+    print(f"{'#' * _BANNER_WIDTH}")
+
+
+def print_footer(message: str) -> None:
+    """Print a footer banner (e.g. 'BUILD SUCCESSFUL')."""
+    print(f"\n{'=' * _BANNER_WIDTH}")
+    print(f"  {message}")
+    print(f"{'=' * _BANNER_WIDTH}")
+
 
 def get_project_root() -> Path:
     """Get the project root directory (resolves symlinks)."""
@@ -23,12 +41,12 @@ def run_command(
     capture_output: bool = False,
 ) -> tuple[bool, str]:
     """Run a command and return success status and output."""
-    print(f"\n{'=' * 60}")
-    print(f"  {description}")
-    print(f"  Command: {' '.join(cmd)}")
+    extras = [f"Command: {' '.join(cmd)}"]
     if cwd:
-        print(f"  Working directory: {cwd}")
-    print(f"{'=' * 60}\n")
+        extras.append(f"Working directory: {cwd}")
+    print_footer(description)
+    for e in extras:
+        print(f"  {e}")
 
     merged_env = os.environ.copy()
     if env:

--- a/scripts/pdg.py
+++ b/scripts/pdg.py
@@ -89,9 +89,7 @@ def cmd_dev(_args: argparse.Namespace) -> bool:
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
-    print(f"\n{'#' * 60}")
-    print("#  Starting Development Server")
-    print(f"{'#' * 60}")
+    utils.print_header("Starting Development Server")
 
     # Ensure dependencies
     pkg_info = utils.ensure_frontend_deps()
@@ -114,9 +112,7 @@ def cmd_package(_args: argparse.Namespace) -> bool:
     project_root = utils.get_project_root()
     dist_dir = project_root / "dist"
 
-    print(f"\n{'#' * 60}")
-    print("#  Packaging Application")
-    print(f"{'#' * 60}")
+    utils.print_header("Packaging Application")
 
     # Build all first
     print("\n[1/2] Building all...")
@@ -154,9 +150,7 @@ def cmd_package(_args: argparse.Namespace) -> bool:
         return False
 
     # Summary
-    print(f"\n{'=' * 60}")
-    print("  PACKAGE CREATED")
-    print(f"{'=' * 60}")
+    utils.print_footer("PACKAGE CREATED")
     print(f"\n  Output: {dist_dir}")
     total_size = sum(f.stat().st_size for f in dist_dir.rglob("*") if f.is_file())
     print(f"  Total size: {total_size / 1024 / 1024:.2f} MB")
@@ -192,9 +186,7 @@ def cmd_release(args: argparse.Namespace) -> bool:
         version = "1.0.0"
         print("\n  No existing tags found. Using v1.0.0")
 
-    print(f"\n{'#' * 60}")
-    print(f"#  Creating Release v{version}")
-    print(f"{'#' * 60}")
+    utils.print_header(f"Creating Release v{version}")
 
     # Step 1: Run checks (unless skipped)
     skip_checks: bool = args.skip_checks
@@ -258,24 +250,18 @@ def cmd_release(args: argparse.Namespace) -> bool:
     print(f"  [OK] Created: {zip_name} ({zip_size:.2f} MB)")
 
     # Summary
-    print(f"\n{'=' * 60}")
-    print("  RELEASE PACKAGE CREATED")
-    print(f"{'=' * 60}")
+    utils.print_footer("RELEASE PACKAGE CREATED")
     print(f"\n  Version:       v{version}")
     print(f"  Archive:       {zip_path}")
     print(f"  Size:          {zip_size:.2f} MB")
     print(f"  Release Notes: {notes_path}")
 
     # Show release notes preview
-    print(f"\n{'=' * 60}")
-    print("  RELEASE NOTES PREVIEW")
-    print(f"{'=' * 60}")
+    utils.print_footer("RELEASE NOTES PREVIEW")
     print(release_notes[:500] + ("..." if len(release_notes) > 500 else ""))
 
     # Commands to execute
-    print(f"\n{'=' * 60}")
-    print("  RELEASE COMMANDS")
-    print(f"{'=' * 60}")
+    utils.print_footer("RELEASE COMMANDS")
     draft: bool = args.draft
     draft_flag = "--draft " if draft else ""
     print(f"""
@@ -294,9 +280,7 @@ def cmd_check(args: argparse.Namespace) -> bool:
     """Handle check command - comprehensive project check."""
     build_type: str = args.type
 
-    print(f"\n{'=' * 60}")
-    print(f"  Comprehensive Project Check ({build_type})")
-    print(f"{'=' * 60}")
+    utils.print_footer(f"Comprehensive Project Check ({build_type})")
 
     errors = 0
 
@@ -316,12 +300,10 @@ def cmd_check(args: argparse.Namespace) -> bool:
         errors += 1
 
     # Summary
-    print(f"\n{'=' * 60}")
     if errors == 0:
-        print("  ALL CHECKS PASSED [OK]")
+        utils.print_footer("ALL CHECKS PASSED [OK]")
     else:
-        print(f"  {errors} CHECK(S) FAILED [FAIL]")
-    print(f"{'=' * 60}")
+        utils.print_footer(f"{errors} CHECK(S) FAILED [FAIL]")
 
     return errors == 0
 
@@ -333,9 +315,7 @@ def cmd_clean(args: argparse.Namespace) -> bool:
     project_root = utils.get_project_root()
     target: str = args.target
 
-    print(f"\n{'#' * 60}")
-    print(f"#  Cleaning: {target}")
-    print(f"{'#' * 60}\n")
+    utils.print_header(f"Cleaning: {target}")
 
     cleaned_items: list[str] = []
 
@@ -369,9 +349,7 @@ def cmd_clean(args: argparse.Namespace) -> bool:
     for item in cleaned_items:
         print(item)
 
-    print(f"\n{'=' * 60}")
-    print("  CLEAN COMPLETE")
-    print(f"{'=' * 60}")
+    utils.print_footer("CLEAN COMPLETE")
 
     return True
 


### PR DESCRIPTION
- `print_header/print_footer` ユーティリティで20+箇所の手書きバナーを集約
- `clang-format` の134ファイル逐次起動を1コマンドに統合し速度改善