### PR TITLE
fix: SQL実行時の接続ロスト自動回復とフォーマットエラーUX分離

### DIFF
--- a/frontend/src/store/query/slices/formatSlice.ts
+++ b/frontend/src/store/query/slices/formatSlice.ts
@@ -1,4 +1,5 @@
 import { formatSQL } from '../../../utils/sqlFormat';
+import { useToastStore } from '../../toastStore';
 import type { Formattable } from '../interfaces/Formattable';
 import type { GetState, SetState } from '../types';
 
@@ -16,12 +17,8 @@ export function createFormatSlice(set: SetState, get: GetState): Formattable {
           ),
         }));
       } catch (error) {
-        set((state) => ({
-          errors: {
-            ...state.errors,
-            [id]: error instanceof Error ? error.message : 'Failed to format SQL',
-          },
-        }));
+        const reason = error instanceof Error ? error.message : 'Failed to format SQL';
+        useToastStore.getState().addToast(`フォーマットできません: ${reason}`, 'error');
       }
     },
 

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -30,6 +30,37 @@ function hasExplicitLimit(sql: string): boolean {
   );
 }
 
+const STALE_CONNECTION_PATTERN = /Connection not found|is no longer active/i;
+
+function recoverStaleConnection(
+  set: SetState,
+  get: GetState,
+  id: string,
+  staleConnectionId: string
+): void {
+  const activeConnId = useConnectionStore.getState().activeConnectionId;
+  const canRebind = !!activeConnId && activeConnId !== staleConnectionId;
+  if (canRebind) {
+    get().updateQueryConnection(id, activeConnId);
+    set((state) =>
+      failExecution(
+        state,
+        id,
+        `接続 ${staleConnectionId} は失われました。アクティブ接続 ${activeConnId} に再バインドしたので、もう一度実行してください。`
+      )
+    );
+    return;
+  }
+  get().updateQueryConnection(id, null);
+  set((state) =>
+    failExecution(
+      state,
+      id,
+      `接続 ${staleConnectionId} は失われました。接続ツリーから接続を選択し直してください。`
+    )
+  );
+}
+
 export function createExecuteSlice(
   set: SetState,
   get: GetState,
@@ -148,6 +179,11 @@ export function createExecuteSlice(
         return;
       }
       const errorMessage = error instanceof Error ? error.message : 'Query execution failed';
+
+      if (STALE_CONNECTION_PATTERN.test(errorMessage)) {
+        recoverStaleConnection(set, get, id, connectionId);
+        return;
+      }
 
       set((state) => failExecution(state, id, errorMessage));
     } finally {

--- a/frontend/src/tests/stores/queryStore.format-fileio.test.ts
+++ b/frontend/src/tests/stores/queryStore.format-fileio.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useQueryStore } from '../../store/queryStore';
+import { useToastStore } from '../../store/toastStore';
 
 vi.mock('../../api/bridge', () => ({
   bridge: {
@@ -87,19 +88,25 @@ describe('formatQuery', () => {
     expect(mockedFormatSQL).not.toHaveBeenCalled();
   });
 
-  it('should set error on format failure', async () => {
+  it('should show toast and not set query error on format failure', async () => {
     const { addQuery, updateQuery } = useQueryStore.getState();
     addQuery('conn_1');
     const queryId = useQueryStore.getState().queries[0].id;
     updateQuery(queryId, 'INVALID');
 
+    useToastStore.setState({ toasts: [] });
+
     vi.mocked(mockedFormatSQL).mockImplementationOnce(() => {
-      throw new Error('Parse error');
+      throw new Error('Parse error at token: ;');
     });
 
     await useQueryStore.getState().formatQuery(queryId);
 
-    expect(useQueryStore.getState().errors[queryId]).toBe('Parse error');
+    expect(useQueryStore.getState().errors[queryId]).toBeUndefined();
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].type).toBe('error');
+    expect(toasts[0].message).toContain('Parse error at token: ;');
   });
 });
 

--- a/frontend/src/tests/stores/queryStore.test.ts
+++ b/frontend/src/tests/stores/queryStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '../helpers/mockSettingsUtils';
+import { useConnectionStore } from '../../store/connectionStore';
 import { useQueryStore } from '../../store/queryStore';
 
 // Mock the bridge module
@@ -31,6 +32,7 @@ describe('queryStore', () => {
       errors: {},
       isExecuting: false,
     });
+    useConnectionStore.setState({ activeConnectionId: null });
     vi.clearAllMocks();
   });
 
@@ -171,6 +173,43 @@ describe('queryStore', () => {
       expect(errors[queryId]).toBe('Syntax error');
       expect(isExecuting).toBe(false);
       expect(executingQueryIds.has(queryId)).toBe(false);
+    });
+
+    it('should rebind tab to active connection when backend reports stale connectionId', async () => {
+      const { addQuery, updateQuery, executeQuery } = useQueryStore.getState();
+
+      addQuery('conn_1');
+      const queryId = useQueryStore.getState().queries[0].id;
+      updateQuery(queryId, 'SELECT 1');
+
+      useConnectionStore.setState({ activeConnectionId: 'conn_5' });
+
+      mockedBridge.executeAsyncQuery.mockRejectedValue(new Error('Connection not found: conn_1'));
+
+      await executeQuery(queryId, 'conn_1');
+
+      const state = useQueryStore.getState();
+      expect(state.queries[0].connectionId).toBe('conn_5');
+      expect(state.errors[queryId]).toContain('conn_5');
+      expect(state.errors[queryId]).toContain('再バインド');
+    });
+
+    it('should clear tab connectionId when no active fallback is available', async () => {
+      const { addQuery, updateQuery, executeQuery } = useQueryStore.getState();
+
+      addQuery('conn_1');
+      const queryId = useQueryStore.getState().queries[0].id;
+      updateQuery(queryId, 'SELECT 1');
+
+      useConnectionStore.setState({ activeConnectionId: null });
+
+      mockedBridge.executeAsyncQuery.mockRejectedValue(new Error('Connection not found: conn_1'));
+
+      await executeQuery(queryId, 'conn_1');
+
+      const state = useQueryStore.getState();
+      expect(state.queries[0].connectionId).toBeNull();
+      expect(state.errors[queryId]).toContain('選択');
     });
   });
 


### PR DESCRIPTION
\- queryExecuteSlice: `Connection not found` 検出時に `activeConnectionId` へ自動rebind、無ければ `connectionId` を `null` に。stale回復処理は`recoverStaleConnection` へ関数抽出

\- formatSlice: sql-formatterのparse error時はerrors格納をやめtoast通知に切替、`ErrorDetailDialog` 誤表示を解消

\- テスト: `stale rebind/clear/toast` 通知の3ケース追加、`beforeEach` で `useConnectionStore` リセットしタブ間隔離を担保

