### PR TITLE
fix: F9 による SQL 実行が反応しない問題を修正

### DIFF
--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -9,6 +9,14 @@ interface SettingsDialogProps {
   onClose: () => void;
 }
 
+// ショートカット表示。値は実キーハンドラ実装 (MainLayout.tsx) と同期させる
+const SHORTCUT_DISPLAY: ReadonlyArray<{ label: string; keys: string }> = [
+  { label: 'クエリを実行', keys: 'F9' },
+  { label: '新規クエリ', keys: 'Ctrl+N' },
+  { label: 'SQLフォーマット', keys: 'Ctrl+Shift+F' },
+  { label: '検索', keys: 'Ctrl+Shift+P' },
+];
+
 export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
   useDialogKeyboard({ isOpen, onEscape: onClose });
   const [settings, setSettings] = useState<AppSettings>(defaultSettings);
@@ -223,22 +231,12 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
 
             {activeTab === 'shortcuts' && (
               <div className={styles.settingsGroup}>
-                <div className={styles.setting}>
-                  <label>クエリを実行</label>
-                  <input type="text" value={settings.shortcuts.execute} readOnly />
-                </div>
-                <div className={styles.setting}>
-                  <label>新規クエリ</label>
-                  <input type="text" value={settings.shortcuts.newQuery} readOnly />
-                </div>
-                <div className={styles.setting}>
-                  <label>SQLフォーマット</label>
-                  <input type="text" value={settings.shortcuts.format} readOnly />
-                </div>
-                <div className={styles.setting}>
-                  <label>検索</label>
-                  <input type="text" value={settings.shortcuts.search} readOnly />
-                </div>
+                {SHORTCUT_DISPLAY.map(({ label, keys }) => (
+                  <div key={label} className={styles.setting}>
+                    <label>{label}</label>
+                    <input type="text" value={keys} readOnly />
+                  </div>
+                ))}
                 <p className={styles.shortcutNote}>
                   このバージョンではキーボードショートカットのカスタマイズはできません。
                 </p>

--- a/frontend/src/components/editor/SqlEditor.tsx
+++ b/frontend/src/components/editor/SqlEditor.tsx
@@ -14,7 +14,6 @@ import {
 } from '../../utils/editorMarkers';
 import { log } from '../../utils/logger';
 import { formatSQL } from '../../utils/sqlFormat';
-import { getStatementAtCursor } from '../../utils/sqlParser';
 import { createCompletionProvider } from './completionProvider';
 import './monacoEnvironment';
 import styles from './SqlEditor.module.css';
@@ -42,13 +41,6 @@ function useApplyMarkers(
     setSqlMarkers(model, diagnostics, owner);
   }, [editorRef, diagnostics, owner]);
 }
