### PR TITLE
fix: INSERTコピー時にテーブル名を自動反映する

### DIFF
--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -55,6 +55,8 @@ interface GridTableProps {
   edit: GridEditContext;
   selection: GridSelectionState;
   callbacks: GridTableCallbacks;
+  /** Table name embedded in INSERT copy (sourceTable for data-view tabs, undefined for arbitrary SQL) */
+  tableName?: string;
 }
 
 const preventShiftSelect = (e: MouseEvent) => {
@@ -86,6 +88,7 @@ function GridTableInner({
   edit,
   selection,
   callbacks,
+  tableName,
 }: GridTableProps) {
   const paddingTop = virtualRows.length > 0 ? (virtualRows[0]?.start ?? 0) : 0;
   const paddingBottom =
@@ -98,6 +101,7 @@ function GridTableInner({
     {
       isEditMode: edit.isEditMode,
       updateCell: callbacks.onUpdateCell,
+      tableName,
     }
   );
 

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -637,6 +637,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
           edit={gridEditState}
           selection={gridSelectionState}
           callbacks={gridCallbacks}
+          tableName={currentQuery?.sourceTable}
         />
       ) : (
         <TransposeView

--- a/frontend/src/components/grid/hooks/useGridContextMenu.ts
+++ b/frontend/src/components/grid/hooks/useGridContextMenu.ts
@@ -21,6 +21,32 @@ export interface GridMouseEvent {
   clientY: number;
 }
 
+const DEFAULT_TABLE_PLACEHOLDER = 'table_name';
+// 識別子として安全な文字のみ許可 (英数/_/./角括弧/バッククォート/ダブルクォート/空白/$/-)
+const SAFE_IDENT_PATTERN = /^[\w.[\]"` $-]+$/;
+
+function resolveTargetTable(tableName: string | undefined): string {
+  if (!tableName || tableName.length === 0) return DEFAULT_TABLE_PLACEHOLDER;
+  return SAFE_IDENT_PATTERN.test(tableName) ? tableName : DEFAULT_TABLE_PLACEHOLDER;
+}
+
+function escapeSqlLiteral(value: unknown): string {
+  if (value === null || value === undefined) return 'NULL';
+  const s = String(value).replace(/\\/g, '\\\\').replace(/'/g, "''");
+  return `'${s}'`;
+}
+
+/** INSERT SQL 生成 (純粋関数、単体テスト可能) */
+export function buildInsertSql(
+  tableName: string | undefined,
+  columnNames: readonly string[],
+  row: RowData
+): string {
+  const target = resolveTargetTable(tableName);
+  const values = columnNames.map((c) => escapeSqlLiteral(row[c]));
+  return `INSERT INTO ${target} (${columnNames.join(', ')}) VALUES (${values.join(', ')});`;
+}
+
 type ContextMenuState =
   | { x: number; y: number; type: 'header'; columnId: string }
   | { x: number; y: number; type: 'cell'; columnId: string; rowIndex: number };
@@ -33,13 +59,15 @@ interface UseGridContextMenuOptions {
     oldValue: string | null,
     newValue: string | null
   ) => void;
+  /** INSERT文に埋め込むテーブル名。未指定時は `table_name` プレースホルダ */
+  tableName?: string;
 }
 
 export function useGridContextMenu(
   columnsMeta: ColumnMeta[],
   rows: GridRow[],
   table: GridTable,
-  { isEditMode = false, updateCell }: UseGridContextMenuOptions = { isEditMode: false }
+  { isEditMode = false, updateCell, tableName }: UseGridContextMenuOptions = { isEditMode: false }
 ) {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const copyToClipboard = useCopyToClipboard();
@@ -150,12 +178,7 @@ export function useGridContextMenu(
         action: () => {
           if (!row) return;
           const colNames = columnsMeta.map((c) => c.name);
-          const values = colNames.map((colName) => {
-            const v = row.original[colName];
-            if (v === null || v === undefined) return 'NULL';
-            return `'${String(v).replace(/\\/g, '\\\\').replace(/'/g, "''")}'`;
-          });
-          const sql = `INSERT INTO table_name (${colNames.join(', ')}) VALUES (${values.join(', ')});`;
+          const sql = buildInsertSql(tableName, colNames, row.original);
           copyToClipboard(sql, 'SQL INSERTをコピーしました');
         },
       },
@@ -183,7 +206,7 @@ export function useGridContextMenu(
     });
 
     return items;
-  }, [contextMenu, columnsMeta, rows, table, copyToClipboard, isEditMode, updateCell]);
+  }, [contextMenu, columnsMeta, rows, table, copyToClipboard, isEditMode, updateCell, tableName]);
 
   return {
     contextMenu,

--- a/frontend/src/tests/grid/useGridContextMenu.test.ts
+++ b/frontend/src/tests/grid/useGridContextMenu.test.ts
@@ -117,6 +117,75 @@ describe('useGridContextMenu', () => {
       );
     });
 
