### PR TITLE
feat: sqruffによるSQL実行前構文チェックとエラー行ハイライトを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ build-tidy/
 
 # CMake system information
 __cmake_systeminformation/
+
+# sqruff binary (fetched by CMake from GitHub Release at build time)
+third_party/sqruff/

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -48,11 +48,13 @@ set(LIB_SOURCES
     providers/utility_provider.cpp
     providers/settings_provider.cpp
     providers/io_provider.cpp
+    providers/lint_provider.cpp
     # Parsers
     parsers/a5er_parser.cpp
     parsers/a5er_utils.cpp
     parsers/er_diagram_parser_factory.cpp
     parsers/sql_formatter.cpp
+    parsers/sql_linter.cpp
     parsers/sql_parser.cpp
     parsers/copy_block_detector.cpp
     # Exporters
@@ -122,6 +124,7 @@ set(HEADERS
     interfaces/providers/utility_provider.h
     interfaces/providers/settings_provider.h
     interfaces/providers/io_provider.h
+    interfaces/providers/lint_provider.h
     # Contexts
     contexts/system_context.h
     # Providers
@@ -135,6 +138,7 @@ set(HEADERS
     providers/utility_provider.h
     providers/settings_provider.h
     providers/io_provider.h
+    providers/lint_provider.h
     # Interfaces (Parser)
     interfaces/parsers/er_model.h
     interfaces/parsers/er_diagram_parser.h
@@ -143,6 +147,7 @@ set(HEADERS
     parsers/a5er_utils.h
     parsers/er_diagram_parser_factory.h
     parsers/sql_formatter.h
+    parsers/sql_linter.h
     parsers/sql_parser.h
     parsers/copy_block_detector.h
     parsers/split_utils.h
@@ -274,5 +279,16 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/config")
         ${CMAKE_SOURCE_DIR}/config
         $<TARGET_FILE_DIR:VelocityDB>/config
         COMMENT "Copying config files..."
+    )
+endif()
+
+# Copy sqruff.exe to output directory (expected at <exe_dir>/sqruff/sqruff.exe)
+if(DEFINED SQRUFF_BINARY_PATH AND EXISTS "${SQRUFF_BINARY_PATH}")
+    add_custom_command(TARGET VelocityDB POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory $<TARGET_FILE_DIR:VelocityDB>/sqruff
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${SQRUFF_BINARY_PATH}
+        $<TARGET_FILE_DIR:VelocityDB>/sqruff/sqruff.exe
+        COMMENT "Copying sqruff.exe..."
     )
 endif()

--- a/backend/contexts/system_context.cpp
+++ b/backend/contexts/system_context.cpp
@@ -5,6 +5,7 @@
 #include "../providers/connection_provider.h"
 #include "../providers/export_provider.h"
 #include "../providers/io_provider.h"
+#include "../providers/lint_provider.h"
 #include "../providers/query_provider.h"
 #include "../providers/schema_provider.h"
 #include "../providers/search_provider.h"
@@ -25,7 +26,8 @@ SystemContext::SystemContext()
     , m_search(std::make_unique<SearchProvider>(*m_connections))
     , m_utility(std::make_unique<UtilityProvider>())
     , m_settings(std::make_unique<SettingsProvider>())
-    , m_io(std::make_unique<IOProvider>()) {}
+    , m_io(std::make_unique<IOProvider>())
+    , m_lint(std::make_unique<LintProvider>()) {}
 
 SystemContext::~SystemContext() = default;
 
@@ -58,6 +60,9 @@ ISettingsProvider& SystemContext::settings() noexcept {
 }
 IIOProvider& SystemContext::io() noexcept {
     return *m_io;
+}
+ILintProvider& SystemContext::lint() noexcept {
+    return *m_lint;
 }
 
 }  // namespace velocitydb

--- a/backend/contexts/system_context.h
+++ b/backend/contexts/system_context.h
@@ -29,6 +29,7 @@ public:
     [[nodiscard]] IUtilityProvider& utility() noexcept override;
     [[nodiscard]] ISettingsProvider& settings() noexcept override;
     [[nodiscard]] IIOProvider& io() noexcept override;
+    [[nodiscard]] ILintProvider& lint() noexcept override;
 
 private:
     std::unique_ptr<IConnectionProvider> m_connections;
@@ -42,6 +43,7 @@ private:
     std::unique_ptr<IUtilityProvider> m_utility;
     std::unique_ptr<ISettingsProvider> m_settings;
     std::unique_ptr<IIOProvider> m_io;
+    std::unique_ptr<ILintProvider> m_lint;
 };
 
 }  // namespace velocitydb

--- a/backend/interfaces/providers/lint_provider.h
+++ b/backend/interfaces/providers/lint_provider.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for static SQL linting via sqruff (parse errors only).
+class ILintProvider {
+public:
+    virtual ~ILintProvider() = default;
+
+    /// Lint a SQL string. params JSON: {"sql":"...","dbType":"sqlserver|postgresql|mysql"}
+    /// Response JSON: {"success":true,"data":{"diagnostics":[{"line":N,"column":N,"code":"PRS...","message":"..."}]}}
+    /// On infrastructure failure (binary missing, timeout, etc.) the response carries success:true with an empty diagnostics array and a "lintUnavailable":true flag, so the caller never blocks query execution over lint infra issues.
+    [[nodiscard]] virtual std::string lintSql(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/lint_provider.h
+++ b/backend/interfaces/providers/lint_provider.h
@@ -12,7 +12,8 @@ public:
 
     /// Lint a SQL string. params JSON: {"sql":"...","dbType":"sqlserver|postgresql|mysql"}
     /// Response JSON: {"success":true,"data":{"diagnostics":[{"line":N,"column":N,"code":"PRS...","message":"..."}]}}
-    /// On infrastructure failure (binary missing, timeout, etc.) the response carries success:true with an empty diagnostics array and a "lintUnavailable":true flag, so the caller never blocks query execution over lint infra issues.
+    /// On infrastructure failure (binary missing, timeout, etc.) the response carries success:true with an empty diagnostics array and a "lintUnavailable":true flag, so the caller never blocks query
+    /// execution over lint infra issues.
     [[nodiscard]] virtual std::string lintSql(std::string_view params) = 0;
 };
 

--- a/backend/interfaces/system_context.h
+++ b/backend/interfaces/system_context.h
@@ -12,6 +12,7 @@ class ISearchProvider;
 class IUtilityProvider;
 class ISettingsProvider;
 class IIOProvider;
+class ILintProvider;
 
 /// Top-level interface aggregating all provider interfaces
 class ISystemContext {
@@ -28,6 +29,7 @@ public:
     [[nodiscard]] virtual IUtilityProvider& utility() noexcept = 0;
     [[nodiscard]] virtual ISettingsProvider& settings() noexcept = 0;
     [[nodiscard]] virtual IIOProvider& io() noexcept = 0;
+    [[nodiscard]] virtual ILintProvider& lint() noexcept = 0;
 };
 
 }  // namespace velocitydb

--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -4,6 +4,7 @@
 #include "interfaces/providers/connection_provider.h"
 #include "interfaces/providers/export_provider.h"
 #include "interfaces/providers/io_provider.h"
+#include "interfaces/providers/lint_provider.h"
 #include "interfaces/providers/query_provider.h"
 #include "interfaces/providers/schema_provider.h"
 #include "interfaces/providers/search_provider.h"
