### PR TITLE
fix: 縦スクロール時の列幅変動を初期値で固定

### DIFF
--- a/frontend/e2e/grid-column-width.spec.ts
+++ b/frontend/e2e/grid-column-width.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Issue #368: 縦スクロールで列幅が変わる問題の再現 E2E テスト
+ *
+ * window.invoke を mock して 200 行のデータを返すように上書きし、
+ * grid 表示後に連続スクロールして列幅の変化を検出する。
+ */
+
+const ROW_COUNT = 200;
+
+function makeMockInvoke(): string {
+  return `
+    const rows = [];
+    for (let i = 0; i < ${ROW_COUNT}; i++) {
+      rows.push([String(i), 'name_' + i + (i % 10 === 0 ? '_long_suffix_to_trigger_auto_size' : ''), '2024-01-' + String((i % 28) + 1).padStart(2, '0') + ' 00:00:00']);
+    }
+    const mockResponses = {
+      connectAsync: { requestId: 'req-1' },
+      pollConnectAsync: { status: 'completed', connectionId: 'mock-conn' },
+      disconnect: {},
+      testConnection: { success: true, message: 'ok' },
+      executeQuery: {
+        columns: [
+          { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+          { name: 'name', type: 'nvarchar', size: 255, nullable: true, isPrimaryKey: false },
+          { name: 'created_at', type: 'datetime', size: 8, nullable: true, isPrimaryKey: false },
+        ],
+        rows: rows,
+        affectedRows: 0,
+        executionTimeMs: 15,
+        cached: false,
+      },
+      getDatabases: ['testdb'],
+      getSchemas: ['dbo'],
+      getTables: [{ schema: 'dbo', name: 'TestTable', type: 'TABLE' }],
+      getColumns: [
+        { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+        { name: 'name', type: 'nvarchar', size: 255, nullable: true, isPrimaryKey: false },
+        { name: 'created_at', type: 'datetime', size: 8, nullable: true, isPrimaryKey: false },
+      ],
+      getSettings: {},
+      writeFrontendLog: {},
+    };
+    window.invoke = async (requestStr) => {
+      const req = JSON.parse(requestStr);
+      const data = mockResponses[req.method];
+      if (data === undefined) {
+        return JSON.stringify({ success: false, error: 'no mock for ' + req.method });
+      }
+      return JSON.stringify({ success: true, data: data });
+    };
+  `;
+}
+
+test.describe('#368 列幅スクロール固定', () => {
+  test('200行スクロール中に <col> 幅が変化しないこと', async ({ page }) => {
+    await page.addInitScript(makeMockInvoke());
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // 診断のため、body の最初の table を探す (存在しなければスキップ)
+    const tableCount = await page.locator('table').count();
+    console.log(`[diag] table count on load: ${tableCount}`);
+
+    // 接続・クエリフロー: UI 操作依存のためここでは store 直接操作が必要になる。
+    // 現状は table が見えたときのみ測定する簡易版。
+    if (tableCount === 0) {
+      test.skip(true, '初期表示で table 無し (接続 UI 経由のセットアップが未実装)');
+      return;
+    }
+
+    const cols = page.locator('colgroup col');
+    const initialWidths = await cols.evaluateAll((els) =>
+      els.map((e) => (e as HTMLElement).getBoundingClientRect().width)
+    );
+    console.log('[diag] initial col widths:', initialWidths);
+
+    // スクロール操作
+    const container = page.locator('[class*="tableContainer"]').first();
+    await container.evaluate((el) => {
+      el.scrollTop = 500;
+    });
+    await page.waitForTimeout(200);
+
+    const afterWidths = await cols.evaluateAll((els) =>
+      els.map((e) => (e as HTMLElement).getBoundingClientRect().width)
+    );
+    console.log('[diag] after-scroll col widths:', afterWidths);
+
+    expect(afterWidths).toEqual(initialWidths);
+  });
+});

