### PR TITLE
fix: SQL補完の文脈判定と未エイリアステーブル対応

### DIFF
--- a/frontend/src/components/editor/completionProvider.ts
+++ b/frontend/src/components/editor/completionProvider.ts
@@ -1,6 +1,7 @@
 import type * as Monaco from 'monaco-editor';
 import { useSchemaStore } from '../../store/schemaStore';
 import { log } from '../../utils/logger';
+import { parseAliases } from './parseAliases';
 
 // SQLキーワード（基本的なもののみ）
 const SQL_KEYWORDS = [
@@ -60,35 +61,6 @@ const SQL_KEYWORDS = [
   'CONVERT',
 ];
 
-// エイリアス情報を解析
-interface AliasInfo {
-  alias: string;
-  tableName: string;
-}
-
-function parseAliases(text: string): AliasInfo[] {
-  const aliases: AliasInfo[] = [];
-
-  // FROM table AS alias, FROM table alias, JOIN table AS alias, JOIN table alias
-  // Brackets are optional to handle both [schema].[table] and schema.table
-  const pattern = /(?:FROM|JOIN)\s+\[?(\w+)\]?(?:\.\[?(\w+)\]?)?\s+(?:AS\s+)?(\w+)/gi;
-
-  const matches = text.matchAll(pattern);
-  for (const match of matches) {
-    const schema = match[2] ? match[1] : null;
-    const table = match[2] ?? match[1];
-    const alias = match[3];
-    if (alias && table && alias.toLowerCase() !== table.toLowerCase()) {
-      aliases.push({
-        alias: alias.toLowerCase(),
-        tableName: schema ? `${schema}.${table}` : table,
-      });
-    }
-  }
-
-  return aliases;
-}
-
 // カーソル位置の文脈を判断
 type ContextType = 'table' | 'column' | 'alias_column' | 'keyword' | 'unknown';
 
@@ -97,31 +69,37 @@ interface CompletionContext {
   aliasOrTable?: string;
 }
 
-function getCompletionContext(
-  model: Monaco.editor.ITextModel,
-  position: Monaco.Position
-): CompletionContext {
-  const lineContent = model.getLineContent(position.lineNumber);
-  const textBeforeCursor = lineContent.substring(0, position.column - 1);
-
-  // ドット直後: エイリアス.カラム または テーブル.カラム
-  const dotMatch = textBeforeCursor.match(/(\w+)\.$/);
+export function detectContextFromText(textBeforeCursor: string): CompletionContext {
+  // ドット直後: エイリアス.カラム または [テーブル].カラム
+  const dotMatch = textBeforeCursor.match(/\[?(\w+)\]?\.$/);
   if (dotMatch) {
     return { type: 'alias_column', aliasOrTable: dotMatch[1] };
   }
 
-  // FROM/JOIN後: テーブル名補完
-  if (/(?:FROM|JOIN)\s+$/i.test(textBeforeCursor)) {
+  // 現在タイピング中の単語を除いた前文脈。これにより `SELECT n` のように部分入力中でも
+  // 直前キーワードで文脈判定できる。
+  const textWithoutCurrentWord = textBeforeCursor.replace(/\w*$/, '');
+
+  if (/(?:FROM|JOIN)\s+$/i.test(textWithoutCurrentWord)) {
     return { type: 'table' };
   }
-
-  // SELECT, WHERE, ON, SET, AND, OR後: カラム名補完
-  if (/(?:SELECT|WHERE|ON|SET|AND|OR|,)\s*$/i.test(textBeforeCursor)) {
+  if (/(?:SELECT|WHERE|ON|SET|AND|OR|,)\s+$/i.test(textWithoutCurrentWord)) {
     return { type: 'column' };
   }
-
-  // デフォルト: キーワード
   return { type: 'keyword' };
+}
+
+function getCompletionContext(
+  model: Monaco.editor.ITextModel,
+  position: Monaco.Position
+): CompletionContext {
+  const textBeforeCursor = model.getValueInRange({
+    startLineNumber: 1,
+    startColumn: 1,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  });
+  return detectContextFromText(textBeforeCursor);
 }
 
 export function createCompletionProvider(
@@ -186,21 +164,46 @@ export function createCompletionProvider(
           }
         }
       } else if (context.type === 'column') {
-        // カラム名補完（全テーブルから）
+        // カラム名補完（FROM句のテーブルから）
         if (connectionId) {
-          // 解析済みテーブルのカラムを補完
+          // 未ロードのテーブルは遅延ロード
+          await Promise.all(
+            aliases.map((alias) => {
+              const cached = useSchemaStore
+                .getState()
+                .getTableColumns(connectionId, alias.tableName);
+              return cached
+                ? Promise.resolve(cached)
+                : useSchemaStore.getState().loadColumns(connectionId, alias.tableName);
+            })
+          );
+
           for (const alias of aliases) {
             const columns = useSchemaStore
               .getState()
               .getTableColumns(connectionId, alias.tableName);
-            if (columns) {
-              for (const col of columns) {
+            if (!columns) continue;
+
+            const emitBare = alias.alias === alias.tableName.toLowerCase();
+            for (const col of columns) {
+              // alias.column 形式(エイリアス有り時の典型入力)
+              suggestions.push({
+                label: `${alias.alias}.${col.name}`,
+                kind: 5, // Field
+                detail: `${alias.tableName}.${col.name} (${col.type})`,
+                insertText: `${alias.alias}.${col.name}`,
+                range,
+                sortText: `a${col.name}`,
+              });
+              // bare column 形式(エイリアス未指定時のみ。重複ノイズ抑制)
+              if (emitBare) {
                 suggestions.push({
-                  label: `${alias.alias}.${col.name}`,
+                  label: col.name,
                   kind: 5, // Field
                   detail: `${alias.tableName}.${col.name} (${col.type})`,
-                  insertText: `${alias.alias}.${col.name}`,
+                  insertText: col.name,
                   range,
+                  sortText: `a${col.name}`,
                 });
               }
             }

--- a/frontend/src/components/editor/parseAliases.ts
+++ b/frontend/src/components/editor/parseAliases.ts
@@ -1,0 +1,71 @@
+export interface AliasInfo {
+  alias: string;
+  tableName: string;
+}
+
+// SQLキーワード。FROM table <keyword> のように直後に出現した場合はエイリアスとみなさない。
+const NON_ALIAS_KEYWORDS = new Set([
+  'WHERE',
+  'ON',
+  'GROUP',
+  'ORDER',
+  'HAVING',
+  'INNER',
+  'LEFT',
+  'RIGHT',
+  'OUTER',
+  'FULL',
+  'JOIN',
+  'CROSS',
+  'UNION',
+  'LIMIT',
+  'OFFSET',
+  'FETCH',
+  'FOR',
+  'WITH',
+  'SET',
+  'VALUES',
+  'RETURNING',
+]);
+
+// エイリアス位置に来てはいけない SQL キーワード。negative lookahead で alias 候補から除外する
+// ことで、正規表現が後続の JOIN/WHERE 等を alias として誤消費しないようにする。
+const ALIAS_BLOCKLIST = [
+  ...NON_ALIAS_KEYWORDS,
+  'FROM',
+  'AS',
+  'AND',
+  'OR',
+  'NOT',
+  'IN',
+  'LIKE',
+  'BETWEEN',
+  'IS',
+  'NULL',
+].join('|');
+
+const ALIAS_LOOKAHEAD = `(?!(?:${ALIAS_BLOCKLIST})\\b)`;
+
+export function parseAliases(text: string): AliasInfo[] {
+  const aliases: AliasInfo[] = [];
+
+  const pattern = new RegExp(
+    String.raw`(?:FROM|JOIN)\s+\[?(\w+)\]?(?:\.\[?(\w+)\]?)?(?:\s+(?:AS\s+)?${ALIAS_LOOKAHEAD}(\w+))?`,
+    'gi'
+  );
+
+  const matches = text.matchAll(pattern);
+  for (const match of matches) {
+    const schema = match[2] ? match[1] : null;
+    const table = match[2] ?? match[1];
+    const rawAlias = match[3];
+    if (!table) continue;
+
+    const hasValidAlias = rawAlias !== undefined && rawAlias.toLowerCase() !== table.toLowerCase();
+    const alias = hasValidAlias ? (rawAlias as string).toLowerCase() : table.toLowerCase();
+    const tableName = schema ? `${schema}.${table}` : table;
+    aliases.push({ alias, tableName });
+  }
+
+  return aliases;
+}

--- a/frontend/src/tests/components/editor/detectContextFromText.test.ts
+++ b/frontend/src/tests/components/editor/detectContextFromText.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { detectContextFromText } from '../../../components/editor/completionProvider';
+
+describe('detectContextFromText', () => {
+  it('detects alias_column after dot', () => {
+    expect(detectContextFromText('SELECT a.')).toEqual({ type: 'alias_column', aliasOrTable: 'a' });
+  });
+
+  it('detects alias_column after dot with bracketed table prefix', () => {
+    expect(detectContextFromText('SELECT [t].')).toEqual({
+      type: 'alias_column',
+      aliasOrTable: 't',
+    });
+  });
+
+  it('detects table after FROM+space', () => {
+    expect(detectContextFromText('SELECT * FROM ')).toEqual({ type: 'table' });
+  });
+
+  it('detects table after FROM with partial word typed', () => {
+    expect(detectContextFromText('SELECT * FROM aut')).toEqual({ type: 'table' });
+  });
+
+  it('detects table after JOIN+space', () => {
+    expect(detectContextFromText('SELECT * FROM a JOIN ')).toEqual({ type: 'table' });
+  });
+
+  it('detects column after SELECT+space', () => {
+    expect(detectContextFromText('SELECT ')).toEqual({ type: 'column' });
+  });
+
+  it('detects column after SELECT with partial word typed (was keyword before fix)', () => {
+    expect(detectContextFromText('SELECT n')).toEqual({ type: 'column' });
+  });
+
+  it('detects column after WHERE with partial word', () => {
+    expect(detectContextFromText('SELECT * FROM t WHERE n')).toEqual({ type: 'column' });
+  });
+
+  it('detects column after comma', () => {
+    expect(detectContextFromText('SELECT a, b, ')).toEqual({ type: 'column' });
+  });
+
+  it('detects column after AND', () => {
+    expect(detectContextFromText('SELECT * FROM t WHERE x=1 AND ')).toEqual({ type: 'column' });
+  });
+
+  it('detects column across multi-line (SQL formatted)', () => {
+    expect(detectContextFromText('SELECT\n    n')).toEqual({ type: 'column' });
+  });
+
+  it('detects table across multi-line after FROM', () => {
+    expect(detectContextFromText('SELECT\n    name\nFROM\n    a')).toEqual({ type: 'table' });
+  });
+
+  it('defaults to keyword at top of empty input', () => {
+    expect(detectContextFromText('')).toEqual({ type: 'keyword' });
+  });
+
+  it('defaults to keyword for unrecognized prefix', () => {
+    expect(detectContextFromText('CREATE TABLE')).toEqual({ type: 'keyword' });
+  });
+});

--- a/frontend/src/tests/components/editor/parseAliases.test.ts
+++ b/frontend/src/tests/components/editor/parseAliases.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { parseAliases } from '../../../components/editor/parseAliases';
+
+describe('parseAliases', () => {
+  describe('with explicit alias', () => {
+    it('parses FROM table AS alias', () => {
+      expect(parseAliases('SELECT * FROM authorities AS a')).toEqual([
+        { alias: 'a', tableName: 'authorities' },
+      ]);
+    });
+
+    it('parses FROM table alias (no AS)', () => {
+      expect(parseAliases('SELECT * FROM authorities a')).toEqual([
+        { alias: 'a', tableName: 'authorities' },
+      ]);
+    });
+
+    it('parses JOIN with alias', () => {
+      expect(parseAliases('SELECT * FROM users u JOIN orders o ON u.id = o.user_id')).toEqual([
+        { alias: 'u', tableName: 'users' },
+        { alias: 'o', tableName: 'orders' },
+      ]);
+    });
+
+    it('handles [bracketed] identifiers', () => {
+      expect(parseAliases('SELECT * FROM [authorities] AS a')).toEqual([
+        { alias: 'a', tableName: 'authorities' },
+      ]);
+    });
+
+    it('handles schema.table', () => {
+      expect(parseAliases('SELECT * FROM [dbo].[users] u')).toEqual([
+        { alias: 'u', tableName: 'dbo.users' },
+      ]);
+    });
+  });
+
+  describe('without alias (new behavior)', () => {
+    it('parses FROM table WHERE (WHERE not treated as alias)', () => {
+      expect(parseAliases('SELECT * FROM authorities WHERE id=1')).toEqual([
+        { alias: 'authorities', tableName: 'authorities' },
+      ]);
+    });
+
+    it('parses FROM table at end of string', () => {
+      expect(parseAliases('SELECT * FROM authorities')).toEqual([
+        { alias: 'authorities', tableName: 'authorities' },
+      ]);
+    });
+
+    it('parses FROM table ORDER BY', () => {
+      expect(parseAliases('SELECT * FROM users ORDER BY id')).toEqual([
+        { alias: 'users', tableName: 'users' },
+      ]);
+    });
+
+    it('parses FROM table GROUP BY', () => {
+      expect(parseAliases('SELECT name FROM users GROUP BY name')).toEqual([
+        { alias: 'users', tableName: 'users' },
+      ]);
+    });
+
+    it('parses FROM table JOIN table2 (both without alias)', () => {
+      expect(parseAliases('SELECT * FROM users JOIN orders ON users.id=orders.user_id')).toEqual([
+        { alias: 'users', tableName: 'users' },
+        { alias: 'orders', tableName: 'orders' },
+      ]);
+    });
+
+    it('parses FROM table INNER JOIN (INNER not treated as alias)', () => {
+      expect(parseAliases('SELECT * FROM users INNER JOIN orders o ON users.id=o.user_id')).toEqual(
+        [
+          { alias: 'users', tableName: 'users' },
+          { alias: 'o', tableName: 'orders' },
+        ]
+      );
+    });
+
+    it('parses FROM table LEFT JOIN', () => {
+      expect(parseAliases('SELECT * FROM users LEFT JOIN orders o ON users.id=o.user_id')).toEqual([
+        { alias: 'users', tableName: 'users' },
+        { alias: 'o', tableName: 'orders' },
+      ]);
+    });
+
+    it('handles [bracketed] table without alias', () => {
+      expect(parseAliases('SELECT * FROM [authorities] WHERE id=1')).toEqual([
+        { alias: 'authorities', tableName: 'authorities' },
+      ]);
+    });
+  });
+
+  describe('mixed cases', () => {
+    it('mixes aliased and non-aliased tables', () => {
+      expect(
+        parseAliases('SELECT * FROM users u JOIN orders ON u.id=orders.user_id WHERE u.active=1')
+      ).toEqual([
+        { alias: 'u', tableName: 'users' },
+        { alias: 'orders', tableName: 'orders' },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
- parseAliases: `negative lookahead` でキーワード誤消費を解消、エイリアス省略時は `tableName` を使用
- detectContextFromText: タイピング中の単語を削って判定( `SELECT n → column` 文脈)、カーソル位置まで全文参照で整形後も動作
- completionProvider: bare column発行 + 未ロード遅延読込
  - bracketed dot match
