### PR TITLE
fix: WHEREフィルターのタブ間リークを解消

### DIFF
--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -134,6 +134,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   } = useWhereFilter({
     activeQueryId: targetQueryId,
     queryConnectionId,
+    storedWhereClause: currentQuery?.whereClause ?? '',
     applyWhereFilter,
   });
 

--- a/frontend/src/components/grid/hooks/useWhereFilter.ts
+++ b/frontend/src/components/grid/hooks/useWhereFilter.ts
@@ -1,8 +1,9 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 interface UseWhereFilterParams {
   activeQueryId: string | null;
   queryConnectionId: string | null;
+  storedWhereClause: string;
   applyWhereFilter: (
     queryId: string,
     connectionId: string,
@@ -13,10 +14,17 @@ interface UseWhereFilterParams {
 export function useWhereFilter({
   activeQueryId,
   queryConnectionId,
+  storedWhereClause,
   applyWhereFilter,
 }: UseWhereFilterParams) {
-  const [whereClause, setWhereClause] = useState('');
+  const [whereClause, setWhereClause] = useState(storedWhereClause);
   const [whereFilterError, setWhereFilterError] = useState<string | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally triggered by activeQueryId change
+  useEffect(() => {
+    setWhereClause(storedWhereClause);
+    setWhereFilterError(null);
+  }, [activeQueryId]);
 
   const whereKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/frontend/src/store/query/slices/dataViewSlice.ts
+++ b/frontend/src/store/query/slices/dataViewSlice.ts
@@ -93,6 +93,7 @@ export function createDataViewSlice(
           connectionId,
           isDirty: false,
           sourceTable: tableName,
+          whereClause: whereClause ?? '',
           isDataView: true,
           useServerSideRowModel: false,
           logicalName,
@@ -166,7 +167,7 @@ export function createDataViewSlice(
         set((state) => ({
           ...startExecution(state, id),
           queries: state.queries.map((q) =>
-            q.id === id ? { ...q, content: sql, isDirty: true } : q
+            q.id === id ? { ...q, content: sql, whereClause: whereClause.trim(), isDirty: true } : q
           ),
         }));
 

--- a/frontend/src/tests/grid/useWhereFilter.test.ts
+++ b/frontend/src/tests/grid/useWhereFilter.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useWhereFilter } from '../../components/grid/hooks/useWhereFilter';
+
+interface SetupProps {
+  activeQueryId: string | null;
+  queryConnectionId: string | null;
+  storedWhereClause: string;
+}
+
+function setup(
+  initial: SetupProps = {
+    activeQueryId: 'q1',
+    queryConnectionId: 'c1',
+    storedWhereClause: '',
+  }
+) {
+  const applyWhereFilter = vi.fn().mockResolvedValue(null);
+  const hook = renderHook(
+    ({ activeQueryId, queryConnectionId, storedWhereClause }: SetupProps) =>
+      useWhereFilter({
+        activeQueryId,
+        queryConnectionId,
+        storedWhereClause,
+        applyWhereFilter,
+      }),
+    { initialProps: initial }
+  );
+  return { hook, applyWhereFilter };
+}
+
+describe('useWhereFilter', () => {
+  it('アクティブクエリが切り替わると storedWhereClause に同期する', () => {
+    const { hook } = setup();
+
+    act(() => {
+      hook.result.current.setWhereClause('age > 18');
+    });
+    expect(hook.result.current.whereClause).toBe('age > 18');
+
+    hook.rerender({ activeQueryId: 'q2', queryConnectionId: 'c1', storedWhereClause: '' });
+
+    expect(hook.result.current.whereClause).toBe('');
+    expect(hook.result.current.whereFilterError).toBeNull();
+  });
+
+  it('保存された WHERE 句があるタブに切り替えるとそれを復元する', () => {
+    const { hook } = setup();
+
+    hook.rerender({
+      activeQueryId: 'q2',
+      queryConnectionId: 'c1',
+      storedWhereClause: 'status = 1',
+    });
+
+    expect(hook.result.current.whereClause).toBe('status = 1');
+  });
+
+  it('同じクエリIDではリセットせず、applyWhereFilter も呼ばれない', () => {
+    const { hook, applyWhereFilter } = setup();
+
+    act(() => {
+      hook.result.current.setWhereClause('id = 1');
+    });
+
+    hook.rerender({
+      activeQueryId: 'q1',
+      queryConnectionId: 'c1',
+      storedWhereClause: '',
+    });
+
+    expect(hook.result.current.whereClause).toBe('id = 1');
+    expect(applyWhereFilter).not.toHaveBeenCalled();
+  });
+
+  it('エラー表示も切り替え時にクリアする', () => {
+    const { hook } = setup();
+
+    act(() => {
+      hook.result.current.setWhereFilterError('syntax error');
+    });
+    expect(hook.result.current.whereFilterError).toBe('syntax error');
+
+    hook.rerender({ activeQueryId: 'q2', queryConnectionId: 'c1', storedWhereClause: '' });
+
+    expect(hook.result.current.whereFilterError).toBeNull();
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -88,6 +88,7 @@ export interface Query {
   isDirty: boolean;
   filePath?: string; // File path when saved to disk
   sourceTable?: string; // Table name when opened from Object Tree (for WHERE filter)
+  whereClause?: string; // Applied WHERE clause for data view (persists across tab switches)
   isDataView?: boolean; // True when viewing table data (show grid instead of editor)
   isERDiagram?: boolean; // True when viewing ER diagram
   useServerSideRowModel?: boolean; // Use AG Grid Server-Side Row Model for large tables


### PR DESCRIPTION
useWhereFilter のローカル state がタブ切替時にリセットされず、前タブの WHERE 句が別タブの UI に残っていた。

- Query 型に whereClause? を追加してタブ単位で保存
- openTableData / applyWhereFilter で保存
- useWhereFilter は activeQueryId 変化時に storedWhereClause へ同期
