### PR TITLE
fix: 複数SELECT結果タブの一部が表示されないバグを修正

### DIFF
--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -32,6 +32,7 @@ import { GridFilterBar } from './GridFilterBar';
 import { GridStatusBar } from './GridStatusBar';
 import { GridTable } from './GridTable';
 import { GridToolbar } from './GridToolbar';
+import { useClampedActiveIndex } from './hooks/useClampedActiveIndex';
 import { useColumnAutoSize } from './hooks/useColumnAutoSize';
 import { useElapsedTimer } from './hooks/useElapsedTimer';
 import { useGridEdit } from './hooks/useGridEdit';
@@ -93,7 +94,6 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   const rowsLengthRef = useRef(0);
   const columnOrderRef = useRef<string[]>([]);
   const viewRowsRef = useRef<Row<RowData>[]>([]);
-  const [activeResultIndex, setActiveResultIndex] = useState(0);
   const [valueEditorState, setValueEditorState] = useState<{
     isOpen: boolean;
     rowIndex: number;
@@ -151,6 +151,9 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     : null;
   const hasFilteredResults = filteredResults && filteredResults.length > 0;
   const singleResult: ResultSet | null = !isMultiple && queryResult ? queryResult : null;
+  const [activeResultIndex, setActiveResultIndex] = useClampedActiveIndex(
+    filteredResults?.length ?? 0
+  );
   const resultSet: ResultSet | null = hasFilteredResults
     ? (filteredResults[activeResultIndex]?.data ?? null)
     : singleResult;

--- a/frontend/src/components/grid/ResultTabs.tsx
+++ b/frontend/src/components/grid/ResultTabs.tsx
@@ -8,21 +8,29 @@ interface ResultTabsProps {
   onSelect: (index: number) => void;
 }
 
+const MAX_TAB_LABEL_LENGTH = 50;
+
 function ResultTabsInner({ results, activeIndex, onSelect }: ResultTabsProps) {
   return (
     <div className={styles.resultTabs}>
-      {results.map((result, index) => (
-        <button
-          key={result.statement}
-          className={`${styles.resultTab} ${activeIndex === index ? styles.activeResultTab : ''}`}
-          onClick={() => onSelect(index)}
-          title={result.statement}
-        >
-          {result.statement.length > 50
-            ? `${result.statement.substring(0, 50)}...`
-            : result.statement}
-        </button>
-      ))}
+      {results.map((result, index) => {
+        const label =
+          result.statement.length > MAX_TAB_LABEL_LENGTH
+            ? `${result.statement.substring(0, MAX_TAB_LABEL_LENGTH)}...`
+            : result.statement;
+        // statement は first-line のみなので重複し得る。実行順で固定配列のため index 併用が必要。
+        const key = `${index}-${result.statement}`;
+        return (
+          <button
+            key={key}
+            className={`${styles.resultTab} ${activeIndex === index ? styles.activeResultTab : ''}`}
+            onClick={() => onSelect(index)}
+            title={result.statement}
+          >
+            {`[${index + 1}] ${label}`}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/grid/hooks/useClampedActiveIndex.ts
+++ b/frontend/src/components/grid/hooks/useClampedActiveIndex.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+/// 結果タブ件数が変動した際に、範囲外になった activeIndex を 0 に戻すフック。
+export function useClampedActiveIndex(length: number): [number, (index: number) => void] {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex((prev) => (prev >= length ? 0 : prev));
+  }, [length]);
+
+  return [activeIndex, setActiveIndex];
+}

--- a/frontend/src/tests/grid/ResultTabs.test.tsx
+++ b/frontend/src/tests/grid/ResultTabs.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ResultTabs } from '../../components/grid/ResultTabs';
+import type { ResultSet } from '../../types';
+
+const emptyResult: ResultSet = {
+  columns: [],
+  rows: [],
+  affectedRows: 0,
+  executionTimeMs: 0,
+};
+
+describe('ResultTabs', () => {
+  it('results が空配列ならボタンを描画しない', () => {
+    render(<ResultTabs results={[]} activeIndex={0} onSelect={vi.fn()} />);
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('statement が重複している 6 タブを全て個別に描画する', () => {
+    const results = Array.from({ length: 6 }, () => ({
+      statement: 'SELECT',
+      data: emptyResult,
+    }));
+    const onSelect = vi.fn();
+
+    render(<ResultTabs results={results} activeIndex={0} onSelect={onSelect} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(6);
+  });
+
+  it('異なるタブをクリックするとそれぞれ対応する index で onSelect が呼ばれる', () => {
+    const results = Array.from({ length: 6 }, () => ({
+      statement: 'SELECT',
+      data: emptyResult,
+    }));
+    const onSelect = vi.fn();
+
+    render(<ResultTabs results={results} activeIndex={0} onSelect={onSelect} />);
+
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[0]);
+    fireEvent.click(buttons[3]);
+    fireEvent.click(buttons[5]);
+
+    expect(onSelect).toHaveBeenNthCalledWith(1, 0);
+    expect(onSelect).toHaveBeenNthCalledWith(2, 3);
+    expect(onSelect).toHaveBeenNthCalledWith(3, 5);
+  });
+
+  it('activeIndex が指すタブにアクティブ用クラスが付く', () => {
+    const results = Array.from({ length: 3 }, () => ({
+      statement: 'SELECT',
+      data: emptyResult,
+    }));
+
+    render(<ResultTabs results={results} activeIndex={1} onSelect={vi.fn()} />);
+
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[0].className).not.toMatch(/activeResultTab/);
+    expect(buttons[1].className).toMatch(/activeResultTab/);
+    expect(buttons[2].className).not.toMatch(/activeResultTab/);
+  });
+});

--- a/frontend/src/tests/grid/useClampedActiveIndex.test.ts
+++ b/frontend/src/tests/grid/useClampedActiveIndex.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useClampedActiveIndex } from '../../components/grid/hooks/useClampedActiveIndex';
+
+describe('useClampedActiveIndex', () => {
+  it('初期 activeIndex は 0', () => {
+    const { result } = renderHook(() => useClampedActiveIndex(5));
+    expect(result.current[0]).toBe(0);
+  });
+
+  it('setter で activeIndex を更新できる', () => {
+    const { result } = renderHook(() => useClampedActiveIndex(5));
+    act(() => {
+      result.current[1](3);
+    });
+    expect(result.current[0]).toBe(3);
+  });
+
+  it('length が減って範囲外になったら 0 に戻る', () => {
+    const { result, rerender } = renderHook(({ length }) => useClampedActiveIndex(length), {
+      initialProps: { length: 6 },
+    });
+    act(() => {
+      result.current[1](5);
+    });
+    expect(result.current[0]).toBe(5);
+
+    rerender({ length: 2 });
+    expect(result.current[0]).toBe(0);
+  });
+
+  it('length が増えた場合は現在の index を維持する', () => {
+    const { result, rerender } = renderHook(({ length }) => useClampedActiveIndex(length), {
+      initialProps: { length: 3 },
+    });
+    act(() => {
+      result.current[1](2);
+    });
+    expect(result.current[0]).toBe(2);
+
+    rerender({ length: 6 });
+    expect(result.current[0]).toBe(2);
+  });
+
+  it('length が 0 になったら activeIndex も 0 に戻る', () => {
+    const { result, rerender } = renderHook(({ length }) => useClampedActiveIndex(length), {
+      initialProps: { length: 3 },
+    });
+    act(() => {
+      result.current[1](2);
+    });
+    rerender({ length: 0 });
+    expect(result.current[0]).toBe(0);
+  });
+});


### PR DESCRIPTION
- ResultTabs の `key` を `${index}-${statement}` に変更し React 重複 `key` 警告を解消。Backend の `firstLine(stmt)` は1行目のみなので、複数SELECTで`statement="SELECT"` 重複が発生し `reconcile` が破綻していた
- `activeResultIndex` のクランプを `useClampedActiveIndex` カスタムフックに抽出し、同一クエリタブで再実行時に前回 index が範囲外になる二次要因を解消
- タブラベルに [n] 連番プレフィックスを付与しユーザー識別性を向上
- `MAX_TAB_LABEL_LENGTH` 定数でマジックナンバー 50 を除去
- 重複 statement 6件の描画/クリック、空配列、index クランプの回帰テストを追加