### PR TITLE
fix: 接続喪失時の危険な自動リバインドと既存タブ破壊を修正 (#372)

### DIFF
--- a/backend/database/connection_registry.cpp
+++ b/backend/database/connection_registry.cpp
@@ -16,7 +16,6 @@ ConnectionRegistry::~ConnectionRegistry() {
 std::string ConnectionRegistry::add(DriverPtr queryDriver, DriverPtr metadataDriver, DriverType driverType) {
     std::lock_guard lock(m_mutex);
     auto id = std::format("conn_{}", m_counter.fetch_add(1));
-    auto now = std::chrono::steady_clock::now();
 
     m_connections[id] = ConnectionEntry{
         .queryDriver = std::move(queryDriver),
@@ -24,8 +23,6 @@ std::string ConnectionRegistry::add(DriverPtr queryDriver, DriverPtr metadataDri
         .driverType = driverType,
         .tunnel = nullptr,
         .params = {},
-        .lastUsed = now,
-        .createdAt = now,
     };
     return id;
 }
@@ -56,7 +53,6 @@ std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::ge
 
     auto it = m_connections.find(id);
     if (it != m_connections.end()) {
-        it->second.lastUsed = std::chrono::steady_clock::now();
         return it->second.queryDriver;
     }
     return std::unexpected(std::format("Connection '{}' not found", id));
@@ -67,7 +63,6 @@ std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::ge
 
     auto it = m_connections.find(id);
     if (it != m_connections.end()) {
-        it->second.lastUsed = std::chrono::steady_clock::now();
         return it->second.metadataDriver;
     }
     return std::unexpected(std::format("Connection '{}' not found", id));
@@ -75,44 +70,6 @@ std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::ge
 
 std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::get(std::string_view id) {
     return getQueryDriver(id);
-}
-
-std::expected<ConnectionRegistry::DriverPtr, std::string> ConnectionRegistry::getQueryDriverChecked(std::string_view id) {
-    std::lock_guard lock(m_mutex);
-
-    auto it = m_connections.find(id);
-    if (it == m_connections.end()) {
-        return std::unexpected(std::format("Connection '{}' not found", id));
-    }
-
-    auto& entry = it->second;
-    if (!entry.queryDriver || !entry.queryDriver->isConnected()) {
-        log<LogLevel::WARNING>(std::format("[DB] Health check failed for connection '{}': not connected", id));
-        // Disconnect metadata driver too
-        if (entry.metadataDriver && entry.metadataDriver->isConnected()) {
-            entry.metadataDriver->disconnect();
-        }
-        m_connections.erase(it);
-        return std::unexpected(std::format("Connection '{}' is no longer active", id));
-    }
-
-    // Lightweight health check: SELECT 1
-    try {
-        [[maybe_unused]] auto _ = entry.queryDriver->execute("SELECT 1");
-    } catch (const std::exception& e) {
-        log<LogLevel::WARNING>(std::format("[DB] Health check failed for connection '{}': {}", id, e.what()));
-        if (entry.queryDriver->isConnected()) {
-            entry.queryDriver->disconnect();
-        }
-        if (entry.metadataDriver && entry.metadataDriver->isConnected()) {
-            entry.metadataDriver->disconnect();
-        }
-        m_connections.erase(it);
-        return std::unexpected(std::format("Connection '{}' health check failed: {}", id, e.what()));
-    }
-
-    entry.lastUsed = std::chrono::steady_clock::now();
-    return entry.queryDriver;
 }
 
 std::expected<DriverType, std::string> ConnectionRegistry::getDriverType(std::string_view id) const {
@@ -183,37 +140,6 @@ void ConnectionRegistry::clear() {
         }
     }
     m_connections.clear();
-}
-
-size_t ConnectionRegistry::evictIdleConnections(std::chrono::minutes maxIdleDuration) {
-    std::lock_guard lock(m_mutex);
-    if (m_connections.empty()) {
-        return 0;
-    }
-
-    auto now = std::chrono::steady_clock::now();
-    size_t evicted = 0;
-
-    std::erase_if(m_connections, [&](auto& pair) {
-        auto& entry = pair.second;
-        if ((now - entry.lastUsed) > maxIdleDuration) {
-            log<LogLevel::INFO>(std::format("[DB] Evicting idle connection '{}'", pair.first));
-            if (entry.queryDriver && entry.queryDriver->isConnected()) {
-                entry.queryDriver->disconnect();
-            }
-            if (entry.metadataDriver && entry.metadataDriver->isConnected()) {
-                entry.metadataDriver->disconnect();
-            }
-            if (entry.tunnel) {
-                entry.tunnel->disconnect();
-            }
-            ++evicted;
-            return true;
-        }
-        return false;
-    });
-
-    return evicted;
 }
 
 }  // namespace velocitydb

--- a/backend/database/connection_registry.h
+++ b/backend/database/connection_registry.h
@@ -6,7 +6,6 @@
 #include "driver_interface.h"
 
 #include <atomic>
-#include <chrono>
 #include <expected>
 #include <memory>
 #include <optional>
@@ -36,17 +35,14 @@ public:
     /// Remove a connection by ID (disconnects both query and metadata drivers)
     void remove(std::string_view id);
 
-    /// Get the query driver by ID (updates lastUsed timestamp)
+    /// Get the query driver by ID
     [[nodiscard]] std::expected<DriverPtr, std::string> getQueryDriver(std::string_view id);
 
-    /// Get the metadata driver by ID (updates lastUsed timestamp)
+    /// Get the metadata driver by ID
     [[nodiscard]] std::expected<DriverPtr, std::string> getMetadataDriver(std::string_view id);
 
     /// Get a connection by ID (alias for getQueryDriver, for backwards compatibility)
     [[nodiscard]] std::expected<DriverPtr, std::string> get(std::string_view id);
-
-    /// Get the query driver with health check (SELECT 1). Removes entry on failure.
-    [[nodiscard]] std::expected<DriverPtr, std::string> getQueryDriverChecked(std::string_view id);
 
     /// Get the driver type for a connection
     [[nodiscard]] std::expected<DriverType, std::string> getDriverType(std::string_view id) const;
@@ -72,9 +68,6 @@ public:
     /// Remove and close all connections
     void clear();
 
-    /// Evict connections idle longer than maxIdleDuration. Returns number evicted.
-    [[nodiscard]] size_t evictIdleConnections(std::chrono::minutes maxIdleDuration = std::chrono::minutes{30});
-
 private:
     struct ConnectionEntry {
         DriverPtr queryDriver;
@@ -82,8 +75,6 @@ private:
         DriverType driverType;
         std::unique_ptr<SshTunnel> tunnel;
         DatabaseConnectionParams params;
-        std::chrono::steady_clock::time_point lastUsed;
-        std::chrono::steady_clock::time_point createdAt;
     };
 
     mutable std::shared_mutex m_mutex;

--- a/backend/providers/connection_provider.cpp
+++ b/backend/providers/connection_provider.cpp
@@ -77,9 +77,6 @@ std::string ConnectionProvider::connectAsync(std::string_view params) {
         return JsonUtils::errorResponse(connectionParams.error());
     }
 
-    // Evict idle connections as side-effect
-    [[maybe_unused]] auto evicted = m_registry->evictIdleConnections();
-
     // Submit raw params — SSH + DB connect happens in background thread
     auto requestId = m_asyncExecutor->submitConnect(std::move(*connectionParams));
     return JsonUtils::successResponse(std::format(R"({{"requestId":"{}"}})", requestId));

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -43,25 +43,14 @@ function recoverStaleConnection(
   id: string,
   staleConnectionId: string
 ): void {
-  const activeConnId = useConnectionStore.getState().activeConnectionId;
-  const canRebind = !!activeConnId && activeConnId !== staleConnectionId;
-  if (canRebind) {
-    get().updateQueryConnection(id, activeConnId);
-    set((state) =>
-      failExecution(
-        state,
-        id,
-        `接続 ${staleConnectionId} は失われました。アクティブ接続 ${activeConnId} に再バインドしたので、もう一度実行してください。`
-      )
-    );
-    return;
-  }
+  // 別 DB への自動リバインドは誤爆リスクがあるため廃止 (#372)。
+  // 接続 ID を null にしてユーザーに明示的な再選択を促す。
   get().updateQueryConnection(id, null);
   set((state) =>
     failExecution(
       state,
       id,
-      `接続 ${staleConnectionId} は失われました。接続ツリーから接続を選択し直してください。`
+      `接続 ${staleConnectionId} が無効になりました。接続ツリーから接続を選択し直してください。`
     )
   );
 }

--- a/frontend/src/tests/stores/queryStore.test.ts
+++ b/frontend/src/tests/stores/queryStore.test.ts
@@ -175,13 +175,14 @@ describe('queryStore', () => {
       expect(executingQueryIds.has(queryId)).toBe(false);
     });
 
-    it('should rebind tab to active connection when backend reports stale connectionId', async () => {
+    it('stale エラーで activeConnectionId があってもリバインドせず null 化する', async () => {
       const { addQuery, updateQuery, executeQuery } = useQueryStore.getState();
 
       addQuery('conn_1');
       const queryId = useQueryStore.getState().queries[0].id;
       updateQuery(queryId, 'SELECT 1');
 
+      // 別 DB に誤爆しないよう、activeConnectionId があってもリバインドしない
       useConnectionStore.setState({ activeConnectionId: 'conn_5' });
 
       mockedBridge.executeAsyncQuery.mockRejectedValue(new Error('Connection not found: conn_1'));
@@ -189,12 +190,13 @@ describe('queryStore', () => {
       await executeQuery(queryId, 'conn_1');
 
       const state = useQueryStore.getState();
-      expect(state.queries[0].connectionId).toBe('conn_5');
-      expect(state.errors[queryId]).toContain('conn_5');
-      expect(state.errors[queryId]).toContain('再バインド');
+      expect(state.queries[0].connectionId).toBeNull();
+      expect(state.errors[queryId]).not.toContain('conn_5');
+      expect(state.errors[queryId]).not.toContain('再バインド');
+      expect(state.errors[queryId]).toContain('接続ツリーから');
     });
 
-    it('should clear tab connectionId when no active fallback is available', async () => {
+    it('stale エラーで activeConnectionId が無いとき null 化する', async () => {
       const { addQuery, updateQuery, executeQuery } = useQueryStore.getState();
 
       addQuery('conn_1');
@@ -209,7 +211,7 @@ describe('queryStore', () => {
 
       const state = useQueryStore.getState();
       expect(state.queries[0].connectionId).toBeNull();
-      expect(state.errors[queryId]).toContain('選択');
+      expect(state.errors[queryId]).toContain('接続ツリーから');
     });
   });
 


### PR DESCRIPTION
## Summary
issue #372 の「接続 conn_X は失われました。アクティブ接続 conn_Y に再バインドした」現象を解消する。

真因 2 点:
1. **既存タブ破壊** (L2): `connectAsync` 副作用で `evictIdleConnections(30min)` が発火し、アイドル中の他タブ接続を抹消していた
2. **危険な自動リバインド** (L1): stale 接続エラー時に `activeConnectionId` (UI 選択中の別 DB の可能性) へ自動リバインド → prod/dev 取り違えリスク

## Changes
- **L1** (072ed2d): `recoverStaleConnection` を常に `null` 化するよう簡素化。リバインドロジック完全廃止
- **L2** (e431545): `evictIdleConnections` 関数ごと削除 + 関連 dead code (`lastUsed`/`createdAt`/`getQueryDriverChecked`) 除去

## Why リバインド完全廃止
`activeConnectionId` は UI 選択中の別 DB の可能性がある。同 SQL を別 DB に飛ばすリスク (prod/dev 取り違え) は致命的なため、自動復旧より明示的な再接続をユーザーに要求する方針に変更。

## Why eviction 完全削除
`connectAsync` の副作用として 30 分アイドルの既存接続を抹消する設計自体が他タブ破壊の原因。YAGNI により関数ごと削除。

## L3 (透過 retry) 切り離し理由
backend テスト基盤 (`backend/tests/`) が未整備で `isConnectionLostError` の SQLSTATE 網羅性や retry 配線の振る舞いを検証不可。無テストでの新機能追加は回帰保護ゼロのため別 PR に分離。

次 PR:
1. `chore: setup Google Test infrastructure for backend`
2. `feat: transparent reconnect on connection loss (#372 Layer 3)`

## Test plan
- [x] backend build SUCCESS
- [x] biome + TypeScript + clang-format ALL PASS
- [x] frontend vitest queryStore 22/22
- [ ] マージ後、SSH 経由実環境で再発しないこと確認

Closes #372