### PR TITLE
fix: 接続ツリーの `environment` 色分けが反映されない不具合を修正

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -162,6 +162,7 @@ export function MainLayout() {
         dbType: config.dbType,
         isProduction: config.isProduction,
         isReadOnly: config.isReadOnly,
+        environment: config.environment,
         ssh: config.ssh.enabled
           ? {
               enabled: true,

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -3,30 +3,47 @@ import { useShallow } from 'zustand/react/shallow';
 import { bridge } from '../../api/bridge';
 import { applyConnectionMigration } from '../../store/connectionMigration';
 import { useConnectionActions, useConnectionStore } from '../../store/connectionStore';
+import {
+  isDatabaseType,
+  isEnvironmentType,
+  isSshAuthType,
+  type SavedConnectionProfile,
+} from '../../types';
 import type { ExpandableType } from '../../utils/treeNode';
 import { ConnectionTreeSection } from './ConnectionTreeSection';
 import styles from './ObjectTree.module.css';
 
-interface SavedProfile {
-  id: string;
-  name: string;
-  server: string;
-  port?: number;
-  database: string;
-  username: string;
-  useWindowsAuth: boolean;
-  savePassword?: boolean;
-  isProduction?: boolean;
-  isReadOnly?: boolean;
-  dbType?: 'sqlserver' | 'postgresql' | 'mysql';
-  ssh?: {
-    enabled: boolean;
-    host: string;
-    port: number;
-    username: string;
-    authType: 'password' | 'privateKey';
-    privateKeyPath: string;
-    savePassword: boolean;
+type RawProfile = Awaited<ReturnType<typeof bridge.getConnectionProfiles>>['profiles'][number];
+
+function normalizeProfile(p: RawProfile): SavedConnectionProfile {
+  return {
+    id: p.id,
+    name: p.name,
+    server: p.server,
+    port: p.port ?? 1433,
+    database: p.database,
+    username: p.username,
+    useWindowsAuth: p.useWindowsAuth,
+    savePassword: p.savePassword ?? false,
+    isProduction: p.isProduction ?? false,
+    isReadOnly: p.isReadOnly ?? false,
+    environment: isEnvironmentType(p.environment ?? '')
+      ? p.environment
+      : p.isProduction
+        ? 'production'
+        : 'development',
+    dbType: isDatabaseType(p.dbType ?? '') ? p.dbType : 'sqlserver',
+    ssh: p.ssh
+      ? {
+          enabled: p.ssh.enabled ?? false,
+          host: p.ssh.host ?? '',
+          port: p.ssh.port ?? 22,
+          username: p.ssh.username ?? '',
+          authType: isSshAuthType(p.ssh.authType ?? '') ? p.ssh.authType : 'password',
+          privateKeyPath: p.ssh.privateKeyPath ?? '',
+          savePassword: p.ssh.savePassword ?? false,
+        }
+      : undefined,
   };
 }
 
@@ -43,8 +60,8 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
     }))
   );
   const { addConnection, cancelConnection } = useConnectionActions();
-  const [profiles, setProfiles] = useState<SavedProfile[]>([]);
-  const [confirmingProfile, setConfirmingProfile] = useState<SavedProfile | null>(null);
+  const [profiles, setProfiles] = useState<SavedConnectionProfile[]>([]);
+  const [confirmingProfile, setConfirmingProfile] = useState<SavedConnectionProfile | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: profileVersion is an intentional re-fetch trigger
@@ -52,7 +69,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
     const fetchProfiles = async () => {
       try {
         const result = await bridge.getConnectionProfiles();
-        setProfiles(result.profiles);
+        setProfiles(result.profiles.map(normalizeProfile));
       } catch (error) {
         console.error('Failed to fetch profiles:', error);
       }
@@ -68,7 +85,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
     (profile) => !connections.some((c) => c.name === profile.name)
   );
 
