### PR TITLE
feat: 接続ツリーのDBノードを環境別に色分け

### DIFF
--- a/frontend/src/components/dialogs/ConnectionDialog.module.css
+++ b/frontend/src/components/dialogs/ConnectionDialog.module.css
@@ -481,7 +481,7 @@
 
 /* Environment-specific colors */
 .environmentRadio.env-development.selected {
-  border-color: #4caf50;
+  border-color: var(--env-development-color);
   background: rgba(76, 175, 80, 0.1);
 }
 
@@ -490,7 +490,7 @@
 }
 
 .environmentRadio.env-staging.selected {
-  border-color: #ff9800;
+  border-color: var(--env-staging-color);
   background: rgba(255, 152, 0, 0.1);
 }
 
@@ -499,7 +499,7 @@
 }
 
 .environmentRadio.env-production.selected {
-  border-color: #f44336;
+  border-color: var(--env-production-color);
   background: rgba(244, 67, 54, 0.1);
 }
 

--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -418,6 +418,7 @@ export function ConnectionTreeSection({
           loadingNodes={loadingNodes}
           selectedNodeId={selectedNodeId}
           connectionColor={connColor}
+          environment={connection.environment}
           onToggle={toggleNode}
           onTableOpen={handleTableOpen}
           onContextMenu={handleContextMenu}

--- a/frontend/src/components/tree/TreeNode.module.css
+++ b/frontend/src/components/tree/TreeNode.module.css
@@ -86,6 +86,18 @@
   padding-left: 4px;
 }
 
+.nameEnvDevelopment {
+  color: var(--env-development-color);
+}
+
+.nameEnvStaging {
+  color: var(--env-staging-color);
+}
+
+.nameEnvProduction {
+  color: var(--env-production-color);
+}
+
 .comment {
   flex: 1;
   overflow: hidden;

--- a/frontend/src/components/tree/TreeNode.tsx
+++ b/frontend/src/components/tree/TreeNode.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from 'react';
-import type { DatabaseObject } from '../../types';
+import type { DatabaseObject, EnvironmentType } from '../../types';
 import { type ExpandableType, isExpandableType } from '../../utils/treeNode';
 import styles from './TreeNode.module.css';
 
@@ -10,10 +10,17 @@ interface TreeNodeProps {
   loadingNodes?: Set<string>;
   selectedNodeId?: string | null;
   connectionColor?: string;
+  environment?: EnvironmentType;
   onToggle: (id: string, node: DatabaseObject) => void;
   onTableOpen?: (nodeId: string, tableName: string, tableType: ExpandableType) => void;
   onContextMenu?: (e: React.MouseEvent, node: DatabaseObject) => void;
 }
+
+const ENV_NAME_CLASS: Record<EnvironmentType, string> = {
+  development: styles.nameEnvDevelopment,
+  staging: styles.nameEnvStaging,
+  production: styles.nameEnvProduction,
+};
 
 // SVG Icons for tree nodes
 const Icons = {
@@ -129,6 +136,7 @@ export const TreeNode = memo(function TreeNode({
   loadingNodes,
   selectedNodeId,
   connectionColor: connColor,
+  environment,
   onToggle,
   onTableOpen,
   onContextMenu,
@@ -163,6 +171,9 @@ export const TreeNode = memo(function TreeNode({
 
   const nodeClasses = `${styles.node}${isLoading ? ` ${styles.loading}` : ''}${isSelected ? ` ${styles.selected}` : ''}`;
 
+  const envClass = node.type === 'database' && environment ? ENV_NAME_CLASS[environment] : '';
+  const nameClasses = `${styles.name}${envClass ? ` ${envClass}` : ''}`;
+
   const nodeStyle = useMemo(
     () => ({
       paddingLeft: `${level * 12 + 4}px`,
@@ -191,7 +202,7 @@ export const TreeNode = memo(function TreeNode({
         <span className={`${styles.icon} ${getIconClass(node.type)}`}>
           {getIcon(node.type, isExpanded)}
         </span>
-        <span className={styles.name}>{node.name}</span>
+        <span className={nameClasses}>{node.name}</span>
         {node.metadata?.comment && <span className={styles.comment}>{node.metadata.comment}</span>}
       </div>
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -54,6 +54,11 @@
   --icon-color: #8c8f94;
   --icon-color-hover: #dfe1e5;
 
+  /* Environment colors (shared between ConnectionDialog border and tree DB name) */
+  --env-development-color: #4caf50;
+  --env-staging-color: #ff9800;
+  --env-production-color: #f44336;
+
   /* Production environment colors */
   --production-bg-primary: #2a1f1f;
   --production-bg-secondary: #352626;

--- a/frontend/src/tests/tree/TreeNode.test.tsx
+++ b/frontend/src/tests/tree/TreeNode.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { TreeNode } from '../../components/tree/TreeNode';
-import type { DatabaseObject } from '../../types';
+import type { DatabaseObject, EnvironmentType } from '../../types';
 
 const createNode = (overrides: Partial<DatabaseObject> = {}): DatabaseObject => ({
   id: 'test-1',
@@ -44,5 +44,47 @@ describe('TreeNode canExpand', () => {
     render(<TreeNode {...createBaseProps()} node={createNode({ type: 'column', name: 'id' })} />);
     const expander = screen.getByRole('button', { hidden: true });
     expect(expander).not.toBeVisible();
+  });
+});
+
+describe('TreeNode environment color', () => {
+  const envCases: Array<{ env: EnvironmentType; expectedClass: string }> = [
+    { env: 'development', expectedClass: 'nameEnvDevelopment' },
+    { env: 'staging', expectedClass: 'nameEnvStaging' },
+    { env: 'production', expectedClass: 'nameEnvProduction' },
+  ];
+
+  for (const { env, expectedClass } of envCases) {
+    it(`databaseノードに environment=${env} を渡すと ${expectedClass} クラスが付く`, () => {
+      render(
+        <TreeNode
+          {...createBaseProps()}
+          node={createNode({ type: 'database', name: 'mydb' })}
+          environment={env}
+        />
+      );
+      const name = screen.getByText('mydb');
+      expect(name.className).toMatch(new RegExp(expectedClass));
+    });
+  }
+
+  it('environment未指定なら環境クラスは付かない', () => {
+    render(
+      <TreeNode {...createBaseProps()} node={createNode({ type: 'database', name: 'mydb' })} />
+    );
+    const name = screen.getByText('mydb');
+    expect(name.className).not.toMatch(/nameEnv(Development|Staging|Production)/);
+  });
+
+  it('databaseタイプ以外にenvironmentを渡しても環境クラスは付かない（ルートのみ）', () => {
+    render(
+      <TreeNode
+        {...createBaseProps()}
+        node={createNode({ type: 'table', name: 'users' })}
+        environment="production"
+      />
+    );
+    const name = screen.getByText('users');
+    expect(name.className).not.toMatch(/nameEnv(Development|Staging|Production)/);
   });
 });


### PR DESCRIPTION
ルートDBノードの文字色を開発/ステージング/本番で緑/橙/赤に色分けし、環境をぱっと見で判別できるようにする。色値はConnectionDialogの環境枠と同値のため、global.cssの--env-*-colorに共通化して参照を統一する。