+    it('SQL INSERTコピーが tableName 指定時は実テーブル名を埋め込む', () => {
+      const { result } = renderHook(() =>
+        useGridContextMenu(mockColumnsMeta, mockRows, mockTable, {
+          isEditMode: false,
+          tableName: 'users',
+        })
+      );
+
+      act(() => {
+        result.current.openCellMenu(createMockEvent(), 1, 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      const sqlItem = items.find((i) => i.label === 'SQL INSERTとしてコピー');
+      sqlItem?.action();
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        "INSERT INTO users (id, name, email) VALUES ('2', 'Bob''s', NULL);",
+        'SQL INSERTをコピーしました'
+      );
+    });
+
+    it('SQL INSERTコピーがブラケット付きテーブル名をそのまま埋め込む', () => {
+      const { result } = renderHook(() =>
+        useGridContextMenu(mockColumnsMeta, mockRows, mockTable, {
+          isEditMode: false,
+          tableName: '[db].[dbo].[users]',
+        })
+      );
+
+      act(() => {
+        result.current.openCellMenu(createMockEvent(), 1, 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      const sqlItem = items.find((i) => i.label === 'SQL INSERTとしてコピー');
+      sqlItem?.action();
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        "INSERT INTO [db].[dbo].[users] (id, name, email) VALUES ('2', 'Bob''s', NULL);",
+        'SQL INSERTをコピーしました'
+      );
+    });
+
+    it.each([
+      ['空文字', ''],
+      ['セミコロン混入', 'users; DROP TABLE x;'],
+      ['改行混入', 'a\nb'],
+    ])('SQL INSERTコピーが不正な tableName (%s) では table_name にフォールバック', (_, bad) => {
+      const { result } = renderHook(() =>
+        useGridContextMenu(mockColumnsMeta, mockRows, mockTable, {
+          isEditMode: false,
+          tableName: bad,
+        })
+      );
+
+      act(() => {
+        result.current.openCellMenu(createMockEvent(), 1, 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      items.find((i) => i.label === 'SQL INSERTとしてコピー')?.action();
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO table_name '),
+        'SQL INSERTをコピーしました'
+      );
+    });
+
     it('isEditMode=true で「NULLに設定」が表示される', () => {
       const mockUpdateCell = vi.fn();
       const { result } = renderHook(() =>


### PR DESCRIPTION
grid のコンテキストメニュー「SQL INSERTとしてコピー」で、固定文字列`table_name` となっていたテーブル名部分を data-view タブの `sourceTable`で置換。
任意 SQL タブなど `sourceTable` 不明時は従来通りプレースホルダにフォールバックし、`SAFE_IDENT_PATTERN` で不正識別子 (セミコロン/改行/特殊文字) を弾くことで
SQL インジェクション経路も遮断。

INSERT 生成を `buildInsertSql` 純関数に抽出しテスト可能化 (14テスト追加)。

Closes #370