@@ -116,6 +117,9 @@ void IPCHandler::registerRoutes() {
     m_routes["getBookmarks"] = [this](auto p) { return m_ctx.io().getBookmarks(p); };
     m_routes["saveBookmark"] = [this](auto p) { return m_ctx.io().saveBookmark(p); };
     m_routes["deleteBookmark"] = [this](auto p) { return m_ctx.io().deleteBookmark(p); };
+
+    // Lint (static SQL check via sqruff)
+    m_routes["lintSql"] = [this](auto p) { return m_ctx.lint().lintSql(p); };
 }
 
 std::string IPCHandler::dispatchRequest(std::string_view request) {

--- a/backend/parsers/sql_linter.cpp
+++ b/backend/parsers/sql_linter.cpp
@@ -1,0 +1,253 @@
+#include "sql_linter.h"
+
+#include "../utils/logger.h"
+#include "simdjson.h"
+
+#include <algorithm>
+#include <array>
+#include <filesystem>
+#include <format>
+#include <memory>
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+namespace velocitydb {
+
+namespace {
+
+struct HandleCloser {
+    void operator()(HANDLE h) const noexcept {
+        if (h && h != INVALID_HANDLE_VALUE)
+            CloseHandle(h);
+    }
+};
+using UniqueHandle = std::unique_ptr<void, HandleCloser>;
+
+[[nodiscard]] std::wstring toWide(std::string_view utf8) {
+    if (utf8.empty())
+        return {};
+    int len = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), nullptr, 0);
+    std::wstring result(len, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), result.data(), len);
+    return result;
+}
+
+/// Quote a CreateProcessW argument per MS C runtime parsing (2n+1 backslash rule).
+[[nodiscard]] std::wstring quoteArg(std::wstring_view arg) {
+    if (!arg.empty() && arg.find_first_of(L" \t\"") == std::wstring_view::npos)
+        return std::wstring(arg);
+
+    std::wstring quoted = L"\"";
+    for (size_t i = 0; i < arg.size();) {
+        size_t nSlashes = 0;
+        while (i < arg.size() && arg[i] == L'\\') {
+            ++nSlashes;
+            ++i;
+        }
+        if (i == arg.size()) {
+            quoted.append(nSlashes * 2, L'\\');
+        } else if (arg[i] == L'"') {
+            quoted.append(nSlashes * 2 + 1, L'\\');
+            quoted.push_back(L'"');
+            ++i;
+        } else {
+            quoted.append(nSlashes, L'\\');
+            quoted.push_back(arg[i]);
+            ++i;
+        }
+    }
+    quoted.push_back(L'"');
+    return quoted;
+}
+
+[[nodiscard]] std::filesystem::path moduleDir() {
+    wchar_t buf[MAX_PATH] = {};
+    GetModuleFileNameW(nullptr, buf, MAX_PATH);
+    return std::filesystem::path(buf).parent_path();
+}
+
+}  // namespace
+
+std::string mapDialectToSqruff(std::string_view dbType) {
+    if (dbType == "sqlserver")
+        return "tsql";
+    if (dbType == "postgresql")
+        return "postgres";
+    if (dbType == "mysql")
+        return "mysql";
+    return {};
+}
+
+std::filesystem::path defaultSqruffBinary() {
+    return moduleDir() / "sqruff" / "sqruff.exe";
+}
+
+std::filesystem::path defaultSqruffConfig() {
+    return moduleDir() / "config" / "sqruff" / ".sqruff";
+}
+
+std::expected<std::vector<LintDiagnostic>, std::string> parseSqruffJson(std::string_view json) {
+    // Empty or whitespace-only stdout is treated as "no diagnostics"
+    bool allWhitespace = true;
+    for (char c : json) {
+        if (c != ' ' && c != '\n' && c != '\r' && c != '\t') {
+            allWhitespace = false;
+            break;
+        }
+    }
+    if (allWhitespace)
+        return std::vector<LintDiagnostic>{};
+
+    thread_local static simdjson::dom::parser parser;
+    auto doc = parser.parse(json.data(), json.size());
+    if (doc.error())
+        return std::unexpected(std::format("sqruff JSON parse error: {}", simdjson::error_message(doc.error())));
+
+    std::vector<LintDiagnostic> diagnostics;
+    auto obj = doc.value().get_object();
+    if (obj.error())
+        return std::unexpected("sqruff JSON top-level is not an object");
+
+    for (auto [_, value] : obj.value()) {
+        auto arr = value.get_array();
+        if (arr.error())
+            continue;
+        for (auto entry : arr.value()) {
+            auto codeRes = entry["code"].get_string();
+            std::string code = codeRes.error() ? std::string{} : std::string(codeRes.value());
+            // Filter: only parse-error rule codes (PRS*) are actionable blockers.
+            if (code.size() < 3 || code.substr(0, 3) != "PRS")
+                continue;
+
+            LintDiagnostic d;
+            d.code = std::move(code);
+
+            if (auto msg = entry["message"].get_string(); !msg.error())
+                d.message.assign(msg.value().data(), msg.value().size());
+
+            auto rangeObj = entry["range"]["start"];
+            if (auto ln = rangeObj["line"].get_int64(); !ln.error())
+                d.line = std::max<int>(1, static_cast<int>(ln.value()));
+            if (auto col = rangeObj["character"].get_int64(); !col.error())
+                d.column = std::max<int>(1, static_cast<int>(col.value()));
+
+            diagnostics.push_back(std::move(d));
+        }
+    }
+    return diagnostics;
+}
+
+std::expected<std::string, LintError> invokeSqruff(const SqlLinterConfig& cfg, std::string_view sql, std::string_view dialect) {
+    std::error_code ec;
+    if (!std::filesystem::exists(cfg.binary, ec)) {
+        return std::unexpected(LintError{LintErrorKind::BinaryNotFound, std::format("sqruff.exe not found at: {}", cfg.binary.string())});
+    }
+
+    SECURITY_ATTRIBUTES sa{};
+    sa.nLength = sizeof(sa);
+    sa.bInheritHandle = TRUE;
+    sa.lpSecurityDescriptor = nullptr;
+
+    HANDLE stdinRead = nullptr, stdinWrite = nullptr;
+    HANDLE stdoutRead = nullptr, stdoutWrite = nullptr;
+    HANDLE stderrRead = nullptr, stderrWrite = nullptr;
+    if (!CreatePipe(&stdinRead, &stdinWrite, &sa, 0))
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, "CreatePipe(stdin) failed"});
+    if (!SetHandleInformation(stdinWrite, HANDLE_FLAG_INHERIT, 0))
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, "SetHandleInformation(stdin) failed"});
+    if (!CreatePipe(&stdoutRead, &stdoutWrite, &sa, 0))
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, "CreatePipe(stdout) failed"});
+    if (!SetHandleInformation(stdoutRead, HANDLE_FLAG_INHERIT, 0))
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, "SetHandleInformation(stdout) failed"});
+    if (!CreatePipe(&stderrRead, &stderrWrite, &sa, 0))
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, "CreatePipe(stderr) failed"});
+    if (!SetHandleInformation(stderrRead, HANDLE_FLAG_INHERIT, 0))
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, "SetHandleInformation(stderr) failed"});
+
+    UniqueHandle stdinReadG{stdinRead}, stdinWriteG{stdinWrite};
+    UniqueHandle stdoutReadG{stdoutRead}, stdoutWriteG{stdoutWrite};
+    UniqueHandle stderrReadG{stderrRead}, stderrWriteG{stderrWrite};
+
+    // Build command line: sqruff.exe [--config X] lint - --dialect Y --format json --parsing-errors
+    std::wstring cmdLine = quoteArg(cfg.binary.wstring());
+    if (!cfg.configFile.empty() && std::filesystem::exists(cfg.configFile, ec)) {
+        cmdLine += L" --config ";
+        cmdLine += quoteArg(cfg.configFile.wstring());
+    }
+    cmdLine += L" --parsing-errors --dialect ";
+    cmdLine += quoteArg(toWide(dialect));
+    cmdLine += L" lint - --format json";
+
+    STARTUPINFOW si{};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput = stdinRead;
+    si.hStdOutput = stdoutWrite;
+    si.hStdError = stderrWrite;
+
+    PROCESS_INFORMATION pi{};
+    std::wstring cmdMutable = cmdLine;
+    if (!CreateProcessW(nullptr, cmdMutable.data(), nullptr, nullptr, TRUE, CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi)) {
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, std::format("CreateProcessW failed (error={})", GetLastError())});
+    }
+    UniqueHandle processG{pi.hProcess};
+    UniqueHandle threadG{pi.hThread};
+
+    // Close child-side pipe ends in parent (otherwise reads/EOF hang)
+    stdinReadG.reset();
+    stdoutWriteG.reset();
+    stderrWriteG.reset();
+
+    // Write SQL to sqruff's stdin then close
+    {
+        size_t offset = 0;
+        while (offset < sql.size()) {
+            DWORD toWrite = static_cast<DWORD>(std::min<size_t>(sql.size() - offset, 65536));
+            DWORD written = 0;
+            if (!WriteFile(stdinWriteG.get(), sql.data() + offset, toWrite, &written, nullptr) || written == 0)
+                break;
+            offset += written;
+        }
+        stdinWriteG.reset();
+    }
+
+    // Drain stdout while process runs
+    std::string stdoutBuf;
+    {
+        std::array<char, 4096> buf{};
+        DWORD bytesRead = 0;
+        while (ReadFile(stdoutReadG.get(), buf.data(), static_cast<DWORD>(buf.size()), &bytesRead, nullptr) && bytesRead > 0) {
+            stdoutBuf.append(buf.data(), bytesRead);
+        }
+    }
+
+    // Wait for exit (with timeout)
+    DWORD waitMs = static_cast<DWORD>(cfg.timeout.count());
+    DWORD waitRes = WaitForSingleObject(processG.get(), waitMs);
+    if (waitRes == WAIT_TIMEOUT) {
+        TerminateProcess(processG.get(), 1);
+        WaitForSingleObject(processG.get(), 1000);
+        return std::unexpected(LintError{LintErrorKind::Timeout, std::format("sqruff timed out after {}ms", waitMs)});
+    }
+    if (waitRes != WAIT_OBJECT_0) {
+        return std::unexpected(LintError{LintErrorKind::SpawnFailed, std::format("WaitForSingleObject failed (res={})", waitRes)});
+    }
+
+    return stdoutBuf;
+}
+
+std::expected<std::vector<LintDiagnostic>, LintError> lintSqlForParseErrors(const SqlLinterConfig& cfg, std::string_view sql, std::string_view dialect) {
+    auto stdoutRes = invokeSqruff(cfg, sql, dialect);
+    if (!stdoutRes)
+        return std::unexpected(stdoutRes.error());
+
+    auto parsed = parseSqruffJson(*stdoutRes);
+    if (!parsed)
+        return std::unexpected(LintError{LintErrorKind::InvalidOutput, parsed.error()});
+    return *parsed;
+}
+
+}  // namespace velocitydb