-
-/** Get the connection ID of the active query tab (not the global activeConnectionId). */
-const getActiveQueryConnectionId = () => {
-  const { queries, activeQueryId } = getQueryState();
-  const found = queries.find((q) => q.id === activeQueryId);
-  return found?.connectionId ?? null;
-};
 
 export function SqlEditor() {
   const { queries, activeQueryId, updateQuery } = useQueryStore();
@@ -140,59 +132,6 @@ export function SqlEditor() {
             log.error(`[SqlEditor] Format: ERROR - ${msg}`);
           } finally {
             isFormattingRef.current = false;
-          }
-        }, 0);
-      });
-      return;
-    }
-
-    // F9 for query execution
-    if (event.key === 'F9' && !event.ctrlKey && !event.shiftKey && !event.altKey) {
-      event.preventDefault();
-      log.debug('[SqlEditor] Global F9 detected');
-      requestAnimationFrame(() => {
-        setTimeout(() => {
-          const qId = getQueryState().activeQueryId;
-          const cId = getActiveQueryConnectionId();
-          if (qId && cId) {
-            getQueryState().executeQuery(qId, cId);
-          }
-        }, 0);
-      });
-      return;
-    }
-
-    // Ctrl+Enter for executing current statement at cursor position
-    if (event.ctrlKey && event.key === 'Enter' && !event.shiftKey && !event.altKey) {
-      event.preventDefault();
-      log.debug('[SqlEditor] Global Ctrl+Enter detected');
-      requestAnimationFrame(() => {
-        setTimeout(() => {
-          if (!editorRef.current) return;
-          const qId = getQueryState().activeQueryId;
-          const cId = getActiveQueryConnectionId();
-          if (!qId || !cId) return;
-
-          const model = editorRef.current.getModel();
-          const position = editorRef.current.getPosition();
-          if (!model || !position) {
-            // フォールバック: 全体を実行
-            getQueryState().executeQuery(qId, cId);
-            return;
-          }
-
-          const cursorOffset = model.getOffsetAt(position);
-          const fullText = model.getValue();
-          const currentStatement = getStatementAtCursor(fullText, cursorOffset);
-
-          if (currentStatement) {
-            log.debug(
-              `[SqlEditor] Executing statement at cursor: ${currentStatement.slice(0, 50)}...`
-            );
-            getQueryState().executeSelectedText(qId, cId, currentStatement);
-          } else {
-            // フォールバック: 全体を実行
-            getQueryState().executeQuery(qId, cId);
           }
         }, 0);
       });

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -564,7 +564,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
         <span>クエリを実行して結果を表示</span>
         <div className={styles.shortcutList}>
           <span className={styles.shortcutItem}>
-            <kbd>Ctrl+Enter</kbd> SQLを実行
+            <kbd>F9</kbd> SQLを実行
           </span>
           <span className={styles.shortcutItem}>
             <kbd>Ctrl+N</kbd> 新規タブ

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -331,7 +331,8 @@ export function MainLayout() {
     } else if (e.ctrlKey && e.key === 'w') {
       e.preventDefault();
       handleCloseTab();
-    } else if (e.ctrlKey && e.key === 'Enter') {
+    } else if (e.key === 'F9' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      // F9 単独のみ実行トリガ。Ctrl/Shift/Alt+F9 は将来の拡張用に予約
       e.preventDefault();
       handleExecute();
     } else if (e.ctrlKey && e.shiftKey && e.key === 'F') {
@@ -424,7 +425,7 @@ export function MainLayout() {
           <button
             onClick={isExecuting ? handleCancel : handleExecute}
             disabled={isRunButtonDisabled(activeQuery, activeQueryConnectionId)}
-            title={isExecuting ? '停止 (Escape)' : '実行 (Ctrl+Enter)'}
+            title={isExecuting ? '停止 (Escape)' : '実行 (F9)'}
             className={styles.executeButton}
           >
             {isExecuting ? Icons.stop : Icons.play}

--- a/frontend/src/hooks/useKeyboardHandler.ts
+++ b/frontend/src/hooks/useKeyboardHandler.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from 'react';
 
+// Monaco Editor が bubbling phase 到達前に stopPropagation するため、
+// capture phase で先に捕捉しないと F9/Ctrl+S 等のグローバルショートカットが発火しない。
+// 運用ルール: 同一キーに対して複数の useKeyboardHandler を置かないこと。
+// capture phase では兄弟リスナーが順次発火し、二重実行になる (例: F9 → executeQuery が2回)。
+const USE_CAPTURE = true;
+
 /**
  * Registers a global keydown handler that always reflects the latest callback.
  * The listener is registered once on mount and never re-registered.
@@ -23,7 +29,7 @@ export function useKeyboardHandler(
       if (containerRef && !containerRef.current?.contains(document.activeElement)) return;
       handlerRef.current(e);
     };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
+    window.addEventListener('keydown', onKeyDown, USE_CAPTURE);
+    return () => window.removeEventListener('keydown', onKeyDown, USE_CAPTURE);
   }, [containerRef]);
 }

--- a/frontend/src/tests/helpers/mockSettingsUtils.ts
+++ b/frontend/src/tests/helpers/mockSettingsUtils.ts
@@ -5,7 +5,7 @@ const mockSettings = {
   query: { autoCommit: true, timeout: 30000, maxRows: 10000 },
   appearance: { theme: 'dark' as const },
   shortcuts: {
-    execute: 'Ctrl+Enter',
+    execute: 'F9',
     newQuery: 'Ctrl+N',
     format: 'Ctrl+Shift+F',
     search: 'Ctrl+Shift+P',

--- a/frontend/src/tests/hooks/useKeyboardHandler.test.ts
+++ b/frontend/src/tests/hooks/useKeyboardHandler.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useKeyboardHandler } from '../../hooks/useKeyboardHandler';
+
+describe('useKeyboardHandler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers keydown listener on window', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const handler = vi.fn();
+
+    const { unmount } = renderHook(() => useKeyboardHandler(handler));
+
+    expect(addSpy.mock.calls.find((c) => c[0] === 'keydown')).toBeDefined();
+
+    unmount();
+    expect(removeSpy.mock.calls.find((c) => c[0] === 'keydown')).toBeDefined();
+  });
+
+  it('registers keydown listener in capture phase to bypass Monaco stopPropagation', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const handler = vi.fn();
+
+    renderHook(() => useKeyboardHandler(handler));
+
+    const addCall = addSpy.mock.calls.find((c) => c[0] === 'keydown');
+    expect(addCall).toBeDefined();
+    // 3rd arg is either `true` (capture) or `{ capture: true }`
+    const useCapture = addCall?.[2];
+    const isCapture =
+      useCapture === true ||
+      (typeof useCapture === 'object' && useCapture !== null && useCapture.capture === true);
+    expect(isCapture).toBe(true);
+  });
+
+  it('removes listener with same capture flag on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const handler = vi.fn();
+
+    const { unmount } = renderHook(() => useKeyboardHandler(handler));
+    unmount();
+
+    const addCall = addSpy.mock.calls.find((c) => c[0] === 'keydown');
+    const removeCall = removeSpy.mock.calls.find((c) => c[0] === 'keydown');
+    // add と remove は同じ capture フラグでないとリスナー解除されない
+    expect(removeCall?.[2]).toEqual(addCall?.[2]);
+  });
+
+  it('invokes handler on keydown event', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyboardHandler(handler));
+
+    const event = new KeyboardEvent('keydown', { key: 'F9' });
+    window.dispatchEvent(event);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toBe(event);
+  });
+
+  it('always uses the latest handler (no stale closures)', () => {
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ h }: { h: (e: KeyboardEvent) => void }) => useKeyboardHandler(h),
+      { initialProps: { h: firstHandler } }
+    );
+
+    // rerender + ref sync effect を flush するため act でラップ
+    act(() => {
+      rerender({ h: secondHandler });
+    });
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'F9' }));
+
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utils/settingsUtils.ts
+++ b/frontend/src/utils/settingsUtils.ts
@@ -39,7 +39,7 @@ export const defaultSettings: AppSettings = {
     theme: 'dark',
   },
   shortcuts: {
-    execute: 'Ctrl+Enter',
+    execute: 'F9',
     newQuery: 'Ctrl+N',
     format: 'Ctrl+Shift+F',
     search: 'Ctrl+Shift+P',


### PR DESCRIPTION
Monaco Editor が keydown を bubbling phase 前に stopPropagation するため、 `useKeyboardHandler` を `capture phase` 登録へ変更。
グローバルショートカット(F9 / Ctrl+S / Ctrl+O / Ctrl+Shift+K) が Monaco フォーカス時も発火するようにした。
併せて SQL 実行トリガを「F9 キー + UI 実行ボタン」の2つに統一

- SqlEditor の F9 / Ctrl+Enter ハンドラを削除 (safety checks 経由の MainLayout へ一本化)
- MainLayout のキーバインドを Ctrl+Enter → F9 に変更
- 設定表示 (SettingsDialog) のショートカットを実装ハードコードに合わせて固定
- useKeyboardHandler テスト (capture phase 検証含む 5 件) を追加