### PR TITLE
fix: Ctrl+Aの誤選択を抑止し全行選択ハンドラを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { ToastContainer } from './components/common/Toast';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { MainLayout } from './components/layout/MainLayout';
+import { useSuppressNativeSelectAll } from './hooks/useSuppressNativeSelectAll';
 import { useConnectionStore } from './store/connectionStore';
 import { useQueryStore } from './store/queryStore';
 
@@ -23,6 +24,8 @@ function App() {
       document.body.removeAttribute('data-production');
     }
   }, [isProduction]);
+
+  useSuppressNativeSelectAll();
 
   return (
     <ErrorBoundary>

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -119,6 +119,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     rangeCellSelect,
     selectColumn,
     rangeSelectColumn,
+    selectAllRows,
     resetSelection,
   } = useGridSelection(rowsLengthRef, columnOrderRef);
 
@@ -310,6 +311,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     onApplyChanges: buildPreview,
     onNavigateRelated: navigateRelated,
     onOpenValueEditor: openValueEditor,
+    onSelectAll: selectAllRows,
   });
 
   const isPaginated = !!pagination;

--- a/frontend/src/components/grid/hooks/useGridKeyboard.ts
+++ b/frontend/src/components/grid/hooks/useGridKeyboard.ts
@@ -30,6 +30,7 @@ interface UseGridKeyboardOptions {
   onApplyChanges: () => Promise<void>;
   onNavigateRelated?: (rowIndex: number, columnName: string) => void;
   onOpenValueEditor?: (rowIndex: number, columnName: string, currentValue: string | null) => void;
+  onSelectAll?: () => void;
 }
 
 interface UseGridKeyboardResult {
@@ -58,6 +59,7 @@ export function useGridKeyboard({
   onApplyChanges,
   onNavigateRelated,
   onOpenValueEditor,
+  onSelectAll,
 }: UseGridKeyboardOptions): UseGridKeyboardResult {
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
   const [editValue, setEditValue] = useState<string>('');
@@ -237,6 +239,16 @@ export function useGridKeyboard({
     if (e.ctrlKey && e.shiftKey && e.key === 'N') {
       e.preventDefault();
       setNull();
+      return;
+    }
+
+    // Ctrl+A: Select all rows (INPUT/TEXTAREA/contenteditable focus 中は既定動作優先)
+    if (e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 'a' || e.key === 'A')) {
+      const active = document.activeElement as HTMLElement | null;
+      const tag = active?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || active?.isContentEditable) return;
+      e.preventDefault();
+      onSelectAll?.();
       return;
     }
 

--- a/frontend/src/components/grid/hooks/useGridSelection.ts
+++ b/frontend/src/components/grid/hooks/useGridSelection.ts
@@ -64,12 +64,13 @@ export function useGridSelection(
       for (let i = 0; i < count; i++) allRows.add(i);
       return allRows;
     });
+    setSelectedColumns(new Set());
   }, [rowsLengthRef]);
 
   const selectColumn = useCallback(
     (columnId: string) => {
-      setSelectedColumns(new Set([columnId]));
       selectAllRows();
+      setSelectedColumns(new Set([columnId]));
       lastClickedRowRef.current = null;
       lastClickedColumnRef.current = columnId;
     },
@@ -84,8 +85,8 @@ export function useGridSelection(
       const endIdx = allColumnIds.indexOf(columnId);
       if (startIdx === -1 || endIdx === -1) return;
       const [from, to] = startIdx < endIdx ? [startIdx, endIdx] : [endIdx, startIdx];
-      setSelectedColumns(new Set(allColumnIds.slice(from, to + 1)));
       selectAllRows();
+      setSelectedColumns(new Set(allColumnIds.slice(from, to + 1)));
       lastClickedRowRef.current = null;
     },
     [columnOrderRef, selectAllRows]
@@ -111,6 +112,7 @@ export function useGridSelection(
     rangeCellSelect,
     selectColumn,
     rangeSelectColumn,
+    selectAllRows,
     resetSelection,
   };
 }

--- a/frontend/src/hooks/useSuppressNativeSelectAll.ts
+++ b/frontend/src/hooks/useSuppressNativeSelectAll.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+/**
+ * INPUT/TEXTAREA/contenteditable 以外にフォーカスがある時の Ctrl+A を抑止する。
+ * WebView2 既定のページ全選択がツリーや空白領域で誤発火するのを防ぐ。
+ */
+export function useSuppressNativeSelectAll(): void {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!(e.ctrlKey || e.metaKey) || e.shiftKey || e.altKey) return;
+      if (e.key !== 'a' && e.key !== 'A') return;
+      const target = document.activeElement as HTMLElement | null;
+      if (!target) {
+        e.preventDefault();
+        return;
+      }
+      const tag = target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (target.isContentEditable) return;
+      e.preventDefault();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+}

--- a/frontend/src/tests/grid/useGridKeyboard.test.ts
+++ b/frontend/src/tests/grid/useGridKeyboard.test.ts
@@ -11,8 +11,11 @@ vi.mock('../../hooks/useCopyToClipboard', () => ({
   useCopyToClipboard: () => mockCopyToClipboard,
 }));
 
+let capturedKeydownHandler: ((e: KeyboardEvent) => void) | null = null;
 vi.mock('../../hooks/useKeyboardHandler', () => ({
-  useKeyboardHandler: vi.fn(),
+  useKeyboardHandler: (handler: (e: KeyboardEvent) => void) => {
+    capturedKeydownHandler = handler;
+  },
 }));
 
 vi.mock('../../utils/logger', () => ({
@@ -49,6 +52,49 @@ const baseOptions = {
 describe('useGridKeyboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedKeydownHandler = null;
+  });
+
+  describe('Ctrl+A', () => {
+    it('onSelectAll を呼び preventDefault する', () => {
+      const onSelectAll = vi.fn();
+      renderHook(() => useGridKeyboard({ ...baseOptions, onSelectAll }));
+
+      const event = new KeyboardEvent('keydown', { key: 'a', ctrlKey: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      capturedKeydownHandler?.(event);
+
+      expect(onSelectAll).toHaveBeenCalledTimes(1);
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('Shift を伴う Ctrl+Shift+A は処理しない', () => {
+      const onSelectAll = vi.fn();
+      renderHook(() => useGridKeyboard({ ...baseOptions, onSelectAll }));
+
+      const event = new KeyboardEvent('keydown', { key: 'A', ctrlKey: true, shiftKey: true });
+      capturedKeydownHandler?.(event);
+
+      expect(onSelectAll).not.toHaveBeenCalled();
+    });
+
+    it('INPUT フォーカス中は onSelectAll を呼ばず既定動作を許可する', () => {
+      const onSelectAll = vi.fn();
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.focus();
+      try {
+        renderHook(() => useGridKeyboard({ ...baseOptions, onSelectAll }));
+        const event = new KeyboardEvent('keydown', { key: 'a', ctrlKey: true });
+        const preventDefault = vi.spyOn(event, 'preventDefault');
+        capturedKeydownHandler?.(event);
+
+        expect(onSelectAll).not.toHaveBeenCalled();
+        expect(preventDefault).not.toHaveBeenCalled();
+      } finally {
+        document.body.removeChild(input);
+      }
+    });
   });
 
   describe('copySelection', () => {


### PR DESCRIPTION
- ツリー/空白フォーカス時のWebView2既定ページ全選択を抑止
- グリッドフォーカス時はCtrl+Aで全行選択
- INPUT/TEXTAREA/contenteditableフォーカス時は既定動作を維持