--- a/backend/parsers/sql_linter.h
+++ b/backend/parsers/sql_linter.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace velocitydb {
+
+/// One parse-error diagnostic from sqruff
+struct LintDiagnostic {
+    int line = 0;    // 1-based line number (Monaco-compatible)
+    int column = 0;  // 1-based column number
+    std::string code;
+    std::string message;
+};
+
+enum class LintErrorKind {
+    BinaryNotFound,  // sqruff.exe not located at expected path
+    SpawnFailed,     // CreateProcessW failed
+    Timeout,         // process did not exit within timeout
+    InvalidOutput,   // JSON parse failure
+};
+
+struct LintError {
+    LintErrorKind kind{};
+    std::string message;
+};
+
+struct SqlLinterConfig {
+    std::filesystem::path binary;
+    std::filesystem::path configFile;
+    std::chrono::milliseconds timeout{5000};
+};
+
+/// Map Velocity-DB DatabaseType to sqruff --dialect value.
+/// Supported: "sqlserver" -> "tsql", "postgresql" -> "postgres", "mysql" -> "mysql".
+/// Returns empty string for unsupported dbType.
+[[nodiscard]] std::string mapDialectToSqruff(std::string_view dbType);
+
+/// Parse sqruff JSON output ({"<path>":[Diagnostic,...]}) and filter to PRS-prefixed rule codes.
+/// The rest of diagnostics (non-parse-errors) are discarded even if sqruff emits them.
+[[nodiscard]] std::expected<std::vector<LintDiagnostic>, std::string> parseSqruffJson(std::string_view json);
+
+/// Spawn sqruff.exe with the given SQL passed on stdin and return raw stdout JSON.
+/// Runs: <binary> --config <configFile> lint - --dialect <dialect> --format json --parsing-errors
+[[nodiscard]] std::expected<std::string, LintError> invokeSqruff(const SqlLinterConfig& cfg, std::string_view sql, std::string_view dialect);
+
+/// Default binary path: <module dir>/sqruff/sqruff.exe
+[[nodiscard]] std::filesystem::path defaultSqruffBinary();
+
+/// Default config path: <module dir>/config/sqruff/.sqruff
+[[nodiscard]] std::filesystem::path defaultSqruffConfig();
+
+/// High-level convenience: invoke sqruff, parse JSON, filter to PRS.
+/// Returns empty vector when SQL has no parse errors.
+[[nodiscard]] std::expected<std::vector<LintDiagnostic>, LintError> lintSqlForParseErrors(const SqlLinterConfig& cfg, std::string_view sql, std::string_view dialect);
+
+}  // namespace velocitydb

--- a/backend/providers/lint_provider.cpp
+++ b/backend/providers/lint_provider.cpp
@@ -1,0 +1,68 @@
+#include "lint_provider.h"
+
+#include "../parsers/sql_linter.h"
+#include "../utils/json_utils.h"
+#include "../utils/logger.h"
+#include "simdjson.h"
+
+#include <format>
+
+namespace velocitydb {
+
+namespace {
+
+[[nodiscard]] std::string serializeDiagnostics(const std::vector<LintDiagnostic>& diags, bool lintUnavailable, std::string_view unavailableReason) {
+    auto arr = JsonUtils::buildArray(diags, [](std::string& out, const auto& d) {
+        out += std::format(R"({{"line":{},"column":{},"code":"{}","message":"{}"}})", d.line, d.column, JsonUtils::escapeString(d.code), JsonUtils::escapeString(d.message));
+    });
+    std::string payload;
+    payload.reserve(arr.size() + 64);
+    payload += R"({"diagnostics":)";
+    payload += arr;
+    if (lintUnavailable) {
+        payload += R"(,"lintUnavailable":true,"reason":")";
+        payload += JsonUtils::escapeString(unavailableReason);
+        payload += '"';
+    }
+    payload += '}';
+    return JsonUtils::successResponse(payload);
+}
+
+}  // namespace
+
+LintProvider::LintProvider() = default;
+
+std::string LintProvider::lintSql(std::string_view params) {
+    thread_local static simdjson::dom::parser parser;
+    auto doc = parser.parse(params.data(), params.size(), false);
+    if (doc.error())
+        return JsonUtils::errorResponse("Invalid JSON params");
+
+    auto sqlRes = doc["sql"].get_string();
+    auto dbTypeRes = doc["dbType"].get_string();
+    if (sqlRes.error())
+        return JsonUtils::errorResponse("Missing 'sql' field");
+    if (dbTypeRes.error())
+        return JsonUtils::errorResponse("Missing 'dbType' field");
+
+    std::string_view sql = sqlRes.value();
+    std::string dialect = mapDialectToSqruff(dbTypeRes.value());
+    if (dialect.empty())
+        return JsonUtils::errorResponse(std::format("Unsupported dbType: {}", dbTypeRes.value()));
+
+    SqlLinterConfig cfg{
+        .binary = defaultSqruffBinary(),
+        .configFile = defaultSqruffConfig(),
+        .timeout = std::chrono::milliseconds{5000},
+    };
+
+    auto result = lintSqlForParseErrors(cfg, sql, dialect);
+    if (!result) {
+        // Infrastructure failure: report as lintUnavailable (caller does NOT block execution).
+        get_logger().log<LogLevel::WARNING>(std::format("sqruff lint unavailable: {}", result.error().message));
+        return serializeDiagnostics({}, true, result.error().message);
+    }
+    return serializeDiagnostics(*result, false, {});
+}
+
+}  // namespace velocitydb

--- a/backend/providers/lint_provider.h
+++ b/backend/providers/lint_provider.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../interfaces/providers/lint_provider.h"
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Concrete provider delegating to parsers/sql_linter for sqruff-based parse-error detection.
+class LintProvider : public ILintProvider {
+public:
+    LintProvider();
+    ~LintProvider() override = default;
+
+    LintProvider(const LintProvider&) = delete;
+    LintProvider& operator=(const LintProvider&) = delete;
+    LintProvider(LintProvider&&) = delete;
+    LintProvider& operator=(LintProvider&&) = delete;
+
+    [[nodiscard]] std::string lintSql(std::string_view params) override;
+};
+
+}  // namespace velocitydb

--- a/config/sqruff/.sqruff
+++ b/config/sqruff/.sqruff
@@ -1,0 +1,4 @@
+[sqruff]
+# Velocity-DB: report parse errors (PRS) only, ignore all style/layout linting
+ignore = linting
+nocolor = True