--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -1,6 +1,6 @@
 import { flexRender, type Row, type Table } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
-import { type MouseEvent, memo, type RefObject, useCallback } from 'react';
+import { type MouseEvent, memo, type RefObject, type UIEvent, useCallback } from 'react';
 import { type ColumnMeta, isSystemColumn, type RowData } from '../../types/grid';
 import type { ValidationError } from '../../utils/validation';
 import { ContextMenu } from '../common/ContextMenu';
@@ -57,6 +57,8 @@ interface GridTableProps {
   callbacks: GridTableCallbacks;
   /** Table name embedded in INSERT copy (sourceTable for data-view tabs, undefined for arbitrary SQL) */
   tableName?: string;
+  /** Scroll 位置保存のためのハンドラ (ResultGrid 側で store 更新) */
+  onScroll?: (e: UIEvent<HTMLDivElement>) => void;
 }
 
 /** Extract row/cell info from a bubbled event via data attributes */
@@ -85,6 +87,7 @@ function GridTableInner({
   selection,
   callbacks,
   tableName,
+  onScroll,
 }: GridTableProps) {
   const paddingTop = virtualRows.length > 0 ? (virtualRows[0]?.start ?? 0) : 0;
   const paddingBottom =
@@ -120,8 +123,26 @@ function GridTableInner({
       className={styles.tableContainer}
       tabIndex={-1}
       onMouseDown={onContainerMouseDown}
+      onScroll={onScroll}
     >
-      <table key={`table-${showLogicalNamesInGrid}`} className={styles.table}>
+      <table
+        key={`table-${showLogicalNamesInGrid}`}
+        className={styles.table}
+        style={{
+          // inline style で table-layout/width を強制 (#368)。
+          // CSS Modules scoping や specificity 由来の適用漏れを排除する。
+          tableLayout: 'fixed',
+          width:
+            table.getHeaderGroups()[0]?.headers.reduce((sum, h) => sum + h.getSize(), 0) ?? 'auto',
+        }}
+      >
+        {/* colgroup で列幅を明示的に固定 (#368)。table-layout: fixed の参照元として
+            最も信頼性が高く、virtualization の spacer <tr> の影響を受けない */}
+        <colgroup>
+          {table.getHeaderGroups()[0]?.headers.map((header) => (
+            <col key={header.id} style={{ width: header.getSize() }} />
+          ))}
+        </colgroup>
         <thead className={styles.thead}>
           {table.getHeaderGroups().map((headerGroup) => (
             <tr key={headerGroup.id} className={styles.theadRow}>

--- a/frontend/src/components/grid/ResultGrid.module.css
+++ b/frontend/src/components/grid/ResultGrid.module.css
@@ -347,6 +347,8 @@
 }
 
 .table {
+  /* fixed: 縦スクロール時の列幅変動を防ぐ (#368)。<th> の explicit width を尊重 */
+  table-layout: fixed;
   width: max-content;
   border-collapse: collapse;
   font-size: 14px;

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -9,7 +9,16 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  memo,
+  Suspense,
+  type UIEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useConnectionStore } from '../../store/connectionStore';
 import {
   useIsActiveDataView,
@@ -34,7 +43,6 @@ import { GridStatusBar } from './GridStatusBar';
 import { GridTable } from './GridTable';
 import { GridToolbar } from './GridToolbar';
 import { useClampedActiveIndex } from './hooks/useClampedActiveIndex';
-import { useColumnAutoSize } from './hooks/useColumnAutoSize';
 import { useElapsedTimer } from './hooks/useElapsedTimer';
 import { useGridEdit } from './hooks/useGridEdit';
 import { useGridKeyboard } from './hooks/useGridKeyboard';
@@ -188,9 +196,14 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     });
   }, [baseRowData]);
 
+  // dep は resultSet.columns に絞る: fetchMoreRows で resultSet identity が変わっても
+  // columns プロパティは `...currentResult` で維持されるため再生成不要。
+  // resultSet 全体を dep にすると columnDef が毎回新規生成され、TanStack Table の
+  // columnSizing との紐付けがスクロールのたびに揺らぎ、列幅変動に繋がる (#368)。
+  const resultSetColumns = resultSet?.columns;
   const columns = useMemo<ColumnDef<RowData>[]>(() => {
-    if (!resultSet) return [];
-    return resultSet.columns.map((col) => {
+    if (!resultSetColumns) return [];
+    return resultSetColumns.map((col) => {
       const isNumeric = isNumericType(col.type);
       const displayName = showLogicalNamesInGrid && col.comment ? col.comment : col.name;
       return {
@@ -202,23 +215,21 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
         meta: { type: col.type, align: isNumeric ? 'right' : 'left' },
       };
     });
-  }, [resultSet, showLogicalNamesInGrid]);
+  }, [resultSetColumns, showLogicalNamesInGrid]);
 
   const columnsMeta = useMemo<ColumnMeta[]>(() => {
-    if (!resultSet) return [];
-    return resultSet.columns.map((col) => ({
+    if (!resultSetColumns) return [];
+    return resultSetColumns.map((col) => ({
       name: col.name,
       comment: col.comment ?? '',
       type: col.type,
     }));
-  }, [resultSet]);
+  }, [resultSetColumns]);
 
   // --- Hooks ---
-  const { columnSizing, setColumnSizing } = useColumnAutoSize({
-    resultSet,
-    columns,
-    rowData: baseRowData,
-  });
+  // 列幅は columnDef.size=150 を初期値に固定。ユーザー drag resize 時のみ columnSizing に
+  // 値が入る。動的 auto-size は #368 の安定性問題のため廃止 (progress.md 参照)。
+  const [columnSizing, setColumnSizing] = useState<Record<string, number>>({});
 
   const {
     isEditMode,
@@ -393,35 +404,102 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   // UI state (sort/filter/selection) は per-tab 独立のためリセット維持。
   // スクロール位置のみ前 queryId 単位で保存→復元 (Issue #366)。
   const prevQueryIdRef = useRef<string | null>(null);
+  const scrollRestoredForQueryRef = useRef<string | null>(null);
+  // タブ切替の過渡期 (queryId 変化 → E2 復元完了まで) に発火する scroll event を
+  // ユーザー操作として扱わないための抑止フラグ。スクロール復元の programmatic scroll や
+  // DOM height 変化による clamp-scroll が store[newQueryId] に旧値を書き込むのを防ぐ。
+  const suppressScrollSaveRef = useRef(false);
+
+  // 1. タブ切替時: UI reset + scroll save 抑止 ON (scroll 保存は onScroll で常時実施)
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally triggered by targetQueryId change
   useEffect(() => {
-    const el = tableContainerRef.current;
-    const prev = prevQueryIdRef.current;
-    const { savePosition, getPosition } = useScrollPositionStore.getState();
-
-    // 1. 旧タブのスクロール位置を保存
-    if (prev && el) {
-      savePosition(prev, { top: el.scrollTop, left: el.scrollLeft });
-    }
-    // 2. measure() 後に復元 (仮想化総サイズ未計算時は scrollToOffset が clamp されるため)
-    const saved = targetQueryId ? getPosition(targetQueryId) : undefined;
-    requestAnimationFrame(() => {
-      rowVirtualizer.measure();
-      if (saved) {
-        rowVirtualizer.scrollToOffset(saved.top);
-        if (el) el.scrollLeft = saved.left;
-      } else {
-        rowVirtualizer.scrollToOffset(0);
-        if (el) el.scrollLeft = 0;
-      }
-    });
+    // 過渡期に発火する scroll event が新 queryId の store を汚染するのを防ぐ。
+    // E2 復元完了または rows 未到達で成立し得ない場合の timeout でクリア。
+    suppressScrollSaveRef.current = true;
     resetSelection();
     setSorting([]);
     setColumnFilters([]);
     setShowColumnFilters(false);
     setActiveResultIndex(0);
     prevQueryIdRef.current = targetQueryId;
+    scrollRestoredForQueryRef.current = null;
   }, [targetQueryId]);
+
+  // Scroll 位置を onScroll で常時保存 (closure で現在の targetQueryId に紐付け)。
+  // useEffect での保存は ref=null or 誤 queryId 問題を起こすため廃止。
+  // 復元中の programmatic scroll は scrollRestoredForQueryRef で識別し保存を抑止する必要はない
+  // (同値を保存するだけで害なし)。
+  const handleScroll = useCallback(
+    (e: UIEvent<HTMLDivElement>) => {
+      if (!targetQueryId) return;
+      if (suppressScrollSaveRef.current) return;
+      const el = e.currentTarget;
+      useScrollPositionStore
+        .getState()
+        .savePosition(targetQueryId, { top: el.scrollTop, left: el.scrollLeft });
+    },
+    [targetQueryId]
+  );
+
+  // 2. スクロール位置復元: rows が描画可能になり container が実サイズを持った後に 1 回だけ実施。
+  // WebView2 の flex layout 解決遅延で clientHeight が 0 のままになる可能性があるため、
+  // rAF ループでリトライ。clamp を避けるため scrollToOffset は totalSize 確定後に実行する。
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll restore is a one-shot per queryId
+  useEffect(() => {
+    if (!targetQueryId) return;
+    if (scrollRestoredForQueryRef.current === targetQueryId) return;
+    if (rows.length === 0) return;
+
+    let cancelled = false;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 30;
+
+    const tryRestore = () => {
+      if (cancelled) return;
+      if (scrollRestoredForQueryRef.current === targetQueryId) return;
+
+      const el = tableContainerRef.current;
+      if (!el || el.clientHeight === 0) {
+        if (attempts++ < MAX_ATTEMPTS) {
+          requestAnimationFrame(tryRestore);
+        } else {
+          // 限界超過 — 復元諦めて抑止解除 (user scroll 保存を許可)
+          suppressScrollSaveRef.current = false;
+        }
+        return;
+      }
+
+      rowVirtualizer.measure();
+      const totalSize = rowVirtualizer.getTotalSize();
+      if (totalSize === 0) {
+        if (attempts++ < MAX_ATTEMPTS) {
+          requestAnimationFrame(tryRestore);
+        } else {
+          suppressScrollSaveRef.current = false;
+        }
+        return;
+      }
+
+      const saved = useScrollPositionStore.getState().getPosition(targetQueryId);
+      if (saved) {
+        rowVirtualizer.scrollToOffset(saved.top);
+        el.scrollLeft = saved.left;
+      }
+      scrollRestoredForQueryRef.current = targetQueryId;
+      // 復元 programmatic scroll 完了後に抑止解除。scroll event は同期発火または
+      // 次 microtask で発火するため rAF 2 回待ち (1 回目: event 発火、2 回目: 解除)。
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          suppressScrollSaveRef.current = false;
+        });
+      });
+    };
+
+    requestAnimationFrame(tryRestore);
+    return () => {
+      cancelled = true;
+    };
+  }, [targetQueryId, rows.length]);
 
   // --- Save scroll position on unmount (tab switched to non-grid view) ---
   useEffect(() => {
@@ -668,6 +746,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
           selection={gridSelectionState}
           callbacks={gridCallbacks}
           tableName={currentQuery?.sourceTable}
+          onScroll={handleScroll}
         />
       ) : (
         <TransposeView

--- a/frontend/src/components/grid/hooks/useColumnAutoSize.ts
+++ b/frontend/src/components/grid/hooks/useColumnAutoSize.ts
@@ -1,5 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table';
-import { useEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import type { ResultSet } from '../../../types';
 import { isDateType, isNumericType, type RowData } from '../../../types/grid';
 import { log } from '../../../utils/logger';
@@ -21,15 +21,20 @@ function createMeasureContext(): CanvasRenderingContext2D | null {
   return canvas.getContext('2d');
 }
 
-let cachedContext: CanvasRenderingContext2D | null = null;
+// Cache a context per font string so we avoid re-assigning ctx.font on every
+// measureText call (10000+ calls per auto-size; font re-set is measurable).
+const contextByFont: Record<string, CanvasRenderingContext2D> = {};
 
 function measureTextWidth(text: string, font: string): number {
-  if (!cachedContext) {
-    cachedContext = createMeasureContext();
+  let ctx = contextByFont[font];
+  if (!ctx) {
+    const created = createMeasureContext();
+    if (!created) return 0;
+    created.font = font;
+    contextByFont[font] = created;
+    ctx = created;
   }
-  if (!cachedContext) return 0;
-  cachedContext.font = font;
-  return cachedContext.measureText(text).width;
+  return ctx.measureText(text).width;
 }
 
 interface ColumnSizeConfig {
@@ -116,8 +121,10 @@ export function useColumnAutoSize({
   columnsRef.current = columns;
   rowDataRef.current = rowData;
 
-  // Auto-size only when column structure changes (new query result)
-  useEffect(() => {
+  // Auto-size only when column structure changes (new query result).
+  // useLayoutEffect: 初回 paint 前に計算を完了させ、default (size: 150) で一瞬表示されてから
+  // auto-size 値へ切り替わる「スクロール時の列幅変化」に見える flash を防ぐ (#368)
+  useLayoutEffect(() => {
     if (!resultSet || rowDataRef.current.length === 0) return;
 
     const columnsKey = getColumnsKey(resultSet);

--- a/frontend/src/tests/grid/ResultGrid.scrollPersistence.test.tsx
+++ b/frontend/src/tests/grid/ResultGrid.scrollPersistence.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render } from '@testing-library/react';
+import { type UIEvent, useCallback } from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useScrollPositionStore } from '../../store/scrollPositionStore';
+
+/**
+ * ResultGrid の scroll 位置保存/復元ロジックの不変条件テスト。
+ *
+ * ResultGrid 本体は useQueryStore/useConnectionStore 等の多数の依存があり
+ * jsdom でフルレンダリングは過大コスト。ここでは **バグ再発の検出力** に焦点を絞り、
+ * onScroll closure で現在の queryId に保存される挙動を再現ハーネスで直接検証する。
+ *
+ * 検出対象:
+ * - Bug 1: タブ切替時 ref=null で save されない (onScroll 方式なら scroll 発生時点で保存済)
+ * - Bug 2: 戻り時 prev タブに現タブ scroll 値を誤保存 (onScroll は closure で currentId 使用)
+ */
+
+interface HarnessProps {
+  queryId: string;
+}
+
+// 本番の ResultGrid 内の handleScroll と同じ形を再現。
+// closure で現在の queryId に紐付けて store に保存する。
+function Harness({ queryId }: HarnessProps) {
+  const handleScroll = useCallback(
+    (e: UIEvent<HTMLDivElement>) => {
+      if (!queryId) return;
+      const el = e.currentTarget;
+      useScrollPositionStore
+        .getState()
+        .savePosition(queryId, { top: el.scrollTop, left: el.scrollLeft });
+    },
+    [queryId]
+  );
+  return (
+    <div
+      data-testid="scroll-container"
+      onScroll={handleScroll}
+      style={{ height: 200, overflow: 'auto' }}
+    >
+      <div style={{ height: 5000 }} />
+    </div>
+  );
+}
+
+describe('ResultGrid scroll 永続化 (onScroll closure 不変条件)', () => {
+  beforeEach(() => {
+    useScrollPositionStore.setState({ positions: {} });
+  });
+
+  it('scroll すると現在の queryId に top/left が保存される', () => {
+    const { getByTestId } = render(<Harness queryId="q1" />);
+    const el = getByTestId('scroll-container');
+
+    // jsdom は scrollTop setter を反映するが layout 計算しないので fireEvent で直接 event 発火。
+    Object.defineProperty(el, 'scrollTop', { value: 7247, writable: true });
+    Object.defineProperty(el, 'scrollLeft', { value: 120, writable: true });
+    fireEvent.scroll(el);
+
+    expect(useScrollPositionStore.getState().getPosition('q1')).toEqual({
+      top: 7247,
+      left: 120,
+    });
+  });
+
+  it('queryId が変わった後の scroll は新しい queryId に保存される (旧 queryId は上書きされない)', () => {
+    const { getByTestId, rerender } = render(<Harness queryId="q1" />);
+    const el = getByTestId('scroll-container');
+
+    // q1 で scroll 7247 保存
+    Object.defineProperty(el, 'scrollTop', { value: 7247, writable: true });
+    Object.defineProperty(el, 'scrollLeft', { value: 0, writable: true });
+    fireEvent.scroll(el);
+    expect(useScrollPositionStore.getState().getPosition('q1')).toEqual({ top: 7247, left: 0 });
+
+    // props 変化で q2 に切替 (ResultGrid 本体での queryId 変化を模倣)
+    rerender(<Harness queryId="q2" />);
+
+    // q2 で scroll 500 保存
+    Object.defineProperty(el, 'scrollTop', { value: 500, writable: true });
+    Object.defineProperty(el, 'scrollLeft', { value: 0, writable: true });
+    fireEvent.scroll(el);
+
+    // Bug 2 回帰検知: q1 には q2 の scroll (500) が**書き込まれていない**こと
+    expect(useScrollPositionStore.getState().getPosition('q1')).toEqual({ top: 7247, left: 0 });
+    expect(useScrollPositionStore.getState().getPosition('q2')).toEqual({ top: 500, left: 0 });
+  });
+
+  it('queryId=null/undefined では保存しない', () => {
+    const { getByTestId } = render(<Harness queryId="" />);
+    const el = getByTestId('scroll-container');
+
+    Object.defineProperty(el, 'scrollTop', { value: 1000, writable: true });
+    fireEvent.scroll(el);
+
+    expect(useScrollPositionStore.getState().positions).toEqual({});
+  });
+
+  it('同一 queryId で複数回 scroll すると最新値で上書きされる', () => {
+    const { getByTestId } = render(<Harness queryId="q1" />);
+    const el = getByTestId('scroll-container');
+
+    Object.defineProperty(el, 'scrollTop', { value: 100, writable: true });
+    fireEvent.scroll(el);
+    Object.defineProperty(el, 'scrollTop', { value: 500, writable: true });
+    fireEvent.scroll(el);
+    Object.defineProperty(el, 'scrollTop', { value: 2000, writable: true });
+    fireEvent.scroll(el);
+
+    expect(useScrollPositionStore.getState().getPosition('q1')).toMatchObject({ top: 2000 });
+  });
+
+  it('queryId A→B→A の往復で A の値が保持される (Bug 1/2 両方の回帰検知)', () => {
+    const { getByTestId, rerender } = render(<Harness queryId="A" />);
+    const el = getByTestId('scroll-container');
+
+    // A で 7247 保存
+    Object.defineProperty(el, 'scrollTop', { value: 7247, writable: true });
+    Object.defineProperty(el, 'scrollLeft', { value: 0, writable: true });
+    fireEvent.scroll(el);
+
+    // A → B 切替 (B ではユーザー scroll 発生せず)
+    rerender(<Harness queryId="B" />);
+
+    // B → A 戻り
+    rerender(<Harness queryId="A" />);
+
+    // A の保存値が維持されている (復元側の store 値読み出しの前提)
+    expect(useScrollPositionStore.getState().getPosition('A')).toEqual({ top: 7247, left: 0 });
+  });
+});
+
+/**
+ * Bug 3 回帰検知: タブ切替過渡期の programmatic scroll が新 queryId を汚染しない
+ * ことを検証。実コードでは suppressScrollSaveRef で抑止される。
+ */
+interface GuardedHarnessProps {
+  queryId: string;
+  /** true の間は scroll event を無視 (本番の suppressScrollSaveRef を模倣) */
+  suppress: boolean;
+}
+
+function GuardedHarness({ queryId, suppress }: GuardedHarnessProps) {
+  const handleScroll = useCallback(
+    (e: UIEvent<HTMLDivElement>) => {
+      if (!queryId) return;
+      if (suppress) return;
+      const el = e.currentTarget;
+      useScrollPositionStore
+        .getState()
+        .savePosition(queryId, { top: el.scrollTop, left: el.scrollLeft });
+    },
+    [queryId, suppress]
+  );
+  return (
+    <div
+      data-testid="scroll-container"
+      onScroll={handleScroll}
+      style={{ height: 200, overflow: 'auto' }}
+    >
+      <div style={{ height: 5000 }} />
+    </div>
+  );
+}
+
+describe('Bug 3: タブ切替過渡期の programmatic scroll 抑止', () => {
+  beforeEach(() => {
+    useScrollPositionStore.setState({ positions: {} });
+  });
+
+  it('suppress=true の間に scroll event が発火しても store に書き込まれない', () => {
+    const { getByTestId, rerender } = render(<GuardedHarness queryId="A" suppress={false} />);
+    const el = getByTestId('scroll-container');
+
+    // A で scroll 23500 保存 (通常動作)
+    Object.defineProperty(el, 'scrollTop', { value: 23500, writable: true });
+    Object.defineProperty(el, 'scrollLeft', { value: 0, writable: true });
+    fireEvent.scroll(el);
+    expect(useScrollPositionStore.getState().getPosition('A')).toEqual({ top: 23500, left: 0 });
+
+    // B に切替 + suppress ON (過渡期を模倣)
+    rerender(<GuardedHarness queryId="B" suppress={true} />);
+
+    // 過渡期に programmatic scroll event が発火 (実本番では restore の副作用)
+    Object.defineProperty(el, 'scrollTop', { value: 23500, writable: true });
+    fireEvent.scroll(el);
+
+    // Bug 3 回帰検知: B に旧 scroll 値が誤保存されていない
+    expect(useScrollPositionStore.getState().getPosition('B')).toBeUndefined();
+  });
+
+  it('suppress 解除後はユーザー scroll が正常に保存される', () => {
+    const { getByTestId, rerender } = render(<GuardedHarness queryId="B" suppress={true} />);
+    const el = getByTestId('scroll-container');
+
+    // 過渡期の programmatic scroll (無視される)
+    Object.defineProperty(el, 'scrollTop', { value: 10000, writable: true });
+    fireEvent.scroll(el);
+    expect(useScrollPositionStore.getState().getPosition('B')).toBeUndefined();
+
+    // 抑止解除 (実本番では E2 復元完了後)
+    rerender(<GuardedHarness queryId="B" suppress={false} />);
+
+    // ユーザー scroll
+    Object.defineProperty(el, 'scrollTop', { value: 500, writable: true });
+    fireEvent.scroll(el);
+    expect(useScrollPositionStore.getState().getPosition('B')).toEqual({ top: 500, left: 0 });
+  });
+});

--- a/frontend/src/tests/grid/useColumnAutoSize.test.ts
+++ b/frontend/src/tests/grid/useColumnAutoSize.test.ts
@@ -1,0 +1,119 @@
+import type { ColumnDef } from '@tanstack/react-table';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useColumnAutoSize } from '../../components/grid/hooks/useColumnAutoSize';
+import type { ResultSet } from '../../types';
+import type { RowData } from '../../types/grid';
+
+function makeResultSet(cols: Array<{ name: string; type: string }>, rows: string[][]): ResultSet {
+  return {
+    columns: cols.map((c) => ({
+      name: c.name,
+      type: c.type,
+      size: 0,
+      nullable: true,
+      isPrimaryKey: false,
+    })),
+    rows,
+    affectedRows: 0,
+    executionTimeMs: 0,
+  };
+}
+
+function makeRowData(cols: string[], rows: string[][]): RowData[] {
+  return rows.map((row, i) => {
+    const obj: RowData = {
+      __rowIndex: String(i + 1),
+      __originalIndex: String(i),
+    };
+    for (let c = 0; c < cols.length; c++) {
+      obj[cols[c]] = row[c];
+    }
+    return obj;
+  });
+}
+
+function makeColumns(cols: string[]): ColumnDef<RowData>[] {
+  return cols.map((name) => ({
+    id: name,
+    header: name,
+    accessorKey: name,
+    size: 150,
+    minSize: 80,
+  }));
+}
+
+describe('useColumnAutoSize', () => {
+  it('初回 resultSet (rows あり) で columnSizing が計算される', () => {
+    const resultSet = makeResultSet([{ name: 'a', type: 'int' }], [['10'], ['2000000000']]);
+    const columns = makeColumns(['a']);
+    const rowData = makeRowData(['a'], [['10'], ['2000000000']]);
+
+    const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+    expect(result.current.columnSizing.a).toBeGreaterThan(0);
+  });
+
+  it('rows が空の resultSet では計算をスキップする', () => {
+    const resultSet = makeResultSet([{ name: 'a', type: 'int' }], []);
+    const columns = makeColumns(['a']);
+    const rowData: RowData[] = [];
+
+    const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+    expect(result.current.columnSizing).toEqual({});
+  });
+
+  it('同じ columnsKey (name:type) の resultSet 差替では columnSizing が再計算されない', () => {
+    const cols = [{ name: 'a', type: 'int' }];
+    const columns = makeColumns(['a']);
+    const initial = {
+      resultSet: makeResultSet(cols, [['1'], ['2']]),
+      columns,
+      rowData: makeRowData(['a'], [['1'], ['2']]),
+    };
+
+    const { result, rerender } = renderHook((props) => useColumnAutoSize(props), {
+      initialProps: initial,
+    });
+
+    const first = result.current.columnSizing;
+    expect(first.a).toBeGreaterThan(0);
+
+    // resultSet identity は変わるが name:type は同じ (infinite scroll 等を想定)
+    rerender({
+      resultSet: makeResultSet(cols, [['1'], ['2'], ['99999999']]),
+      columns,
+      rowData: makeRowData(['a'], [['1'], ['2'], ['99999999']]),
+    });
+
+    // ガードにより再計算されないため state identity が保持される
+    expect(result.current.columnSizing).toBe(first);
+  });
+
+  it('columnsKey (name:type) が変わると再計算される', () => {
+    const columnsA = makeColumns(['a']);
+    const columnsB = makeColumns(['b']);
+    const initial = {
+      resultSet: makeResultSet([{ name: 'a', type: 'int' }], [['1']]),
+      columns: columnsA,
+      rowData: makeRowData(['a'], [['1']]),
+    };
+
+    const { result, rerender } = renderHook((props) => useColumnAutoSize(props), {
+      initialProps: initial,
+    });
+
+    const first = result.current.columnSizing;
+    expect(first.a).toBeGreaterThan(0);
+
+    rerender({
+      resultSet: makeResultSet([{ name: 'b', type: 'varchar' }], [['hello']]),
+      columns: columnsB,
+      rowData: makeRowData(['b'], [['hello']]),
+    });
+
+    expect(result.current.columnSizing.b).toBeGreaterThan(0);
+    expect(result.current.columnSizing.a).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- table-layout: fixed + colgroup + inline width で virtualization 時の列幅再計算を防止
- タブ切替時のスクロール復元も修正 (onScroll closure + suppress flag で過渡期の programmatic scroll による新 queryId 汚染を回避)
- Bug 1/2/3 の回帰検知テストを追加 (scrollPersistence.test.tsx 7件)
