### PR TITLE
fix: 複数セルの矩形選択とコピーを動作させる

### DIFF
--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -1,6 +1,6 @@
 import { flexRender, type Row, type Table } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
-import { type MouseEvent, memo, type RefObject } from 'react';
+import { type MouseEvent, memo, type RefObject, useCallback } from 'react';
 import { type ColumnMeta, isSystemColumn, type RowData } from '../../types/grid';
 import type { ValidationError } from '../../utils/validation';
 import { ContextMenu } from '../common/ContextMenu';
@@ -59,10 +59,6 @@ interface GridTableProps {
   tableName?: string;
 }
 
-const preventShiftSelect = (e: MouseEvent) => {
-  if (e.shiftKey) e.preventDefault();
-};
-
 /** Extract row/cell info from a bubbled event via data attributes */
 function findCellFromEvent(e: MouseEvent) {
   const td = (e.target as HTMLElement).closest('td[data-field]') as HTMLElement | null;
@@ -105,8 +101,26 @@ function GridTableInner({
     }
   );
 
+  // Move focus into the table container on click so global keyboard handlers
+  // (useKeyboardHandler gates by containerRef.contains(activeElement)) can
+  // receive Ctrl+C etc. Without this, the browser's default text selection
+  // copies only the last clicked cell. Also suppresses the default Shift+click
+  // text-range selection which would otherwise conflict with grid selection.
+  const onContainerMouseDown = useCallback(
+    (e: MouseEvent) => {
+      if (e.shiftKey) e.preventDefault();
+      tableContainerRef.current?.focus({ preventScroll: true });
+    },
+    [tableContainerRef]
+  );
+
   return (
-    <div ref={tableContainerRef} className={styles.tableContainer} onMouseDown={preventShiftSelect}>
+    <div
+      ref={tableContainerRef}
+      className={styles.tableContainer}
+      tabIndex={-1}
+      onMouseDown={onContainerMouseDown}
+    >
       <table key={`table-${showLogicalNamesInGrid}`} className={styles.table}>
         <thead className={styles.thead}>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/frontend/src/components/grid/ResultGrid.module.css
+++ b/frontend/src/components/grid/ResultGrid.module.css
@@ -343,6 +343,7 @@
   min-height: 0;
   background-color: var(--bg-primary);
   contain: strict;
+  outline: none;
 }
 
 .table {

--- a/frontend/src/components/grid/hooks/useGridSelection.ts
+++ b/frontend/src/components/grid/hooks/useGridSelection.ts
@@ -42,18 +42,36 @@ export function useGridSelection(
   const rangeCellSelect = useCallback(
     (rowIndex: number, field: string) => {
       if (isSystemColumn(field)) return;
-      if (lastClickedRowRef.current === null || lastClickedColumnRef.current !== field) {
+      if (lastClickedRowRef.current === null || lastClickedColumnRef.current === null) {
         selectCell(rowIndex, field);
         return;
       }
-      const start = Math.min(lastClickedRowRef.current, rowIndex);
-      const end = Math.max(lastClickedRowRef.current, rowIndex);
-      const range = new Set<number>();
-      for (let i = start; i <= end; i++) range.add(i);
-      setSelectedRows(range);
-      setSelectedColumns(new Set([field]));
+      const allColumnIds = columnOrderRef.current;
+      const anchorColIdx = allColumnIds.indexOf(lastClickedColumnRef.current);
+      const targetColIdx = allColumnIds.indexOf(field);
+      if (anchorColIdx === -1 || targetColIdx === -1) {
+        selectCell(rowIndex, field);
+        return;
+      }
+      const rowStart = Math.min(lastClickedRowRef.current, rowIndex);
+      const rowEnd = Math.max(lastClickedRowRef.current, rowIndex);
+      const rowRange = new Set<number>();
+      for (let i = rowStart; i <= rowEnd; i++) rowRange.add(i);
+
+      const [colFrom, colTo] =
+        anchorColIdx < targetColIdx ? [anchorColIdx, targetColIdx] : [targetColIdx, anchorColIdx];
+      const colRange = new Set(
+        allColumnIds.slice(colFrom, colTo + 1).filter((id) => !isSystemColumn(id))
+      );
+      if (colRange.size === 0) {
+        selectCell(rowIndex, field);
+        return;
+      }
+
+      setSelectedRows(rowRange);
+      setSelectedColumns(colRange);
     },
-    [selectCell]
+    [selectCell, columnOrderRef]
   );
 
   const selectAllRows = useCallback(() => {

--- a/frontend/src/tests/grid/useGridSelection.test.ts
+++ b/frontend/src/tests/grid/useGridSelection.test.ts
@@ -1,0 +1,79 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useGridSelection } from '../../components/grid/hooks/useGridSelection';
+
+function makeRefs(rowsLength: number, columnOrder: string[]) {
+  return {
+    rowsLengthRef: { current: rowsLength },
+    columnOrderRef: { current: columnOrder },
+  };
+}
+
+describe('useGridSelection', () => {
+  describe('selectCell', () => {
+    it('単一セルを選択する (selectedRows/selectedColumns がそれぞれ 1 要素)', () => {
+      const { rowsLengthRef, columnOrderRef } = makeRefs(5, ['a', 'b', 'c']);
+      const { result } = renderHook(() => useGridSelection(rowsLengthRef, columnOrderRef));
+
+      act(() => result.current.selectCell(2, 'b'));
+
+      expect(Array.from(result.current.selectedRows)).toEqual([2]);
+      expect(Array.from(result.current.selectedColumns)).toEqual(['b']);
+    });
+  });
+
+  describe('rangeCellSelect (Shift+クリックで矩形選択)', () => {
+    it('同一列内の行レンジを選択する (既存挙動)', () => {
+      const { rowsLengthRef, columnOrderRef } = makeRefs(5, ['a', 'b', 'c']);
+      const { result } = renderHook(() => useGridSelection(rowsLengthRef, columnOrderRef));
+
+      act(() => result.current.selectCell(1, 'b'));
+      act(() => result.current.rangeCellSelect(3, 'b'));
+
+      expect(Array.from(result.current.selectedRows).sort()).toEqual([1, 2, 3]);
+      expect(Array.from(result.current.selectedColumns)).toEqual(['b']);
+    });
+
+    it('異なる列にまたがる矩形 (行×列) を選択する', () => {
+      const { rowsLengthRef, columnOrderRef } = makeRefs(5, ['a', 'b', 'c', 'd']);
+      const { result } = renderHook(() => useGridSelection(rowsLengthRef, columnOrderRef));
+
+      act(() => result.current.selectCell(1, 'b'));
+      act(() => result.current.rangeCellSelect(3, 'd'));
+
+      expect(Array.from(result.current.selectedRows).sort()).toEqual([1, 2, 3]);
+      expect(Array.from(result.current.selectedColumns).sort()).toEqual(['b', 'c', 'd']);
+    });
+
+    it('逆方向 (右下 → 左上) の矩形選択も対応する', () => {
+      const { rowsLengthRef, columnOrderRef } = makeRefs(5, ['a', 'b', 'c', 'd']);
+      const { result } = renderHook(() => useGridSelection(rowsLengthRef, columnOrderRef));
+
+      act(() => result.current.selectCell(3, 'c'));
+      act(() => result.current.rangeCellSelect(1, 'a'));
+
+      expect(Array.from(result.current.selectedRows).sort()).toEqual([1, 2, 3]);
+      expect(Array.from(result.current.selectedColumns).sort()).toEqual(['a', 'b', 'c']);
+    });
+
+    it('アンカー未設定時は単一セル選択にフォールバック', () => {
+      const { rowsLengthRef, columnOrderRef } = makeRefs(5, ['a', 'b', 'c']);
+      const { result } = renderHook(() => useGridSelection(rowsLengthRef, columnOrderRef));
+
+      act(() => result.current.rangeCellSelect(2, 'b'));
+
+      expect(Array.from(result.current.selectedRows)).toEqual([2]);
+      expect(Array.from(result.current.selectedColumns)).toEqual(['b']);
+    });
+
+    it('システム列は選択対象外 (__rowIndex 等が列レンジに含まれても除外)', () => {
+      const { rowsLengthRef, columnOrderRef } = makeRefs(5, ['__rowIndex', 'a', 'b', 'c']);
+      const { result } = renderHook(() => useGridSelection(rowsLengthRef, columnOrderRef));
+
+      act(() => result.current.selectCell(0, 'a'));
+      act(() => result.current.rangeCellSelect(1, 'c'));
+
+      expect(Array.from(result.current.selectedColumns).sort()).toEqual(['a', 'b', 'c']);
+    });
+  });
+});

--- a/frontend/src/tests/hooks/useKeyboardHandler.test.ts
+++ b/frontend/src/tests/hooks/useKeyboardHandler.test.ts
@@ -61,6 +61,42 @@ describe('useKeyboardHandler', () => {
     expect(handler.mock.calls[0][0]).toBe(event);
   });
 
+  it('does not invoke handler when activeElement is outside containerRef', () => {
+    const handler = vi.fn();
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const containerRef = { current: container };
+
+    renderHook(() => useKeyboardHandler(handler, containerRef));
+
+    // document.body is outside container → handler must not fire
+    expect(container.contains(document.activeElement)).toBe(false);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true }));
+
+    expect(handler).not.toHaveBeenCalled();
+
+    document.body.removeChild(container);
+  });
+
+  it('invokes handler when activeElement is inside containerRef', () => {
+    const handler = vi.fn();
+    const container = document.createElement('div');
+    const child = document.createElement('button');
+    container.appendChild(child);
+    document.body.appendChild(container);
+    const containerRef = { current: container };
+
+    renderHook(() => useKeyboardHandler(handler, containerRef));
+
+    child.focus();
+    expect(container.contains(document.activeElement)).toBe(true);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'c', ctrlKey: true }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(container);
+  });
+
   it('always uses the latest handler (no stale closures)', () => {
     const firstHandler = vi.fn();
     const secondHandler = vi.fn();


### PR DESCRIPTION
grid で選択した複数セルをコピーしても「左上1セル」しか入らない不具合を2つの根本原因から修正

1. rangeCellSelect (Shift+クリック) が同一列内の行レンジのみ対応で、異なる列をまたぐと単一セル選択にフォールバックしていた
    → 行レンジ × 列レンジの矩形選択に拡張
2. tableContainer に tabIndex が無く focus が移らないため、 `useKeyboardHandler` の `containerRef` スコープ判定が常に false となり、
    `Ctrl+C` ハンドラが発火せずブラウザ既定のテキスト選択が作動していた
    → tabIndex=-1 付与 + onMouseDown で focus 移動 (preventScroll) + CSS で outline 抑止

Closes #369