-  const handleProfileClick = useCallback((profile: SavedProfile) => {
+  const handleProfileClick = useCallback((profile: SavedConnectionProfile) => {
     setConfirmingProfile(profile);
   }, []);
 
@@ -99,14 +116,17 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
       const result = await addConnection({
         name: confirmingProfile.name,
         server: confirmingProfile.server,
-        port: confirmingProfile.port ?? 1433,
+        port: confirmingProfile.port,
         database: confirmingProfile.database,
         username: confirmingProfile.username,
         password,
         useWindowsAuth: confirmingProfile.useWindowsAuth,
         dbType: confirmingProfile.dbType ?? 'sqlserver',
-        isProduction: confirmingProfile.isProduction ?? false,
-        isReadOnly: confirmingProfile.isReadOnly ?? false,
+        isProduction: confirmingProfile.isProduction,
+        isReadOnly: confirmingProfile.isReadOnly,
+        environment:
+          confirmingProfile.environment ??
+          (confirmingProfile.isProduction ? 'production' : 'development'),
         ssh: confirmingProfile.ssh?.enabled
           ? {
               enabled: true,

--- a/frontend/src/tests/components/tree/ObjectTreeProfileConnect.test.tsx
+++ b/frontend/src/tests/components/tree/ObjectTreeProfileConnect.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addConnectionMock = vi.fn().mockResolvedValue({});
+const cancelConnectionMock = vi.fn();
+
+vi.mock('../../../store/connectionStore', () => {
+  const useConnectionStore = (
+    selector?: (s: { connections: unknown[]; profileVersion: number }) => unknown
+  ) => (selector ? selector({ connections: [], profileVersion: 0 }) : null);
+  (useConnectionStore as unknown as { getState: () => unknown }).getState = () => ({
+    connections: [],
+    activeConnectionId: null,
+  });
+  return {
+    useConnectionStore,
+    useConnectionActions: () => ({
+      addConnection: addConnectionMock,
+      cancelConnection: cancelConnectionMock,
+    }),
+  };
+});
+
+vi.mock('../../../store/connectionMigration', () => ({
+  applyConnectionMigration: vi.fn(),
+}));
+
+vi.mock('../../../api/bridge', () => ({
+  bridge: {
+    getConnectionProfiles: vi.fn().mockResolvedValue({
+      profiles: [
+        {
+          id: 'p_stg',
+          name: 'Staging.MMS',
+          server: '172.31.17.239',
+          port: 1433,
+          database: 'MMS',
+          username: 'sa',
+          useWindowsAuth: false,
+          savePassword: false,
+          isProduction: false,
+          isReadOnly: false,
+          environment: 'staging',
+          dbType: 'sqlserver',
+        },
+      ],
+    }),
+    getProfilePassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshPassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshKeyPassphrase: vi.fn().mockResolvedValue({ passphrase: '' }),
+  },
+}));
+
+import { ObjectTree } from '../../../components/tree/ObjectTree';
+
+describe('ObjectTree profile connect', () => {
+  beforeEach(() => {
+    addConnectionMock.mockClear();
+    cancelConnectionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('staging プロファイル接続時に environment=staging が addConnection に渡される', async () => {
+    render(<ObjectTree filter="" />);
+
+    const profileItem = await screen.findByText('Staging.MMS');
+    fireEvent.click(profileItem);
+
+    const connectButton = await screen.findByText('接続');
+    fireEvent.click(connectButton);
+
+    await waitFor(() => {
+      expect(addConnectionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ environment: 'staging' })
+      );
+    });
+  });
+});

--- a/frontend/src/tests/stores/connectionStore.test.ts
+++ b/frontend/src/tests/stores/connectionStore.test.ts
@@ -72,6 +72,22 @@ describe('connectionStore', () => {
       expect(state.connectRequestId).toBeNull();
     });
 
+    it('should preserve explicit environment (staging) instead of inferring from isProduction', async () => {
+      mockConnectAsync.mockResolvedValue({ requestId: 'conn_1' });
+      mockGetConnectResult.mockResolvedValue({
+        status: 'connected',
+        connectionId: 'db_1',
+      });
+
+      await useConnectionStore.getState().addConnection({
+        ...baseConnection,
+        environment: 'staging',
+      });
+
+      const state = useConnectionStore.getState();
+      expect(state.connections[0].environment).toBe('staging');
+    });
+
     it('should set isConnecting=true during connection', async () => {
       let resolveConnect: ((v: { requestId: string }) => void) | undefined;
       mockConnectAsync.mockReturnValue(


### PR DESCRIPTION
`ObjectTree / MainLayout` の `addConnection` 呼び出しで `environment` が渡されておらず、 `staging` プロファイルでも `isProduction:false` のため、 `development` にフォールバックして緑色になっていた。

- `ObjectTree`: 共通 `SavedConnectionProfile` 型へ統一し `normalizeProfile` で `bridge` 戻り値を正規化。 `addConnection` に `environment` を明示的に渡す
- `MainLayout`: `addConnection` に `config.environment` を渡す
- 回帰テスト追加 ( `connectionStore` の `environment` 保持 + `ObjectTree` の プロファイル接続フロー)