### PR TITLE
fix: 新規クエリタブにアクティブ接続を自動バインド

### DIFF
--- a/frontend/src/components/editor/EditorTabs.tsx
+++ b/frontend/src/components/editor/EditorTabs.tsx
@@ -4,6 +4,7 @@ import { useQueries, useQueryActions, useQueryStore } from '../../store/querySto
 import type { Query } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
 import { stripBrackets } from '../../utils/stringUtils';
+import { resolveNewQueryConnectionId } from '../layout/newQueryConnection';
 import styles from './EditorTabs.module.css';
 
 // SQL file icon
@@ -331,7 +332,8 @@ export function EditorTabs() {
               type="button"
               className={styles.overflowMenuItem}
               onClick={() => {
-                addQuery(activeQueryConnectionId);
+                const activeConnectionId = useConnectionStore.getState().activeConnectionId;
+                addQuery(resolveNewQueryConnectionId(activeQueryConnectionId, activeConnectionId));
                 setAddMenuOpen(false);
               }}
             >

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -16,6 +16,7 @@ import type { ConnectionConfig } from '../dialogs/ConnectionDialog';
 import { QueryConfirmDialog } from '../dialogs/QueryConfirmDialog';
 import { CenterPanel } from './CenterPanel';
 import styles from './MainLayout.module.css';
+import { resolveNewQueryConnectionId } from './newQueryConnection';
 import { isRunButtonDisabled } from './runButtonState';
 
 // Lazy load heavy components (dialogs, panels) to reduce initial bundle size
@@ -182,7 +183,8 @@ export function MainLayout() {
   };
 
   const handleNewQuery = useCallback(() => {
-    addQuery(activeQueryConnectionId);
+    const activeConnectionId = useConnectionStore.getState().activeConnectionId;
+    addQuery(resolveNewQueryConnectionId(activeQueryConnectionId, activeConnectionId));
   }, [addQuery, activeQueryConnectionId]);
 
   // Store pending execution for use after confirmation

--- a/frontend/src/components/layout/newQueryConnection.ts
+++ b/frontend/src/components/layout/newQueryConnection.ts
@@ -1,0 +1,6 @@
+export function resolveNewQueryConnectionId(
+  activeQueryConnectionId: string | null | undefined,
+  activeConnectionId: string | null | undefined
+): string | null {
+  return activeQueryConnectionId ?? activeConnectionId ?? null;
+}

--- a/frontend/src/tests/components/layout/newQueryConnection.test.ts
+++ b/frontend/src/tests/components/layout/newQueryConnection.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { resolveNewQueryConnectionId } from '../../../components/layout/newQueryConnection';
+
+describe('resolveNewQueryConnectionId', () => {
+  it('uses active query tab connection when present', () => {
+    expect(resolveNewQueryConnectionId('tab-conn', 'store-conn')).toBe('tab-conn');
+  });
+
+  it('falls back to connection store active id when tab connection is null', () => {
+    expect(resolveNewQueryConnectionId(null, 'store-conn')).toBe('store-conn');
+  });
+
+  it('falls back to connection store active id when tab connection is undefined', () => {
+    expect(resolveNewQueryConnectionId(undefined, 'store-conn')).toBe('store-conn');
+  });
+
+  it('returns null when both are null', () => {
+    expect(resolveNewQueryConnectionId(null, null)).toBeNull();
+  });
+
+  it('returns null when both are undefined', () => {
+    expect(resolveNewQueryConnectionId(undefined, undefined)).toBeNull();
+  });
+
+  it('prefers tab connection even when store has different active id', () => {
+    expect(resolveNewQueryConnectionId('tab-conn', 'different-conn')).toBe('tab-conn');
+  });
+});

--- a/frontend/src/tests/editor/EditorTabs.test.tsx
+++ b/frontend/src/tests/editor/EditorTabs.test.tsx
@@ -24,9 +24,14 @@ vi.mock('../../store/queryStore', () => ({
   }),
 }));
 
-vi.mock('../../store/connectionStore', () => ({
-  useConnectionStore: () => [],
-}));
+vi.mock('../../store/connectionStore', () => {
+  const useConnectionStore = (selector?: (s: { connections: unknown[] }) => unknown) =>
+    selector ? selector({ connections: [] }) : [];
+  (useConnectionStore as unknown as { getState: () => unknown }).getState = () => ({
+    activeConnectionId: null,
+  });
+  return { useConnectionStore };
+});
 
 vi.mock('../../utils/colorContrast', () => ({
   connectionColor: () => '#000',


### PR DESCRIPTION
## Summary

- 新規クエリタブ (+ ボタン / Ctrl+N) のconnectionIdが未設定になりカラム補完がトリガーされない問題を修正
- 接続ストアの activeConnectionId にフォールバックする pure helper を新設
- MainLayout.tsx と EditorTabs.tsx の呼び出し箇所で利用

Closes #348

## Test plan

- [x] Vitest `newQueryConnection.test.ts` 6 tests PASS
- [x] Vitest 全体 421 tests PASS
- [x] Biome check PASS
- [x] pdg lint PASS
- [x] 手動確認: DB 接続後 Ctrl+N → 新規タブ上で `SELECT a. FROM [table] as a` 入力 → カラム候補表示
