### PR TITLE
fix: タブ切替時にグリッドのスクロール位置を保持する

### DIFF
--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -21,6 +21,7 @@ import {
   useQueryResult,
   useQueryStore,
 } from '../../store/queryStore';
+import { useScrollPositionStore } from '../../store/scrollPositionStore';
 import { useSessionStore } from '../../store/sessionStore';
 import type { ResultSet } from '../../types';
 import { type ColumnMeta, type GridViewMode, isNumericType, type RowData } from '../../types/grid';
@@ -388,23 +389,52 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     return () => observer.disconnect();
   }, [rowVirtualizer]);
 
-  // --- Reset scroll & UI state when switching query tabs ---
+  // --- Preserve scroll position per query when switching tabs ---
+  // UI state (sort/filter/selection) は per-tab 独立のためリセット維持。
+  // スクロール位置のみ前 queryId 単位で保存→復元 (Issue #366)。
+  const prevQueryIdRef = useRef<string | null>(null);
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally triggered by targetQueryId change
   useEffect(() => {
-    rowVirtualizer.scrollToOffset(0);
-    if (tableContainerRef.current) {
-      tableContainerRef.current.scrollLeft = 0;
+    const el = tableContainerRef.current;
+    const prev = prevQueryIdRef.current;
+    const { savePosition, getPosition } = useScrollPositionStore.getState();
+
+    // 1. 旧タブのスクロール位置を保存
+    if (prev && el) {
+      savePosition(prev, { top: el.scrollTop, left: el.scrollLeft });
     }
-    // Re-measure after paint to handle WebView2 layout delay
+    // 2. measure() 後に復元 (仮想化総サイズ未計算時は scrollToOffset が clamp されるため)
+    const saved = targetQueryId ? getPosition(targetQueryId) : undefined;
     requestAnimationFrame(() => {
       rowVirtualizer.measure();
+      if (saved) {
+        rowVirtualizer.scrollToOffset(saved.top);
+        if (el) el.scrollLeft = saved.left;
+      } else {
+        rowVirtualizer.scrollToOffset(0);
+        if (el) el.scrollLeft = 0;
+      }
     });
     resetSelection();
     setSorting([]);
     setColumnFilters([]);
     setShowColumnFilters(false);
     setActiveResultIndex(0);
+    prevQueryIdRef.current = targetQueryId;
   }, [targetQueryId]);
+
+  // --- Save scroll position on unmount (tab switched to non-grid view) ---
+  useEffect(() => {
+    return () => {
+      const el = tableContainerRef.current;
+      const qid = prevQueryIdRef.current;
+      if (qid && el) {
+        useScrollPositionStore
+          .getState()
+          .savePosition(qid, { top: el.scrollTop, left: el.scrollLeft });
+      }
+    };
+  }, []);
 
   // --- Infinite scroll: fetch more rows when nearing bottom ---
   useEffect(() => {

--- a/frontend/src/store/scrollPositionStore.ts
+++ b/frontend/src/store/scrollPositionStore.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+/**
+ * Preserves grid scroll position per queryId across tab switches.
+ * Not persisted (session-only) — cleared on app restart.
+ */
+export interface ScrollPosition {
+  top: number;
+  left: number;
+}
+
+interface ScrollPositionState {
+  positions: Record<string, ScrollPosition>;
+  savePosition: (queryId: string, pos: ScrollPosition) => void;
+  getPosition: (queryId: string) => ScrollPosition | undefined;
+  clearPosition: (queryId: string) => void;
+}
+
+export const useScrollPositionStore = create<ScrollPositionState>((set, get) => ({
+  positions: {},
+
+  savePosition: (queryId, pos) => {
+    set((state) => ({ positions: { ...state.positions, [queryId]: pos } }));
+  },
+
+  getPosition: (queryId) => get().positions[queryId],
+
+  clearPosition: (queryId) => {
+    set((state) => {
+      if (!(queryId in state.positions)) return state;
+      const { [queryId]: _removed, ...rest } = state.positions;
+      return { positions: rest };
+    });
+  },
+}));

--- a/frontend/src/tests/stores/scrollPositionStore.test.ts
+++ b/frontend/src/tests/stores/scrollPositionStore.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useScrollPositionStore } from '../../store/scrollPositionStore';
+
+describe('scrollPositionStore', () => {
+  beforeEach(() => {
+    useScrollPositionStore.setState({ positions: {} });
+  });
+
+  it('savePosition で保存した値が getPosition で取得できる', () => {
+    useScrollPositionStore.getState().savePosition('q1', { top: 120, left: 40 });
+    expect(useScrollPositionStore.getState().getPosition('q1')).toEqual({ top: 120, left: 40 });
+  });
+
+  it('未保存の queryId は undefined を返す', () => {
+    expect(useScrollPositionStore.getState().getPosition('unknown')).toBeUndefined();
+  });
+
+  it('同一 queryId の再保存で上書きされる', () => {
+    const { savePosition, getPosition } = useScrollPositionStore.getState();
+    savePosition('q1', { top: 10, left: 0 });
+    savePosition('q1', { top: 300, left: 50 });
+    expect(getPosition('q1')).toEqual({ top: 300, left: 50 });
+  });
+
+  it('複数 queryId が独立して保持される', () => {
+    const { savePosition, getPosition } = useScrollPositionStore.getState();
+    savePosition('q1', { top: 10, left: 0 });
+    savePosition('q2', { top: 999, left: 77 });
+    expect(getPosition('q1')).toEqual({ top: 10, left: 0 });
+    expect(getPosition('q2')).toEqual({ top: 999, left: 77 });
+  });
+
+  it('clearPosition で特定 queryId のみ削除される', () => {
+    const { savePosition, getPosition, clearPosition } = useScrollPositionStore.getState();
+    savePosition('q1', { top: 10, left: 0 });
+    savePosition('q2', { top: 999, left: 77 });
+    clearPosition('q1');
+    expect(getPosition('q1')).toBeUndefined();
+    expect(getPosition('q2')).toEqual({ top: 999, left: 77 });
+  });
+
+  it('未保存の queryId に対する clearPosition は冪等 (エラーにならない)', () => {
+    expect(() => useScrollPositionStore.getState().clearPosition('missing')).not.toThrow();
+  });
+});


### PR DESCRIPTION
ResultGrid が targetQueryId 変化時に `scrollToOffset(0) / scrollLeft = 0` で強制リセットしていたため、別タブから戻ってもスクロール位置が先頭に戻っていた (加えて SqlEditor タブ遷移時は ResultGrid 自体が unmount される)。

scrollPositionStore (軽量 Zustand、セッションのみ) を新設し、旧タブ離脱時に scrollTop/scrollLeft を save、新タブ復帰時に `getPosition` で復元。未保存時は従来どおり先頭。 `sort/filter/selection` のリセットは per-tab 独立設計として維持。

Closes #366