--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -1,6 +1,7 @@
 import type {
   AsyncQueryResultResponse,
   ConstraintInfo,
+  DatabaseType,
   IPCRequest,
   IPCResponse,
   TableMetadata,
@@ -332,6 +333,17 @@ class Bridge {
 
   async cancelQuery(connectionId: string): Promise<void> {
     return this.call('cancelQuery', { connectionId }, S.cancelQuery);
+  }
+
+  async lintSql(
+    sql: string,
+    dbType: DatabaseType
+  ): Promise<{
+    diagnostics: { line: number; column: number; code: string; message: string }[];
+    lintUnavailable?: boolean;
+    reason?: string;
+  }> {
+    return this.call('lintSql', { sql, dbType }, S.lintSql);
   }
 
   // Schema methods

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -234,3 +234,17 @@ export const getBookmarks = z.array(
 );
 export const saveBookmark = zVoid;
 export const deleteBookmark = zVoid;
+
+// --- Lint (sqruff) ---
+export const lintSql = z.object({
+  diagnostics: z.array(
+    z.object({
+      line: z.number(),
+      column: z.number(),
+      code: z.string(),
+      message: z.string(),
+    })
+  ),
+  lintUnavailable: z.boolean().optional(),
+  reason: z.string().optional(),
+});

--- a/frontend/src/components/editor/SqlEditor.tsx
+++ b/frontend/src/components/editor/SqlEditor.tsx
@@ -4,8 +4,9 @@ import type * as Monaco from 'monaco-editor';
 import * as monaco from 'monaco-editor';
 import { useCallback, useEffect, useRef } from 'react';
 import { useKeyboardHandler } from '../../hooks/useKeyboardHandler';
-import { useQueryStore } from '../../store/queryStore';
+import { useLintDiagnostics, useQueryStore } from '../../store/queryStore';
 import { useSchemaStore } from '../../store/schemaStore';
+import { clearSqlMarkers, setSqlMarkers } from '../../utils/editorMarkers';
 import { log } from '../../utils/logger';
 import { formatSQL } from '../../utils/sqlFormat';
 import { getStatementAtCursor } from '../../utils/sqlParser';
@@ -31,6 +32,7 @@ export function SqlEditor() {
   const { queries, activeQueryId, updateQuery } = useQueryStore();
   const activeQuery = queries.find((q) => q.id === activeQueryId);
   const queryConnectionId = activeQuery?.connectionId ?? null;
+  const lintDiagnostics = useLintDiagnostics(activeQueryId);
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
   const completionDisposableRef = useRef<Monaco.IDisposable | null>(null);
@@ -243,6 +245,17 @@ export function SqlEditor() {
       log.debug(`[SqlEditor] Completion provider updated for connection: ${queryConnectionId}`);
     }
   }, [queryConnectionId]);
+
+  // sqruff lint診断をMonaco markerに反映
+  useEffect(() => {
+    const model = editorRef.current?.getModel();
+    if (!model) return;
+    if (!lintDiagnostics || lintDiagnostics.length === 0) {
+      clearSqlMarkers(model, 'sqruff');
+      return;
+    }
+    setSqlMarkers(model, lintDiagnostics, 'sqruff');
+  }, [lintDiagnostics]);
 
   // クリーンアップ
   useEffect(() => {

--- a/frontend/src/components/editor/SqlEditor.tsx
+++ b/frontend/src/components/editor/SqlEditor.tsx
@@ -2,11 +2,16 @@ import loader from '@monaco-editor/loader';
 import Editor, { type OnMount } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
 import * as monaco from 'monaco-editor';
-import { useCallback, useEffect, useRef } from 'react';
+import { type MutableRefObject, useCallback, useEffect, useRef } from 'react';
 import { useKeyboardHandler } from '../../hooks/useKeyboardHandler';
-import { useLintDiagnostics, useQueryStore } from '../../store/queryStore';
+import { useLintDiagnostics, useQueryStore, useRuntimeDiagnostics } from '../../store/queryStore';
 import { useSchemaStore } from '../../store/schemaStore';
-import { clearSqlMarkers, setSqlMarkers } from '../../utils/editorMarkers';
+import {
+  clearSqlMarkers,
+  type SqlMarkerInput,
+  type SqlMarkerOwner,
+  setSqlMarkers,
+} from '../../utils/editorMarkers';
 import { log } from '../../utils/logger';
 import { formatSQL } from '../../utils/sqlFormat';
 import { getStatementAtCursor } from '../../utils/sqlParser';
@@ -21,6 +26,23 @@ loader.config({ monaco });
 // to avoid stale closures captured at handler invocation time
 const getQueryState = () => useQueryStore.getState();
 
+/** owner別diagnosticsをMonaco markerに反映する汎用hook */
+function useApplyMarkers(
+  editorRef: MutableRefObject<Parameters<OnMount>[0] | null>,
+  diagnostics: SqlMarkerInput[] | null,
+  owner: SqlMarkerOwner
+): void {
+  useEffect(() => {
+    const model = editorRef.current?.getModel();
+    if (!model) return;
+    if (!diagnostics || diagnostics.length === 0) {
+      clearSqlMarkers(model, owner);
+      return;
+    }
+    setSqlMarkers(model, diagnostics, owner);
+  }, [editorRef, diagnostics, owner]);
+}
+
 /** Get the connection ID of the active query tab (not the global activeConnectionId). */
 const getActiveQueryConnectionId = () => {
   const { queries, activeQueryId } = getQueryState();
@@ -33,6 +55,7 @@ export function SqlEditor() {
   const activeQuery = queries.find((q) => q.id === activeQueryId);
   const queryConnectionId = activeQuery?.connectionId ?? null;
   const lintDiagnostics = useLintDiagnostics(activeQueryId);
+  const runtimeDiagnostics = useRuntimeDiagnostics(activeQueryId);
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
   const completionDisposableRef = useRef<Monaco.IDisposable | null>(null);
@@ -246,16 +269,9 @@ export function SqlEditor() {
     }
   }, [queryConnectionId]);
 
-  // sqruff lint診断をMonaco markerに反映
-  useEffect(() => {
-    const model = editorRef.current?.getModel();
-    if (!model) return;
-    if (!lintDiagnostics || lintDiagnostics.length === 0) {
-      clearSqlMarkers(model, 'sqruff');
-      return;
-    }
-    setSqlMarkers(model, lintDiagnostics, 'sqruff');
-  }, [lintDiagnostics]);
+  // sqruff lint + ODBC実行エラー(runtime)をMonaco markerに反映 (owner別に独立管理)
+  useApplyMarkers(editorRef, lintDiagnostics, 'sqruff');
+  useApplyMarkers(editorRef, runtimeDiagnostics, 'runtime');
 
   // クリーンアップ
   useEffect(() => {

--- a/frontend/src/store/query/index.ts
+++ b/frontend/src/store/query/index.ts
@@ -3,6 +3,7 @@ export {
   useIsActiveDataView,
   useIsActiveERDiagram,
   useIsQueryExecuting,
+  useLintDiagnostics,
   usePaginationState,
   useQueries,
   useQueryActions,

--- a/frontend/src/store/query/index.ts
+++ b/frontend/src/store/query/index.ts
@@ -11,6 +11,7 @@ export {
   useQueryError,
   useQueryResult,
   useQueryStore,
+  useRuntimeDiagnostics,
 } from './queryStore';
 
 export type { QueryState } from './types';

--- a/frontend/src/store/query/queryStore.ts
+++ b/frontend/src/store/query/queryStore.ts
@@ -34,6 +34,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   executingQueryIds: new Set<string>(),
   errors: {},
   paginationStates: {},
+  lintDiagnostics: {},
   isExecuting: false,
 
   // Slices (Device Layer implementations injected via DI)
@@ -81,6 +82,10 @@ export const useIsQueryExecuting = (queryId: string | null | undefined) =>
 /** Per-query pagination state selector */
 export const usePaginationState = (queryId: string | null | undefined) =>
   useQueryStore((state) => (queryId ? (state.paginationStates[queryId] ?? null) : null));
+
+/** Per-query lint diagnostics selector (sqruff PRS) */
+export const useLintDiagnostics = (queryId: string | null | undefined) =>
+  useQueryStore((state) => (queryId ? (state.lintDiagnostics[queryId] ?? null) : null));
 
 export const useQueryActions = () =>
   useQueryStore(

--- a/frontend/src/store/query/queryStore.ts
+++ b/frontend/src/store/query/queryStore.ts
@@ -35,6 +35,7 @@ export const useQueryStore = create<QueryState>((set, get) => ({
   errors: {},
   paginationStates: {},
   lintDiagnostics: {},
+  runtimeDiagnostics: {},
   isExecuting: false,
 
   // Slices (Device Layer implementations injected via DI)
@@ -86,6 +87,10 @@ export const usePaginationState = (queryId: string | null | undefined) =>
 /** Per-query lint diagnostics selector (sqruff PRS) */
 export const useLintDiagnostics = (queryId: string | null | undefined) =>
   useQueryStore((state) => (queryId ? (state.lintDiagnostics[queryId] ?? null) : null));
+
+/** Per-query runtime diagnostics selector (ODBC実行エラー等) */
+export const useRuntimeDiagnostics = (queryId: string | null | undefined) =>
+  useQueryStore((state) => (queryId ? (state.runtimeDiagnostics[queryId] ?? null) : null));
 
 export const useQueryActions = () =>
   useQueryStore(

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -1,4 +1,5 @@
 import { bridge as apiBridge } from '../../../api/bridge';
+import type { SqlMarkerInput } from '../../../utils/editorMarkers';
 import { log } from '../../../utils/logger';
 import { getSettings } from '../../../utils/settingsUtils';
 import {
@@ -8,6 +9,7 @@ import {
   SQL_BEGIN_TRANSACTION,
 } from '../../../utils/sqlIdentifier';
 import { useConnectionStore } from '../../connectionStore';
+import { useToastStore } from '../../toastStore';
 import { executeAsyncWithPolling, toQueryResult } from '../helpers/asyncPolling';
 import { endExecution, failExecution, startExecution } from '../helpers/executionState';
 import { fetchAndUpdateRowCount } from '../helpers/paginationHelper';
@@ -92,7 +94,57 @@ export function createExecuteSlice(
     }
   }
 
+  function buildSyntaxErrorToast(markers: SqlMarkerInput[]): string {
+    const first = markers[0];
+    if (markers.length === 1) return `構文エラー: L${first.line} ${first.message}`;
+    return `構文エラー ${markers.length}件 (L${first.line}...): エディタのマーカーを参照`;
+  }
+
+  async function precheckWithSqruff(
+    id: string,
+    connectionId: string,
+    sql: string
+  ): Promise<SqlMarkerInput[] | null> {
+    // dialect判定不能ならlintスキップ (実行側のfail-openに委ねる)
+    const conn = useConnectionStore.getState().connections.find((c) => c.id === connectionId);
+    if (!conn?.dbType) return null;
+
+    try {
+      const result = await apiBridge.lintSql(sql, conn.dbType);
+      if (result.lintUnavailable) {
+        log.warning(`[queryExecuteSlice] lint unavailable: ${result.reason ?? 'unknown'}`);
+        return null;
+      }
+      // backend側で既にPRSのみに絞り込み済み。diagnostics破損時の保険として再確認
+      const prs = result.diagnostics.filter((d) => d.code.startsWith('PRS'));
+      if (prs.length === 0) return null;
+      const markers: SqlMarkerInput[] = prs.map((d) => ({
+        line: d.line,
+        column: d.column,
+        code: d.code,
+        message: d.message,
+      }));
+      set((state) => ({
+        lintDiagnostics: { ...state.lintDiagnostics, [id]: markers },
+      }));
+      useToastStore.getState().addToast(buildSyntaxErrorToast(markers), 'error');
+      return markers;
+    } catch (error) {
+      log.warning(`[queryExecuteSlice] lint invocation failed: ${error}`);
+      return null;
+    }
+  }
+
   async function executeAsync(id: string, connectionId: string, sql: string): Promise<void> {
+    // 事前lint: 構文エラー(PRS)検出時はexecuteQueryを呼ばずmarkerのみ
+    const prsMarkers = await precheckWithSqruff(id, connectionId, sql);
+    if (prsMarkers) {
+      set((state) => failExecution(state, id, prsMarkers[0].message));
+      return;
+    }
+    // lint通過 or lintUnavailable: 古いmarkerをクリアして実行継続
+    set((state) => ({ lintDiagnostics: { ...state.lintDiagnostics, [id]: [] } }));
+
     const controller = new AbortController();
     abort.register(id, controller);
 

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -1,5 +1,6 @@
 import { bridge as apiBridge } from '../../../api/bridge';
 import type { SqlMarkerInput } from '../../../utils/editorMarkers';
+import { parseErrorMessage } from '../../../utils/errorParser';
 import { log } from '../../../utils/logger';
 import { getSettings } from '../../../utils/settingsUtils';
 import {
@@ -33,6 +34,8 @@ function hasExplicitLimit(sql: string): boolean {
 }
 
 const STALE_CONNECTION_PATTERN = /Connection not found|is no longer active/i;
+// ODBCエラーは通常 column 情報を持たない。行頭にマーカー配置 (editorMarkers が行末まで伸ばす)
+const RUNTIME_MARKER_DEFAULT_COLUMN = 1;
 
 function recoverStaleConnection(
   set: SetState,
@@ -142,8 +145,11 @@ export function createExecuteSlice(
       set((state) => failExecution(state, id, prsMarkers[0].message));
       return;
     }
-    // lint通過 or lintUnavailable: 古いmarkerをクリアして実行継続
-    set((state) => ({ lintDiagnostics: { ...state.lintDiagnostics, [id]: [] } }));
+    // lint通過 or lintUnavailable: 古いmarker(sqruff/runtime両方)をクリアして実行継続
+    set((state) => ({
+      lintDiagnostics: { ...state.lintDiagnostics, [id]: [] },
+      runtimeDiagnostics: { ...state.runtimeDiagnostics, [id]: [] },
+    }));
 
     const controller = new AbortController();
     abort.register(id, controller);
@@ -237,7 +243,22 @@ export function createExecuteSlice(
         return;
       }
 
-      set((state) => failExecution(state, id, errorMessage));
+      // 行情報が取れた場合のみruntime markerセット (owner: runtime)。failExecution と1回にまとめる
+      const parsedErr = parseErrorMessage(errorMessage);
+      const runtimeMarker: SqlMarkerInput | null =
+        parsedErr.line !== undefined
+          ? {
+              line: parsedErr.line,
+              column: RUNTIME_MARKER_DEFAULT_COLUMN,
+              message: parsedErr.summary,
+            }
+          : null;
+      set((state) => ({
+        ...failExecution(state, id, errorMessage),
+        ...(runtimeMarker && {
+          runtimeDiagnostics: { ...state.runtimeDiagnostics, [id]: [runtimeMarker] },
+        }),
+      }));
     } finally {
       activeQueryIds.delete(id);
       abort.unregister(id);

--- a/frontend/src/store/query/types.ts
+++ b/frontend/src/store/query/types.ts
@@ -31,6 +31,7 @@ export interface QueryState
   errors: Record<string, string | null>;
   paginationStates: Record<string, PaginationState>;
   lintDiagnostics: Record<string, SqlMarkerInput[]>;
+  runtimeDiagnostics: Record<string, SqlMarkerInput[]>;
   /** @deprecated Use executingQueryIds instead. Kept for toolbar compatibility. */
   isExecuting: boolean;
 }

--- a/frontend/src/store/query/types.ts
+++ b/frontend/src/store/query/types.ts
@@ -1,4 +1,5 @@
 import type { Query, QueryResult } from '../../types';
+import type { SqlMarkerInput } from '../../utils/editorMarkers';
 import type { DataViewable } from './interfaces/DataViewable';
 import type { ERDiagrammable } from './interfaces/ERDiagrammable';
 import type { Executable } from './interfaces/Executable';
@@ -29,6 +30,7 @@ export interface QueryState
   executingQueryIds: Set<string>;
   errors: Record<string, string | null>;
   paginationStates: Record<string, PaginationState>;
+  lintDiagnostics: Record<string, SqlMarkerInput[]>;
   /** @deprecated Use executingQueryIds instead. Kept for toolbar compatibility. */
   isExecuting: boolean;
 }

--- a/frontend/src/store/queryStore.ts
+++ b/frontend/src/store/queryStore.ts
@@ -14,4 +14,5 @@ export {
   useQueryError,
   useQueryResult,
   useQueryStore,
+  useRuntimeDiagnostics,
 } from './query';

--- a/frontend/src/store/queryStore.ts
+++ b/frontend/src/store/queryStore.ts
@@ -6,6 +6,7 @@ export {
   useIsActiveDataView,
   useIsActiveERDiagram,
   useIsQueryExecuting,
+  useLintDiagnostics,
   usePaginationState,
   useQueries,
   useQueryActions,

--- a/frontend/src/tests/stores/queryStore.runtime-diagnostics.test.ts
+++ b/frontend/src/tests/stores/queryStore.runtime-diagnostics.test.ts
@@ -84,14 +84,13 @@ describe('runtimeDiagnostics', () => {
     // 2回目: 実行開始時にクリアされてから成功
     mockedBridge.executeAsyncQuery.mockResolvedValueOnce({ queryId: 'async_1' });
     mockedBridge.getAsyncQueryResult.mockResolvedValueOnce({
+      queryId: 'async_1',
       status: 'completed',
-      result: {
-        columns: [],
-        rows: [],
-        affectedRows: 0,
-        executionTimeMs: 0,
-        truncated: false,
-      },
+      columns: [],
+      rows: [],
+      affectedRows: 0,
+      executionTimeMs: 0,
+      truncated: false,
     });
     await executeQuery(queryId, 'conn_1');
     expect(useQueryStore.getState().runtimeDiagnostics[queryId]).toEqual([]);

--- a/frontend/src/tests/stores/queryStore.runtime-diagnostics.test.ts
+++ b/frontend/src/tests/stores/queryStore.runtime-diagnostics.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../helpers/mockSettingsUtils';
+import { useQueryStore } from '../../store/queryStore';
+
+vi.mock('../../api/bridge', () => ({
+  bridge: {
+    executeAsyncQuery: vi.fn(),
+    getAsyncQueryResult: vi.fn(),
+    cancelAsyncQuery: vi.fn(),
+    removeAsyncQuery: vi.fn().mockResolvedValue({ removed: true }),
+    lintSql: vi.fn().mockResolvedValue({ diagnostics: [], lintUnavailable: true }),
+    getColumns: vi.fn(),
+    cancelQuery: vi.fn(),
+  },
+}));
+
+import { bridge } from '../../api/bridge';
+
+const mockedBridge = vi.mocked(bridge);
+
+describe('runtimeDiagnostics', () => {
+  beforeEach(() => {
+    useQueryStore.setState({
+      queries: [],
+      activeQueryId: null,
+      results: {},
+      executingQueryIds: new Set<string>(),
+      errors: {},
+      lintDiagnostics: {},
+      runtimeDiagnostics: {},
+      paginationStates: {},
+      isExecuting: false,
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('SQL Server形式の実行エラー(Line N)からrow markerをセットする', async () => {
+    mockedBridge.executeAsyncQuery.mockRejectedValue(
+      new Error("Msg 208, Level 16, State 1, Line 3\nInvalid object name 'x'.")
+    );
+    const { addQuery, executeQuery, updateQuery } = useQueryStore.getState();
+    addQuery('conn_1');
+    const queryId = useQueryStore.getState().queries[0].id;
+    updateQuery(queryId, 'SELECT 1');
+
+    await executeQuery(queryId, 'conn_1');
+
+    const { runtimeDiagnostics } = useQueryStore.getState();
+    expect(runtimeDiagnostics[queryId]).toEqual([
+      expect.objectContaining({ line: 3, column: 1, message: "Invalid object name 'x'." }),
+    ]);
+  });
+
+  it('行情報がないエラーではruntimeDiagnosticsを追加しない', async () => {
+    mockedBridge.executeAsyncQuery.mockRejectedValue(new Error('random failure'));
+    const { addQuery, executeQuery, updateQuery } = useQueryStore.getState();
+    addQuery('conn_1');
+    const queryId = useQueryStore.getState().queries[0].id;
+    updateQuery(queryId, 'SELECT 1');
+
+    await executeQuery(queryId, 'conn_1');
+
+    const { runtimeDiagnostics } = useQueryStore.getState();
+    expect(runtimeDiagnostics[queryId] ?? []).toEqual([]);
+  });
+
+  it('再実行開始時に古いruntime markerをクリアする', async () => {
+    const { addQuery, executeQuery, updateQuery } = useQueryStore.getState();
+    addQuery('conn_1');
+    const queryId = useQueryStore.getState().queries[0].id;
+    updateQuery(queryId, 'SELECT 1');
+
+    // 1回目: エラーでmarkerセット
+    mockedBridge.executeAsyncQuery.mockRejectedValueOnce(
+      new Error('Msg 100, Level 16, State 1, Line 5\nerr')
+    );
+    await executeQuery(queryId, 'conn_1');
+    expect(useQueryStore.getState().runtimeDiagnostics[queryId]?.length).toBe(1);
+
+    // 2回目: 実行開始時にクリアされてから成功
+    mockedBridge.executeAsyncQuery.mockResolvedValueOnce({ queryId: 'async_1' });
+    mockedBridge.getAsyncQueryResult.mockResolvedValueOnce({
+      status: 'completed',
+      result: {
+        columns: [],
+        rows: [],
+        affectedRows: 0,
+        executionTimeMs: 0,
+        truncated: false,
+      },
+    });
+    await executeQuery(queryId, 'conn_1');
+    expect(useQueryStore.getState().runtimeDiagnostics[queryId]).toEqual([]);
+  });
+});

--- a/frontend/src/tests/utils/editorMarkers.test.ts
+++ b/frontend/src/tests/utils/editorMarkers.test.ts
@@ -26,7 +26,11 @@ describe('editorMarkers', () => {
 
   it('converts Diagnostic to Monaco Error marker with 1-based coords', () => {
     const model = makeModel('SELEC * FROM t');
-    setSqlMarkers(model as unknown as monaco.editor.ITextModel, [{ line: 1, column: 1, code: 'PRS', message: 'parse error' }], 'sqruff');
+    setSqlMarkers(
+      model as unknown as monaco.editor.ITextModel,
+      [{ line: 1, column: 1, code: 'PRS', message: 'parse error' }],
+      'sqruff'
+    );
     expect(monaco.editor.setModelMarkers).toHaveBeenCalledWith(model, 'sqruff', [
       expect.objectContaining({
         severity: monaco.MarkerSeverity.Error,
@@ -49,12 +53,20 @@ describe('editorMarkers', () => {
     const model = makeModel('');
     clearSqlMarkers(model as unknown as monaco.editor.ITextModel, 'sqruff');
     expect(monaco.editor.setModelMarkers).toHaveBeenCalledWith(model, 'sqruff', []);
-    expect(monaco.editor.setModelMarkers).not.toHaveBeenCalledWith(model, 'runtime', expect.anything());
+    expect(monaco.editor.setModelMarkers).not.toHaveBeenCalledWith(
+      model,
+      'runtime',
+      expect.anything()
+    );
   });
 
   it('normalizes end column to at least startColumn+1 when line is short', () => {
     const model = makeModel('a');
-    setSqlMarkers(model as unknown as monaco.editor.ITextModel, [{ line: 1, column: 10, message: 'msg' }], 'sqruff');
+    setSqlMarkers(
+      model as unknown as monaco.editor.ITextModel,
+      [{ line: 1, column: 10, message: 'msg' }],
+      'sqruff'
+    );
     const call = vi.mocked(monaco.editor.setModelMarkers).mock.calls[0];
     const marker = (call?.[2] as monaco.editor.IMarkerData[])[0];
     expect(marker.endColumn).toBeGreaterThan(marker.startColumn);

--- a/frontend/src/tests/utils/editorMarkers.test.ts
+++ b/frontend/src/tests/utils/editorMarkers.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('monaco-editor', () => {
+  const setModelMarkers = vi.fn();
+  return {
+    editor: { setModelMarkers },
+    MarkerSeverity: { Error: 8, Warning: 4, Info: 2, Hint: 1 },
+  };
+});
+
+import * as monaco from 'monaco-editor';
+import { clearSqlMarkers, setSqlMarkers } from '../../utils/editorMarkers';
+
+type MockModel = {
+  getLineContent: (n: number) => string;
+};
+
+const makeModel = (line: string): MockModel => ({
+  getLineContent: () => line,
+});
+
+describe('editorMarkers', () => {
+  beforeEach(() => {
+    vi.mocked(monaco.editor.setModelMarkers).mockClear();
+  });
+
+  it('converts Diagnostic to Monaco Error marker with 1-based coords', () => {
+    const model = makeModel('SELEC * FROM t');
+    setSqlMarkers(model as unknown as monaco.editor.ITextModel, [{ line: 1, column: 1, code: 'PRS', message: 'parse error' }], 'sqruff');
+    expect(monaco.editor.setModelMarkers).toHaveBeenCalledWith(model, 'sqruff', [
+      expect.objectContaining({
+        severity: monaco.MarkerSeverity.Error,
+        startLineNumber: 1,
+        startColumn: 1,
+        endLineNumber: 1,
+        message: '[PRS] parse error',
+        source: 'sqruff',
+      }),
+    ]);
+  });
+
+  it('empty diagnostics clears previous markers for owner', () => {
+    const model = makeModel('');
+    setSqlMarkers(model as unknown as monaco.editor.ITextModel, [], 'sqruff');
+    expect(monaco.editor.setModelMarkers).toHaveBeenCalledWith(model, 'sqruff', []);
+  });
+
+  it('clearSqlMarkers only clears specified owner', () => {
+    const model = makeModel('');
+    clearSqlMarkers(model as unknown as monaco.editor.ITextModel, 'sqruff');
+    expect(monaco.editor.setModelMarkers).toHaveBeenCalledWith(model, 'sqruff', []);
+    expect(monaco.editor.setModelMarkers).not.toHaveBeenCalledWith(model, 'runtime', expect.anything());
+  });
+
+  it('normalizes end column to at least startColumn+1 when line is short', () => {
+    const model = makeModel('a');
+    setSqlMarkers(model as unknown as monaco.editor.ITextModel, [{ line: 1, column: 10, message: 'msg' }], 'sqruff');
+    const call = vi.mocked(monaco.editor.setModelMarkers).mock.calls[0];
+    const marker = (call?.[2] as monaco.editor.IMarkerData[])[0];
+    expect(marker.endColumn).toBeGreaterThan(marker.startColumn);
+  });
+
+  it('does nothing when model is null', () => {
+    setSqlMarkers(null, [{ line: 1, column: 1, message: 'x' }], 'sqruff');
+    expect(monaco.editor.setModelMarkers).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/tests/utils/errorParser.test.ts
+++ b/frontend/src/tests/utils/errorParser.test.ts
@@ -54,6 +54,27 @@ describe('parseErrorMessage', () => {
     });
   });
 
+  describe('行番号抽出', () => {
+    it('SQL Server: Msg行からLine番号を抽出', () => {
+      const raw = "Msg 208, Level 16, State 1, Line 3\nInvalid object name 'x'.";
+      expect(parseErrorMessage(raw).line).toBe(3);
+    });
+
+    it('PostgreSQL: LINE Nパターンを抽出', () => {
+      const raw = 'ERROR:  syntax error\nLINE 2: SELECT foo\n        ^';
+      expect(parseErrorMessage(raw).line).toBe(2);
+    });
+
+    it('MySQL: at line N パターンを抽出', () => {
+      const raw = "ERROR 1064 (42000): You have an error in your SQL syntax near 'foo' at line 4";
+      expect(parseErrorMessage(raw).line).toBe(4);
+    });
+
+    it('行情報がない場合はundefined', () => {
+      expect(parseErrorMessage('random error').line).toBeUndefined();
+    });
+  });
+
   describe('不明形式', () => {
     it('パースできない場合はrawメッセージをsummaryに返す', () => {
       const raw = 'Something went wrong';

--- a/frontend/src/utils/editorMarkers.ts
+++ b/frontend/src/utils/editorMarkers.ts
@@ -1,0 +1,42 @@
+import * as monaco from 'monaco-editor';
+
+export interface SqlMarkerInput {
+  line: number; // 1-based
+  column: number; // 1-based
+  message: string;
+  code?: string;
+}
+
+export type SqlMarkerOwner = 'sqruff' | 'runtime' | 'format';
+
+export function setSqlMarkers(
+  model: monaco.editor.ITextModel | null | undefined,
+  diagnostics: SqlMarkerInput[],
+  owner: SqlMarkerOwner
+): void {
+  if (!model) return;
+  const markers: monaco.editor.IMarkerData[] = diagnostics.map((d) => {
+    const startColumn = Math.max(1, d.column);
+    const startLineNumber = Math.max(1, d.line);
+    const line = model.getLineContent(startLineNumber) ?? '';
+    const endColumn = Math.max(startColumn + 1, line.length + 1);
+    return {
+      severity: monaco.MarkerSeverity.Error,
+      message: d.code ? `[${d.code}] ${d.message}` : d.message,
+      startLineNumber,
+      startColumn,
+      endLineNumber: startLineNumber,
+      endColumn,
+      source: owner,
+    };
+  });
+  monaco.editor.setModelMarkers(model, owner, markers);
+}
+
+export function clearSqlMarkers(
+  model: monaco.editor.ITextModel | null | undefined,
+  owner: SqlMarkerOwner
+): void {
+  if (!model) return;
+  monaco.editor.setModelMarkers(model, owner, []);
+}

--- a/frontend/src/utils/errorParser.ts
+++ b/frontend/src/utils/errorParser.ts
@@ -1,11 +1,15 @@
 export interface ParsedError {
   summary: string;
   detail: string;
+  line?: number;
 }
 
 const PSQL_ERROR_RE = /^(?:psql:[^\n]*?:\s*)?ERROR:\s+(.+)/;
-const SQLSERVER_MSG_RE = /^Msg\s+\d+,\s+Level\s+\d+,\s+State\s+\d+,\s+Line\s+\d+\n(.+)/;
+const SQLSERVER_MSG_RE = /^Msg\s+\d+,\s+Level\s+\d+,\s+State\s+\d+,\s+Line\s+(\d+)\n(.+)/;
 const MYSQL_ERROR_RE = /^ERROR\s+\d+\s+\(\w+\):\s+(.+)/;
+
+const POSTGRES_LINE_RE = /\bLINE\s+(\d+)\s*:/;
+const MYSQL_AT_LINE_RE = /\bat\s+line\s+(\d+)\b/i;
 
 export function parseErrorMessage(raw: string): ParsedError {
   if (!raw) return { summary: '', detail: '' };
@@ -14,17 +18,31 @@ export function parseErrorMessage(raw: string): ParsedError {
 
   const psqlMatch = firstLine.match(PSQL_ERROR_RE);
   if (psqlMatch) {
-    return { summary: psqlMatch[1].trim(), detail: raw };
+    const lineMatch = raw.match(POSTGRES_LINE_RE);
+    return {
+      summary: psqlMatch[1].trim(),
+      detail: raw,
+      line: lineMatch ? Number(lineMatch[1]) : undefined,
+    };
   }
 
   const sqlServerMatch = raw.match(SQLSERVER_MSG_RE);
   if (sqlServerMatch) {
-    return { summary: sqlServerMatch[1].trim(), detail: raw };
+    return {
+      summary: sqlServerMatch[2].trim(),
+      detail: raw,
+      line: Number(sqlServerMatch[1]),
+    };
   }
 
   const mysqlMatch = firstLine.match(MYSQL_ERROR_RE);
   if (mysqlMatch) {
-    return { summary: mysqlMatch[1].trim(), detail: raw };
+    const lineMatch = raw.match(MYSQL_AT_LINE_RE);
+    return {
+      summary: mysqlMatch[1].trim(),
+      detail: raw,
+      line: lineMatch ? Number(lineMatch[1]) : undefined,
+    };
   }
 
   return { summary: firstLine, detail: raw };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,10 +28,12 @@ set(TEST_SOURCES
     database/test_transaction_manager.cpp
     parsers/test_a5er_parser.cpp
     parsers/test_sql_formatter.cpp
+    parsers/test_sql_linter.cpp
     parsers/test_sql_parser.cpp
     database/test_postgresql_driver.cpp
     database/test_psql_subprocess.cpp
     exporters/test_csv_exporter.cpp
+    providers/test_lint_provider.cpp
     providers/test_settings_provider.cpp
     providers/test_utility_provider.cpp
     utils/test_sql_validation.cpp

--- a/tests/parsers/test_sql_linter.cpp
+++ b/tests/parsers/test_sql_linter.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+
+#include "parsers/sql_linter.h"
+
+namespace velocitydb {
+namespace {
+
+// ===== mapDialectToSqruff =====
+
+TEST(MapDialectToSqruffTest, SqlServerToTsql) {
+    EXPECT_EQ(mapDialectToSqruff("sqlserver"), "tsql");
+}
+
+TEST(MapDialectToSqruffTest, PostgresqlToPostgres) {
+    EXPECT_EQ(mapDialectToSqruff("postgresql"), "postgres");
+}
+
+TEST(MapDialectToSqruffTest, MysqlToMysql) {
+    EXPECT_EQ(mapDialectToSqruff("mysql"), "mysql");
+}
+
+TEST(MapDialectToSqruffTest, UnknownReturnsEmpty) {
+    EXPECT_EQ(mapDialectToSqruff("oracle"), "");
+    EXPECT_EQ(mapDialectToSqruff(""), "");
+}
+
+// ===== parseSqruffJson =====
+
+TEST(ParseSqruffJsonTest, EmptyStringReturnsEmpty) {
+    auto result = parseSqruffJson("");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST(ParseSqruffJsonTest, WhitespaceOnlyReturnsEmpty) {
+    auto result = parseSqruffJson("   \n\t  ");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST(ParseSqruffJsonTest, EmptyObjectReturnsEmpty) {
+    auto result = parseSqruffJson("{}");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST(ParseSqruffJsonTest, ParsesPrsDiagnostic) {
+    std::string json = R"({"stdin":[{"code":"PRS","message":"unexpected token","range":{"start":{"line":3,"character":5}},"severity":1,"source":"sqruff"}]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ((*result)[0].line, 3);
+    EXPECT_EQ((*result)[0].column, 5);
+    EXPECT_EQ((*result)[0].code, "PRS");
+    EXPECT_EQ((*result)[0].message, "unexpected token");
+}
+
+TEST(ParseSqruffJsonTest, FiltersNonPrsCodes) {
+    std::string json = R"({"stdin":[
+        {"code":"L001","message":"style","range":{"start":{"line":1,"character":1}}},
+        {"code":"PRS","message":"parse error","range":{"start":{"line":2,"character":1}}},
+        {"code":"CP01","message":"capitalization","range":{"start":{"line":3,"character":1}}}
+    ]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ((*result)[0].code, "PRS");
+}
+
+TEST(ParseSqruffJsonTest, AcceptsPrsPrefixedCodes) {
+    std::string json = R"({"stdin":[
+        {"code":"PRS001","message":"a","range":{"start":{"line":1,"character":1}}},
+        {"code":"PRS_UNEXPECTED","message":"b","range":{"start":{"line":2,"character":1}}}
+    ]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->size(), 2u);
+}
+
+TEST(ParseSqruffJsonTest, MultipleFilesFlattened) {
+    // JSON object key iteration order is not guaranteed; assert on the set of messages.
+    std::string json = R"({
+        "a.sql":[{"code":"PRS","message":"m1","range":{"start":{"line":1,"character":1}}}],
+        "b.sql":[{"code":"PRS","message":"m2","range":{"start":{"line":2,"character":2}}}]
+    })";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 2u);
+    std::set<std::string> msgs{(*result)[0].message, (*result)[1].message};
+    EXPECT_EQ(msgs, (std::set<std::string>{"m1", "m2"}));
+}
+
+TEST(ParseSqruffJsonTest, MissingCodeFieldIsDiscarded) {
+    // A diagnostic without "code" cannot be classified as PRS, so the filter discards it.
+    // Regression guard: if sqruff ever emits code-less entries we keep fail-closed on them.
+    std::string json = R"({"stdin":[{"message":"m","range":{"start":{"line":1,"character":1}}}]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST(ParseSqruffJsonTest, MalformedJsonReturnsError) {
+    auto result = parseSqruffJson("{not valid json");
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST(ParseSqruffJsonTest, ClampsLineColumnToOne) {
+    std::string json = R"({"stdin":[{"code":"PRS","message":"m","range":{"start":{"line":0,"character":0}}}]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ((*result)[0].line, 1);
+    EXPECT_EQ((*result)[0].column, 1);
+}
+
+// ===== lintSqlForParseErrors (BinaryNotFound path) =====
+
+TEST(LintSqlForParseErrorsTest, BinaryNotFoundReturnsError) {
+    SqlLinterConfig cfg{
+        .binary = "C:/nonexistent/path/sqruff.exe",
+        .configFile = {},
+        .timeout = std::chrono::milliseconds{1000},
+    };
+    auto result = lintSqlForParseErrors(cfg, "SELECT 1", "tsql");
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().kind, LintErrorKind::BinaryNotFound);
+}
+
+}  // namespace
+}  // namespace velocitydb

--- a/tests/providers/test_lint_provider.cpp
+++ b/tests/providers/test_lint_provider.cpp
@@ -1,0 +1,67 @@
+#include <gtest/gtest.h>
+
+#include "providers/lint_provider.h"
+#include "simdjson.h"
+
+namespace velocitydb {
+namespace {
+
+class LintProviderTest : public ::testing::Test {
+protected:
+    LintProvider provider;
+
+    [[nodiscard]] static simdjson::dom::element parseJson(simdjson::padded_string_view json) {
+        thread_local simdjson::dom::parser p;
+        return p.parse(json).value();
+    }
+};
+
+TEST_F(LintProviderTest, InvalidJsonReturnsError) {
+    auto response = provider.lintSql("not json");
+    simdjson::padded_string padded(response);
+    auto doc = parseJson(padded);
+    EXPECT_FALSE(doc["success"].get_bool().value());
+    std::string_view errMsg = doc["error"].get_string().value();
+    EXPECT_NE(errMsg.find("Invalid JSON"), std::string_view::npos);
+}
+
+TEST_F(LintProviderTest, MissingSqlFieldReturnsError) {
+    auto response = provider.lintSql(R"({"dbType":"sqlserver"})");
+    simdjson::padded_string padded(response);
+    auto doc = parseJson(padded);
+    EXPECT_FALSE(doc["success"].get_bool().value());
+    std::string_view errMsg = doc["error"].get_string().value();
+    EXPECT_NE(errMsg.find("'sql'"), std::string_view::npos);
+}
+
+TEST_F(LintProviderTest, MissingDbTypeFieldReturnsError) {
+    auto response = provider.lintSql(R"({"sql":"SELECT 1"})");
+    simdjson::padded_string padded(response);
+    auto doc = parseJson(padded);
+    EXPECT_FALSE(doc["success"].get_bool().value());
+    std::string_view errMsg = doc["error"].get_string().value();
+    EXPECT_NE(errMsg.find("'dbType'"), std::string_view::npos);
+}
+
+TEST_F(LintProviderTest, UnsupportedDbTypeReturnsError) {
+    auto response = provider.lintSql(R"({"sql":"SELECT 1","dbType":"oracle"})");
+    simdjson::padded_string padded(response);
+    auto doc = parseJson(padded);
+    EXPECT_FALSE(doc["success"].get_bool().value());
+    std::string_view errMsg = doc["error"].get_string().value();
+    EXPECT_NE(errMsg.find("Unsupported dbType"), std::string_view::npos);
+}
+
+TEST_F(LintProviderTest, FailOpenContractReturnsSuccessRegardlessOfBinary) {
+    // Fail-open contract: whether the binary exists (empty diagnostics for valid SQL)
+    // or is missing (lintUnavailable:true), the response is always success:true with
+    // a diagnostics array. Never success:false for valid-shape input.
+    auto response = provider.lintSql(R"({"sql":"SELECT 1","dbType":"sqlserver"})");
+    simdjson::padded_string padded(response);
+    auto doc = parseJson(padded);
+    EXPECT_TRUE(doc["success"].get_bool().value());
+    EXPECT_FALSE(doc["data"]["diagnostics"].get_array().error());
+}
+
+}  // namespace
+}  // namespace velocitydb

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -62,3 +62,38 @@ FetchContent_MakeAvailable(glaze)
 
 # Note: xlsxwriter requires separate build
 # For now, it's disabled until properly integrated
+
+# sqruff - SQL linter (Windows x86_64 prebuilt binary)
+# https://github.com/quarylabs/sqruff
+# License: Apache-2.0
+set(SQRUFF_VERSION "0.38.0")
+set(SQRUFF_SHA256 "004e2b7a7a8c32256bc76bc61b642014856ff3fa1c4aedf9854e66c5b8a4817b")
+set(SQRUFF_ARCHIVE "${CMAKE_CURRENT_SOURCE_DIR}/sqruff/sqruff-${SQRUFF_VERSION}.zip")
+set(SQRUFF_EXTRACT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sqruff/${SQRUFF_VERSION}")
+set(SQRUFF_EXE "${SQRUFF_EXTRACT_DIR}/sqruff.exe")
+
+if(NOT EXISTS "${SQRUFF_EXE}")
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/sqruff")
+    if(NOT EXISTS "${SQRUFF_ARCHIVE}")
+        message(STATUS "Downloading sqruff v${SQRUFF_VERSION}...")
+        file(DOWNLOAD
+            "https://github.com/quarylabs/sqruff/releases/download/v${SQRUFF_VERSION}/sqruff-windows-x86_64.zip"
+            "${SQRUFF_ARCHIVE}"
+            EXPECTED_HASH SHA256=${SQRUFF_SHA256}
+            SHOW_PROGRESS
+            TLS_VERIFY ON
+        )
+    endif()
+    file(ARCHIVE_EXTRACT
+        INPUT "${SQRUFF_ARCHIVE}"
+        DESTINATION "${SQRUFF_EXTRACT_DIR}"
+    )
+endif()
+
+if(EXISTS "${SQRUFF_EXE}")
+    message(STATUS "sqruff binary: ${SQRUFF_EXE}")
+    add_library(sqruff_binary INTERFACE)
+    set(SQRUFF_BINARY_PATH "${SQRUFF_EXE}" CACHE INTERNAL "Path to sqruff.exe")
+else()
+    message(FATAL_ERROR "sqruff.exe extraction failed: ${SQRUFF_EXE}")
+endif()


### PR DESCRIPTION
- third_party: sqruff v0.38.0 Windows バイナリをCMakeで取得、SHA256検証
- backend: ILintProvider/LintProvider + sql_linter (CreateProcessW + stdin/stdout pipe)
- backend: .sqruff設定で構文エラー(PRS)のみ有効化、スタイル警告は無視
- backend: ipc_handler に lintSql ルート追加
- frontend: Monaco setModelMarkers owner分離ユーティリティ (sqruff/runtime/format)
- frontend: 実行前 lintSql → PRSあれば実行ブロック + 行マーカー + toast
- frontend: lint機構自体の失敗(バイナリ欠損等)は実行ブロックせずwarnログのみ
- frontend: 接続dbType不明時は lintスキップ (fail-open)