### PR TITLE
fix: Run ボタンをエディタタブかつ実行可能時のみ有効化

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -16,6 +16,7 @@ import type { ConnectionConfig } from '../dialogs/ConnectionDialog';
 import { QueryConfirmDialog } from '../dialogs/QueryConfirmDialog';
 import { CenterPanel } from './CenterPanel';
 import styles from './MainLayout.module.css';
+import { isRunButtonDisabled } from './runButtonState';
 
 // Lazy load heavy components (dialogs, panels) to reduce initial bundle size
 const LeftPanel = lazyWithRetry(() =>
@@ -419,7 +420,7 @@ export function MainLayout() {
         <div className={styles.toolbarGroup}>
           <button
             onClick={isExecuting ? handleCancel : handleExecute}
-            disabled={!activeQueryId || !activeQueryConnectionId}
+            disabled={isRunButtonDisabled(activeQuery, activeQueryConnectionId)}
             title={isExecuting ? '停止 (Escape)' : '実行 (Ctrl+Enter)'}
             className={styles.executeButton}
           >

--- a/frontend/src/components/layout/runButtonState.ts
+++ b/frontend/src/components/layout/runButtonState.ts
@@ -1,0 +1,10 @@
+import type { Query } from '../../types';
+
+export function isRunButtonDisabled(
+  activeQuery: Query | null | undefined,
+  activeQueryConnectionId: string | null | undefined
+): boolean {
+  if (!activeQuery || !activeQueryConnectionId) return true;
+  if (activeQuery.isDataView === true || activeQuery.isERDiagram === true) return true;
+  return activeQuery.content.trim().length === 0;
+}

--- a/frontend/src/tests/components/layout/runButtonState.test.ts
+++ b/frontend/src/tests/components/layout/runButtonState.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isRunButtonDisabled } from '../../../components/layout/runButtonState';
+import type { Query } from '../../../types';
+
+const baseQuery: Query = {
+  id: 'q1',
+  name: 'tab',
+  content: 'SELECT 1',
+  connectionId: 'c1',
+  isDirty: false,
+};
+
+describe('isRunButtonDisabled', () => {
+  it('enables when editor tab has content and connection', () => {
+    expect(isRunButtonDisabled(baseQuery, 'c1')).toBe(false);
+  });
+
+  it('disables when no active query', () => {
+    expect(isRunButtonDisabled(null, 'c1')).toBe(true);
+  });
+
+  it('disables when no connection', () => {
+    expect(isRunButtonDisabled(baseQuery, null)).toBe(true);
+  });
+
+  it('disables on data view tab', () => {
+    expect(isRunButtonDisabled({ ...baseQuery, isDataView: true }, 'c1')).toBe(true);
+  });
+
+  it('disables on ER diagram tab', () => {
+    expect(isRunButtonDisabled({ ...baseQuery, isERDiagram: true }, 'c1')).toBe(true);
+  });
+
+  it('disables when content is empty', () => {
+    expect(isRunButtonDisabled({ ...baseQuery, content: '' }, 'c1')).toBe(true);
+  });
+
+  it('disables when content is whitespace only', () => {
+    expect(isRunButtonDisabled({ ...baseQuery, content: '   \n\t  ' }, 'c1')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Run ボタンの活性化条件に以下を追加:
  - `isDataView` タブ (テーブル表示) で disabled
  - `isERDiagram` タブで disabled
  - `content` が空/空白のみで disabled
- 判定ロジックを pure helper `isRunButtonDisabled` に抽出 (`runButtonState.ts`)
- ユニットテスト 7 件追加

Closes #349

## Test plan
- [x] Vitest `runButtonState.test.ts` PASS
- [x] Vitest 全体 415 tests PASS
- [x] Biome check PASS
- [x] `pdg lint` PASS (TS + C++)
- [ ] 手動確認: テーブルタブで実行ボタンが disabled になること
- [ ] 手動確認: エディタタブ + 接続 + クエリ記述時に実行ボタンが有効になること