### PR TITLE
fix: cross-DB参照を可視化しPostgresエラーに対処案内を追加

### DIFF
--- a/frontend/src/components/editor/SqlEditor.module.css
+++ b/frontend/src/components/editor/SqlEditor.module.css
@@ -1,6 +1,43 @@
 .container {
   height: 100%;
   width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.editorWrapper {
+  flex: 1;
+  min-height: 0;
+}
+
+.crossDbBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  background: var(--bg-subtle, #2a2d35);
+  border-bottom: 1px solid var(--border-color, #3a3d45);
+  color: var(--text-secondary, #c8c8c8);
+  flex-shrink: 0;
+}
+
+.crossDbIcon {
+  opacity: 0.8;
+}
+
+.crossDbLabel {
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
+}
+
+.crossDbName {
+  padding: 1px 8px;
+  background: var(--accent-subtle, #3a4a5a);
+  border: 1px solid var(--accent-border, #4a5a6a);
+  border-radius: 10px;
+  color: var(--accent-text, #a0c4e0);
+  font-family: var(--font-mono, monospace);
 }
 
 .empty {

--- a/frontend/src/components/editor/SqlEditor.tsx
+++ b/frontend/src/components/editor/SqlEditor.tsx
@@ -2,10 +2,12 @@ import loader from '@monaco-editor/loader';
 import Editor, { type OnMount } from '@monaco-editor/react';
 import type * as Monaco from 'monaco-editor';
 import * as monaco from 'monaco-editor';
-import { type MutableRefObject, useCallback, useEffect, useRef } from 'react';
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useKeyboardHandler } from '../../hooks/useKeyboardHandler';
+import { useConnections } from '../../store/connectionStore';
 import { useLintDiagnostics, useQueryStore, useRuntimeDiagnostics } from '../../store/queryStore';
 import { useSchemaStore } from '../../store/schemaStore';
+import { extractReferencedDatabases } from '../../utils/crossDbDetector';
 import {
   clearSqlMarkers,
   type SqlMarkerInput,
@@ -46,6 +48,12 @@ export function SqlEditor() {
   const { queries, activeQueryId, updateQuery } = useQueryStore();
   const activeQuery = queries.find((q) => q.id === activeQueryId);
   const queryConnectionId = activeQuery?.connectionId ?? null;
+  const connections = useConnections();
+  const currentDb = connections.find((c) => c.id === queryConnectionId)?.database ?? '';
+  const referencedDatabases = useMemo(
+    () => extractReferencedDatabases(activeQuery?.content ?? '', currentDb),
+    [activeQuery?.content, currentDb]
+  );
   const lintDiagnostics = useLintDiagnostics(activeQueryId);
   const runtimeDiagnostics = useRuntimeDiagnostics(activeQueryId);
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
@@ -232,29 +240,44 @@ export function SqlEditor() {
 
   return (
     <div className={styles.container}>
-      <Editor
-        height="100%"
-        language="sql"
-        theme="vs-dark"
-        value={activeQuery.content}
-        onChange={handleEditorChange}
-        onMount={handleEditorDidMount}
-        options={{
-          minimap: { enabled: false },
-          fontSize: 14,
-          lineNumbers: 'on',
-          scrollBeyondLastLine: false,
-          automaticLayout: true,
-          tabSize: 4,
-          wordWrap: 'on',
-          renderLineHighlight: 'line',
-          matchBrackets: 'always',
-          folding: true,
-          suggestOnTriggerCharacters: true,
-          // .horizontalResizer の margin: -4px 食い込みを相殺 + 視認性余裕 4px
-          padding: { bottom: 8 },
-        }}
-      />
+      {referencedDatabases.length > 0 && (
+        <div className={styles.crossDbBar} data-testid="cross-db-bar">
+          <span className={styles.crossDbIcon} aria-hidden="true">
+            🔗
+          </span>
+          <span className={styles.crossDbLabel}>cross-DB:</span>
+          {referencedDatabases.map((db) => (
+            <span key={db} className={styles.crossDbName}>
+              {db}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className={styles.editorWrapper}>
+        <Editor
+          height="100%"
+          language="sql"
+          theme="vs-dark"
+          value={activeQuery.content}
+          onChange={handleEditorChange}
+          onMount={handleEditorDidMount}
+          options={{
+            minimap: { enabled: false },
+            fontSize: 14,
+            lineNumbers: 'on',
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            tabSize: 4,
+            wordWrap: 'on',
+            renderLineHighlight: 'line',
+            matchBrackets: 'always',
+            folding: true,
+            suggestOnTriggerCharacters: true,
+            // .horizontalResizer の margin: -4px 食い込みを相殺 + 視認性余裕 4px
+            padding: { bottom: 8 },
+          }}
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -234,6 +234,9 @@ export function createExecuteSlice(
 
       // 行情報が取れた場合のみruntime markerセット (owner: runtime)。failExecution と1回にまとめる
       const parsedErr = parseErrorMessage(errorMessage);
+      const displayMessage = parsedErr.hint
+        ? `${errorMessage}\n\n💡 ${parsedErr.hint}`
+        : errorMessage;
       const runtimeMarker: SqlMarkerInput | null =
         parsedErr.line !== undefined
           ? {
@@ -243,7 +246,7 @@ export function createExecuteSlice(
             }
           : null;
       set((state) => ({
-        ...failExecution(state, id, errorMessage),
+        ...failExecution(state, id, displayMessage),
         ...(runtimeMarker && {
           runtimeDiagnostics: { ...state.runtimeDiagnostics, [id]: [runtimeMarker] },
         }),

--- a/frontend/src/tests/utils/crossDbDetector.test.ts
+++ b/frontend/src/tests/utils/crossDbDetector.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { extractReferencedDatabases } from '../../utils/crossDbDetector';
+
+describe('extractReferencedDatabases', () => {
+  it('空SQLでは空配列を返す', () => {
+    expect(extractReferencedDatabases('', 'db1')).toEqual([]);
+    expect(extractReferencedDatabases('   \n  ', 'db1')).toEqual([]);
+  });
+
+  it('3-part nameなしなら空配列', () => {
+    expect(extractReferencedDatabases('SELECT * FROM dbo.Users', 'db1')).toEqual([]);
+    expect(extractReferencedDatabases('SELECT * FROM Users', 'db1')).toEqual([]);
+  });
+
+  it('接続中DBと同じ3-part nameは除外', () => {
+    expect(extractReferencedDatabases('SELECT * FROM db1.dbo.T1', 'db1')).toEqual([]);
+  });
+
+  it('接続中DBと異なる3-part nameを抽出', () => {
+    expect(extractReferencedDatabases('SELECT * FROM db2.dbo.T1', 'db1')).toEqual(['db2']);
+  });
+
+  it('JOIN 内の複数cross-DB参照を抽出', () => {
+    const sql = 'SELECT * FROM db1.dbo.T1 JOIN db2.dbo.T2 ON T1.id = T2.id';
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual(['db2']);
+  });
+
+  it('3つ以上のDB参照を順序保持で抽出', () => {
+    const sql = 'SELECT * FROM db1.s.a JOIN db2.s.b JOIN db3.s.c';
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual(['db2', 'db3']);
+  });
+
+  it('重複は1回だけ', () => {
+    const sql = 'SELECT * FROM db2.s.a JOIN db2.s.b ON db2.s.a.id = db2.s.b.id';
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual(['db2']);
+  });
+
+  it('角括弧識別子 [db]', () => {
+    expect(extractReferencedDatabases('SELECT * FROM [db2].[dbo].[T1]', 'db1')).toEqual(['db2']);
+  });
+
+  it('バッククォート識別子', () => {
+    expect(extractReferencedDatabases('SELECT * FROM `db2`.`dbo`.`T1`', 'db1')).toEqual(['db2']);
+  });
+
+  it('ダブルクォート識別子', () => {
+    expect(extractReferencedDatabases('SELECT * FROM "db2"."dbo"."T1"', 'db1')).toEqual(['db2']);
+  });
+
+  it('行コメント内の3-part nameは無視', () => {
+    const sql = '-- SELECT * FROM db2.dbo.T1\nSELECT 1';
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual([]);
+  });
+
+  it('ブロックコメント内の3-part nameは無視', () => {
+    const sql = '/* SELECT * FROM db2.dbo.T1 */ SELECT 1';
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual([]);
+  });
+
+  it('文字列リテラル内の3-part nameは無視', () => {
+    const sql = "SELECT 'db2.dbo.T1' AS label FROM Users";
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual([]);
+  });
+
+  it('接続DB比較は大文字小文字を区別しない', () => {
+    expect(extractReferencedDatabases('SELECT * FROM DB1.dbo.T1', 'db1')).toEqual([]);
+    expect(extractReferencedDatabases('SELECT * FROM db1.dbo.T1', 'DB1')).toEqual([]);
+  });
+
+  it('currentDbが空文字なら全ての参照DBを返す', () => {
+    expect(extractReferencedDatabases('SELECT * FROM db1.dbo.T', '')).toEqual(['db1']);
+  });
+
+  it('2-part name (db.table) は抽出対象外', () => {
+    expect(extractReferencedDatabases('SELECT * FROM db2.T1', 'db1')).toEqual([]);
+  });
+
+  it('抽出結果は元の綴りを保持', () => {
+    const sql = 'SELECT * FROM MyDB.dbo.T1';
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual(['MyDB']);
+  });
+
+  it('角括弧内にスペース含むDB名', () => {
+    const sql = 'SELECT * FROM [My Database].[dbo].[T1]';
+    expect(extractReferencedDatabases(sql, 'db1')).toEqual(['My Database']);
+  });
+
+  it('角括弧内のDB名が接続DBと一致すれば除外', () => {
+    const sql = 'SELECT * FROM [My Database].[dbo].[T1]';
+    expect(extractReferencedDatabases(sql, 'My Database')).toEqual([]);
+  });
+});

--- a/frontend/src/tests/utils/errorParser.test.ts
+++ b/frontend/src/tests/utils/errorParser.test.ts
@@ -96,4 +96,29 @@ describe('parseErrorMessage', () => {
       expect(result.detail).toBe('');
     });
   });
+
+  describe('cross-DB ヒント (PostgreSQL)', () => {
+    it('cross-database references not implemented エラーに hint を付与', () => {
+      const raw = 'ERROR:  cross-database references are not implemented: "db2.public.t"';
+      const result = parseErrorMessage(raw);
+      expect(result.summary).toBe('cross-database references are not implemented: "db2.public.t"');
+      expect(result.hint).toBeDefined();
+      expect(result.hint).toMatch(/postgres_fdw|dblink/);
+    });
+
+    it('hint は大文字小文字を区別せずマッチ', () => {
+      const raw = 'ERROR:  Cross-Database References Are Not Implemented: foo';
+      expect(parseErrorMessage(raw).hint).toBeDefined();
+    });
+
+    it('通常エラーには hint を付与しない', () => {
+      const raw = 'ERROR:  relation "users" does not exist';
+      expect(parseErrorMessage(raw).hint).toBeUndefined();
+    });
+
+    it('SQL Server の cross-DB エラー文言には hint を付与しない (SQL Server は実行成功前提)', () => {
+      const raw = "Msg 208, Level 16, State 1, Line 1\nInvalid object name 'db2.dbo.t'.";
+      expect(parseErrorMessage(raw).hint).toBeUndefined();
+    });
+  });
 });

--- a/frontend/src/utils/crossDbDetector.ts
+++ b/frontend/src/utils/crossDbDetector.ts
@@ -1,0 +1,45 @@
+// 識別子: bare / [bracket] / `backtick` / "doubleQuote"
+const IDENT_SRC = '(?:[A-Za-z_][A-Za-z0-9_$]*|\\[[^\\]]+\\]|`[^`]+`|"[^"]+")';
+const THREE_PART_RE = new RegExp(
+  `(${IDENT_SRC})\\s*\\.\\s*${IDENT_SRC}\\s*\\.\\s*${IDENT_SRC}`,
+  'g'
+);
+
+// コメント/文字列リテラルを同幅スペースで置換 (位置保持は不要、単に誤検出回避)
+const STRIP_RE = /--[^\n]*|\/\*[\s\S]*?\*\/|'(?:''|[^'])*'/g;
+
+function unwrapIdentifier(ident: string): string {
+  const first = ident.charAt(0);
+  if (first === '[' && ident.endsWith(']')) return ident.slice(1, -1);
+  if (first === '`' && ident.endsWith('`')) return ident.slice(1, -1);
+  if (first === '"' && ident.endsWith('"')) return ident.slice(1, -1);
+  return ident;
+}
+
+/**
+ * SQL から 3-part name (db.schema.table) の DB 名を抽出する。
+ * 接続中の DB と一致するものは除外 (大文字小文字無視)。
+ *
+ * - コメント (-- / block) と文字列リテラルは無視
+ * - 識別子 quote: [bracket] / `backtick` / "doubleQuote" / bare 対応
+ * - 結果は順序保持・重複排除 (初出の綴りを保持)
+ */
+export function extractReferencedDatabases(sql: string, currentDb: string): string[] {
+  if (!sql.trim()) return [];
+
+  const stripped = sql.replace(STRIP_RE, ' ');
+  const currentLower = currentDb.toLowerCase();
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const match of stripped.matchAll(THREE_PART_RE)) {
+    const db = unwrapIdentifier(match[1]);
+    const dbLower = db.toLowerCase();
+    if (dbLower === currentLower && currentDb !== '') continue;
+    if (seen.has(dbLower)) continue;
+    seen.add(dbLower);
+    result.push(db);
+  }
+
+  return result;
+}

--- a/frontend/src/utils/errorParser.ts
+++ b/frontend/src/utils/errorParser.ts
@@ -2,6 +2,7 @@ export interface ParsedError {
   summary: string;
   detail: string;
   line?: number;
+  hint?: string;
 }
 
 const PSQL_ERROR_RE = /^(?:psql:[^\n]*?:\s*)?ERROR:\s+(.+)/;
@@ -10,6 +11,10 @@ const MYSQL_ERROR_RE = /^ERROR\s+\d+\s+\(\w+\):\s+(.+)/;
 
 const POSTGRES_LINE_RE = /\bLINE\s+(\d+)\s*:/;
 const MYSQL_AT_LINE_RE = /\bat\s+line\s+(\d+)\b/i;
+const POSTGRES_CROSS_DB_RE = /cross-database\s+references\s+are\s+not\s+implemented/i;
+
+const POSTGRES_CROSS_DB_HINT =
+  'PostgreSQL は別データベース間の参照を直接サポートしていません。postgres_fdw または dblink 拡張を使用してください。';
 
 export function parseErrorMessage(raw: string): ParsedError {
   if (!raw) return { summary: '', detail: '' };
@@ -19,10 +24,12 @@ export function parseErrorMessage(raw: string): ParsedError {
   const psqlMatch = firstLine.match(PSQL_ERROR_RE);
   if (psqlMatch) {
     const lineMatch = raw.match(POSTGRES_LINE_RE);
+    const hint = POSTGRES_CROSS_DB_RE.test(raw) ? POSTGRES_CROSS_DB_HINT : undefined;
     return {
       summary: psqlMatch[1].trim(),
       detail: raw,
       line: lineMatch ? Number(lineMatch[1]) : undefined,
+      hint,
     };
   }
 


### PR DESCRIPTION
## Summary

issue #367「別DBのテーブルとJOINするなど、DBまたぎのSQLを実行するときの案内がない」を解消する。

3-part name (`db.schema.table`) を含むSQLを検出し、エディタ上部に参照DBバッジを表示。PostgreSQL実行時の `cross-database references are not implemented` エラーには対処方法のヒントを付加。

## Why Option C (バッジのみ)

- SQL Server / MySQL は ODBC で 3-part name が native 通過 → backend 改修不要
- 事前警告なし、実行ブロックなし → ユーザー作業を阻害しない
- スキーマツリー拡張 (Option B) は遅延ロード設計が必要で段階分離

## Why Frontend-only 解析

- 入力中の即時反応 → IPC 往復コストを避ける
- 3-part name は正規表現で十分

## Why 2-part name 対象外

- SQL Server `schema.table` と MySQL `db.table` が同形で区別不能 → `false positive` 過多

## Why errorParser に hint フィールド

- Postgres は 3-part 構文が無効 → 実行時にのみ検出可能
- libpq エラー文言検出で hint 付加、既存の `summary/detail/line` 構造を壊さない

## Test plan

- [x] crossDbDetector 19/19 PASS
- [x] errorParser 14/14 PASS (+4 新規)
- [x] queryStore 22/22 PASS
- [x] full vitest 553/553 PASS (60 スイート)
- [x] biome check 変更7ファイル PASS
- [ ] マージ後、実環境で SQL Server cross-DB JOIN バッジ表示確認
- [ ] マージ後、実環境で Postgres cross-DB エラーに hint 表示確認

Closes #367