### PR TITLE
feat: INSERT文のVALUES句にカラム名インレイヒントを追加

### DIFF
--- a/frontend/src/components/editor/SqlEditor.tsx
+++ b/frontend/src/components/editor/SqlEditor.tsx
@@ -17,6 +17,7 @@ import {
 import { log } from '../../utils/logger';
 import { formatSQL } from '../../utils/sqlFormat';
 import { createCompletionProvider } from './completionProvider';
+import { createInlayHintProvider } from './inlayHintProvider';
 import './monacoEnvironment';
 import styles from './SqlEditor.module.css';
 
@@ -59,6 +60,7 @@ export function SqlEditor() {
   const editorRef = useRef<Parameters<OnMount>[0] | null>(null);
   const monacoRef = useRef<typeof Monaco | null>(null);
   const completionDisposableRef = useRef<Monaco.IDisposable | null>(null);
+  const inlayHintDisposableRef = useRef<Monaco.IDisposable | null>(null);
   const isFormattingRef = useRef(false);
   const lastEditorValueRef = useRef<string>('');
 
@@ -191,29 +193,48 @@ export function SqlEditor() {
         createCompletionProvider(queryConnectionId)
       );
 
+      // Register inlay hint provider for INSERT VALUES column names
+      if (inlayHintDisposableRef.current) {
+        inlayHintDisposableRef.current.dispose();
+      }
+      inlayHintDisposableRef.current = monaco.languages.registerInlayHintsProvider(
+        'sql',
+        createInlayHintProvider(queryConnectionId)
+      );
+
       // Preload schema if connected
       if (queryConnectionId) {
         useSchemaStore.getState().loadTables(queryConnectionId);
       }
 
-      log.debug('[SqlEditor] Editor mounted with completion provider');
+      log.debug('[SqlEditor] Editor mounted with completion + inlay hint providers');
     },
     [queryConnectionId]
   );
 
-  // 接続IDが変わったらcompletionProviderを再登録
+  // 接続IDが変わったらcompletion + inlay hint providerを再登録
+  // null遷移時も古いproviderをdispose (切断後に古いschema cacheを参照させない)
   useEffect(() => {
-    if (monacoRef.current && queryConnectionId) {
-      if (completionDisposableRef.current) {
-        completionDisposableRef.current.dispose();
-      }
-      completionDisposableRef.current = monacoRef.current.languages.registerCompletionItemProvider(
-        'sql',
-        createCompletionProvider(queryConnectionId)
-      );
-      useSchemaStore.getState().loadTables(queryConnectionId);
-      log.debug(`[SqlEditor] Completion provider updated for connection: ${queryConnectionId}`);
+    if (!monacoRef.current) return;
+    if (completionDisposableRef.current) {
+      completionDisposableRef.current.dispose();
+      completionDisposableRef.current = null;
     }
+    if (inlayHintDisposableRef.current) {
+      inlayHintDisposableRef.current.dispose();
+      inlayHintDisposableRef.current = null;
+    }
+    if (!queryConnectionId) return;
+    completionDisposableRef.current = monacoRef.current.languages.registerCompletionItemProvider(
+      'sql',
+      createCompletionProvider(queryConnectionId)
+    );
+    inlayHintDisposableRef.current = monacoRef.current.languages.registerInlayHintsProvider(
+      'sql',
+      createInlayHintProvider(queryConnectionId)
+    );
+    useSchemaStore.getState().loadTables(queryConnectionId);
+    log.debug(`[SqlEditor] Providers updated for connection: ${queryConnectionId}`);
   }, [queryConnectionId]);
 
   // sqruff lint + ODBC実行エラー(runtime)をMonaco markerに反映 (owner別に独立管理)
@@ -225,6 +246,9 @@ export function SqlEditor() {
     return () => {
       if (completionDisposableRef.current) {
         completionDisposableRef.current.dispose();
+      }
+      if (inlayHintDisposableRef.current) {
+        inlayHintDisposableRef.current.dispose();
       }
     };
   }, []);

--- a/frontend/src/components/editor/inlayHintProvider.ts
+++ b/frontend/src/components/editor/inlayHintProvider.ts
@@ -1,0 +1,63 @@
+import type * as Monaco from 'monaco-editor';
+import { languages as MonacoLanguages } from 'monaco-editor';
+import { useSchemaStore } from '../../store/schemaStore';
+import { extractInsertTargets } from '../../utils/insertHintExtractor';
+
+function emptyList(): Monaco.languages.InlayHintList {
+  return { hints: [], dispose: () => {} };
+}
+
+export function createInlayHintProvider(
+  connectionId: string | null
+): Monaco.languages.InlayHintsProvider {
+  return {
+    displayName: 'sqlInsertInlayHints',
+
+    provideInlayHints: async (
+      model: Monaco.editor.ITextModel,
+      _range: Monaco.Range,
+      token: Monaco.CancellationToken
+    ): Promise<Monaco.languages.InlayHintList> => {
+      if (!connectionId) return emptyList();
+
+      const sql = model.getValue();
+      const targets = extractInsertTargets(sql);
+      if (targets.length === 0) return emptyList();
+
+      const store = useSchemaStore.getState();
+      const needLoad = targets.filter(
+        (t) => t.columnNames === null && !store.getTableColumns(connectionId, t.tableName)
+      );
+      if (needLoad.length > 0) {
+        await Promise.all(needLoad.map((t) => store.loadColumns(connectionId, t.tableName)));
+      }
+      if (token.isCancellationRequested) return emptyList();
+
+      const hints: Monaco.languages.InlayHint[] = [];
+      for (const target of targets) {
+        const names =
+          target.columnNames ??
+          (useSchemaStore.getState().getTableColumns(connectionId, target.tableName) ?? []).map(
+            (c) => c.name
+          );
+        if (names.length === 0) continue;
+
+        for (const row of target.valueRows) {
+          for (let i = 0; i < row.length; i++) {
+            const name = names[i];
+            if (!name) continue;
+            const pos = model.getPositionAt(row[i].offset);
+            hints.push({
+              label: `${name}:`,
+              position: pos,
+              kind: MonacoLanguages.InlayHintKind.Parameter,
+              paddingRight: true,
+            });
+          }
+        }
+      }
+
+      return { hints, dispose: () => {} };
+    },
+  };
+}

--- a/frontend/src/tests/components/editor/inlayHintProvider.test.ts
+++ b/frontend/src/tests/components/editor/inlayHintProvider.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('monaco-editor', () => ({
+  languages: {
+    InlayHintKind: { Type: 1, Parameter: 2 },
+  },
+}));
+
+vi.mock('../../../api/bridge', () => ({
+  bridge: {
+    getColumns: vi.fn(),
+    getTables: vi.fn(),
+  },
+}));
+
+import type * as Monaco from 'monaco-editor';
+import { bridge } from '../../../api/bridge';
+import { createInlayHintProvider } from '../../../components/editor/inlayHintProvider';
+import { useSchemaStore } from '../../../store/schemaStore';
+import type { Column } from '../../../types';
+
+type MockModel = {
+  getValue: () => string;
+  getPositionAt: (offset: number) => Monaco.IPosition;
+};
+
+function makeModel(sql: string): Monaco.editor.ITextModel {
+  const model: MockModel = {
+    getValue: () => sql,
+    getPositionAt: (offset: number) => ({ lineNumber: 1, column: offset + 1 }),
+  };
+  return model as unknown as Monaco.editor.ITextModel;
+}
+
+function makeToken(cancelled = false): Monaco.CancellationToken {
+  return { isCancellationRequested: cancelled } as unknown as Monaco.CancellationToken;
+}
+
+const FAKE_RANGE = {} as Monaco.Range;
+
+function seedTable(connectionId: string, tableName: string, columns?: Column[]) {
+  useSchemaStore.setState({
+    schemas: new Map([
+      [
+        connectionId,
+        {
+          tables: [
+            {
+              name: tableName,
+              schema: 'dbo',
+              type: 'TABLE' as const,
+              columns,
+              columnsLoaded: columns !== undefined,
+            },
+          ],
+          tablesLoaded: true,
+          loadingTables: false,
+          loadingColumns: new Set<string>(),
+        },
+      ],
+    ]),
+  });
+}
+
+function seedTables(connectionId: string, tables: Array<{ name: string; columns?: Column[] }>) {
+  useSchemaStore.setState({
+    schemas: new Map([
+      [
+        connectionId,
+        {
+          tables: tables.map((t) => ({
+            name: t.name,
+            schema: 'dbo',
+            type: 'TABLE' as const,
+            columns: t.columns,
+            columnsLoaded: t.columns !== undefined,
+          })),
+          tablesLoaded: true,
+          loadingTables: false,
+          loadingColumns: new Set<string>(),
+        },
+      ],
+    ]),
+  });
+}
+
+function col(name: string, type = 'int'): Column {
+  return { name, type, size: 0, nullable: true, isPrimaryKey: false };
+}
+
+describe('createInlayHintProvider', () => {
+  beforeEach(() => {
+    useSchemaStore.setState({ schemas: new Map() });
+    vi.mocked(bridge.getColumns).mockReset();
+  });
+
+  describe('connectionId null', () => {
+    it('空リストを返す', async () => {
+      const provider = createInlayHintProvider(null);
+      const model = makeModel('INSERT INTO users VALUES (1, 2)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints).toEqual([]);
+    });
+  });
+
+  describe('明示カラムリスト', () => {
+    it('VALUES の各値に columnNames 順のラベルを付与', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO users (id, name, age) VALUES (1, 2, 3)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      const hints = result?.hints ?? [];
+      expect(hints).toHaveLength(3);
+      expect(hints[0].label).toBe('id:');
+      expect(hints[1].label).toBe('name:');
+      expect(hints[2].label).toBe('age:');
+    });
+
+    it('kind が InlayHintKind.Parameter (=2)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO t (a) VALUES (1)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints[0].kind).toBe(2);
+      expect(result?.hints[0].paddingRight).toBe(true);
+    });
+
+    it('値数 > カラム数: 余剰値にはヒント生成しない', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO t (a, b) VALUES (1, 2, 3, 4)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints).toHaveLength(2);
+      expect(result?.hints.map((h) => h.label)).toEqual(['a:', 'b:']);
+    });
+
+    it('カラム数 > 値数: 値数分のみ生成', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO t (a, b, c, d) VALUES (1, 2)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints).toHaveLength(2);
+      expect(result?.hints.map((h) => h.label)).toEqual(['a:', 'b:']);
+    });
+
+    it('複数行 VALUES: 全行にヒント生成', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO t (a, b) VALUES (1, 2), (3, 4), (5, 6)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints).toHaveLength(6);
+      expect(result?.hints.map((h) => h.label)).toEqual(['a:', 'b:', 'a:', 'b:', 'a:', 'b:']);
+    });
+  });
+
+  describe('暗黙カラムリスト (schemaStore 連携)', () => {
+    it('キャッシュ済みテーブル: カラム順でラベル生成', async () => {
+      seedTable('conn_1', 'users', [col('id'), col('name'), col('age')]);
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO users VALUES (1, 2, 3)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['id:', 'name:', 'age:']);
+      expect(vi.mocked(bridge.getColumns)).not.toHaveBeenCalled();
+    });
+
+    it('未ロード時: loadColumns を経由してヒント生成', async () => {
+      seedTable('conn_1', 'orders');
+      vi.mocked(bridge.getColumns).mockResolvedValue([col('order_id'), col('qty')]);
+
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO orders VALUES (1, 2)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+
+      expect(vi.mocked(bridge.getColumns)).toHaveBeenCalledWith('conn_1', 'orders');
+      expect(result?.hints.map((h) => h.label)).toEqual(['order_id:', 'qty:']);
+    });
+
+    it('schemaStore に該当テーブルなし: ヒント0件', async () => {
+      seedTable('conn_1', 'other_table', [col('id')]);
+      vi.mocked(bridge.getColumns).mockResolvedValue([]);
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO missing VALUES (1, 2)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints).toEqual([]);
+    });
+  });
+
+  describe('position 計算', () => {
+    it('各ヒントの position.column が値のoffset+1 (1-based)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const sql = 'INSERT INTO t (a, b, c) VALUES (1, 2, 3)';
+      const model = makeModel(sql);
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      const hints = result?.hints ?? [];
+      expect(hints[0].position.column).toBe(sql.indexOf('1') + 1);
+      expect(hints[1].position.column).toBe(sql.indexOf('2') + 1);
+      expect(hints[2].position.column).toBe(sql.indexOf('3') + 1);
+    });
+  });
+
+  describe('cancellation', () => {
+    it('loadColumns 完了後に cancellation 検出で空返却', async () => {
+      seedTable('conn_1', 't');
+      vi.mocked(bridge.getColumns).mockResolvedValue([col('a')]);
+
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('INSERT INTO t VALUES (1)');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken(true));
+      expect(result?.hints).toEqual([]);
+    });
+  });
+
+  describe('INSERT なし', () => {
+    it('SELECT文のみ: 空リスト', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('SELECT * FROM users');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints).toEqual([]);
+    });
+  });
+
+  describe('複数 INSERT 文', () => {
+    it('異なるテーブルへのINSERT: 各々のカラム名で生成', async () => {
+      seedTables('conn_1', [
+        { name: 'users', columns: [col('uid'), col('uname')] },
+        { name: 'orders', columns: [col('oid'), col('uid_fk')] },
+      ]);
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel(
+        'INSERT INTO users VALUES (1, 2); INSERT INTO orders VALUES (10, 20);'
+      );
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['uid:', 'uname:', 'oid:', 'uid_fk:']);
+    });
+  });
+});

--- a/frontend/src/tests/utils/insertHintExtractor.test.ts
+++ b/frontend/src/tests/utils/insertHintExtractor.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { extractInsertTargets } from '../../utils/insertHintExtractor';
+
+const slice = (sql: string, p: { offset: number; length: number }) =>
+  sql.slice(p.offset, p.offset + p.length);
+
+describe('extractInsertTargets', () => {
+  describe('基本的なINSERT構文', () => {
+    it('INSERT INTO t VALUES (1, 2, 3) - カラムリストなし', () => {
+      const targets = extractInsertTargets('INSERT INTO users VALUES (1, 2, 3)');
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('users');
+      expect(targets[0].columnNames).toBeNull();
+      expect(targets[0].valueRows).toHaveLength(1);
+      expect(targets[0].valueRows[0]).toHaveLength(3);
+    });
+
+    it('INSERT INTO t (c1, c2) VALUES (1, 2) - 明示的カラムリスト', () => {
+      const sql = 'INSERT INTO users (id, name) VALUES (1, 2)';
+      const targets = extractInsertTargets(sql);
+      expect(targets[0].tableName).toBe('users');
+      expect(targets[0].columnNames).toEqual(['id', 'name']);
+      expect(targets[0].valueRows[0]).toHaveLength(2);
+    });
+
+    it('値のoffset/lengthが元SQLの値と一致', () => {
+      const sql = 'INSERT INTO t VALUES (42, 100, 999)';
+      const row = extractInsertTargets(sql)[0].valueRows[0];
+      expect(slice(sql, row[0])).toBe('42');
+      expect(slice(sql, row[1])).toBe('100');
+      expect(slice(sql, row[2])).toBe('999');
+    });
+
+    it('大文字小文字を区別しない (insert into)', () => {
+      const targets = extractInsertTargets('insert into users values (1)');
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('users');
+    });
+  });
+
+  describe('識別子quote', () => {
+    it('[bracket] テーブル名', () => {
+      const targets = extractInsertTargets('INSERT INTO [my table] VALUES (1)');
+      expect(targets[0].tableName).toBe('my table');
+    });
+
+    it('`backtick` テーブル名', () => {
+      const targets = extractInsertTargets('INSERT INTO `my-table` VALUES (1)');
+      expect(targets[0].tableName).toBe('my-table');
+    });
+
+    it('"doubleQuote" テーブル名', () => {
+      const targets = extractInsertTargets('INSERT INTO "my.table" VALUES (1)');
+      expect(targets[0].tableName).toBe('my.table');
+    });
+
+    it('schema.table 形式', () => {
+      const targets = extractInsertTargets('INSERT INTO public.users VALUES (1)');
+      expect(targets[0].tableName).toBe('public.users');
+    });
+
+    it('カラム名のquote解除', () => {
+      const sql = 'INSERT INTO t ([col 1], `col-2`, "col.3") VALUES (1, 2, 3)';
+      const targets = extractInsertTargets(sql);
+      expect(targets[0].columnNames).toEqual(['col 1', 'col-2', 'col.3']);
+    });
+  });
+
+  describe('複数値行', () => {
+    it('INSERT ... VALUES (...), (...), (...) - 3行', () => {
+      const sql = 'INSERT INTO t VALUES (1, 2), (3, 4), (5, 6)';
+      const targets = extractInsertTargets(sql);
+      expect(targets).toHaveLength(1);
+      expect(targets[0].valueRows).toHaveLength(3);
+      expect(targets[0].valueRows[0]).toHaveLength(2);
+      expect(targets[0].valueRows[1]).toHaveLength(2);
+      expect(targets[0].valueRows[2]).toHaveLength(2);
+    });
+
+    it('複数行の各値 offset が元SQLの値位置を正確に指す', () => {
+      const sql = 'INSERT INTO t VALUES (11, 22), (33, 44)';
+      const rows = extractInsertTargets(sql)[0].valueRows;
+      expect(slice(sql, rows[0][0])).toBe('11');
+      expect(slice(sql, rows[0][1])).toBe('22');
+      expect(slice(sql, rows[1][0])).toBe('33');
+      expect(slice(sql, rows[1][1])).toBe('44');
+    });
+  });
+
+  describe('値内の特殊文字', () => {
+    it('文字列リテラル内のカンマは値区切りとみなさない', () => {
+      const sql = "INSERT INTO t VALUES ('a, b', 'c')";
+      const targets = extractInsertTargets(sql);
+      expect(targets[0].valueRows[0]).toHaveLength(2);
+    });
+
+    it("文字列リテラル値のoffset/lengthが '...' 全体を指す", () => {
+      const sql = "INSERT INTO t VALUES ('a, b', 'c')";
+      const [v1, v2] = extractInsertTargets(sql)[0].valueRows[0];
+      expect(slice(sql, v1)).toBe("'a, b'");
+      expect(slice(sql, v2)).toBe("'c'");
+    });
+
+    it('関数呼び出しのネスト括弧', () => {
+      const sql = 'INSERT INTO t VALUES (COALESCE(a, b), c)';
+      const targets = extractInsertTargets(sql);
+      expect(targets[0].valueRows[0]).toHaveLength(2);
+    });
+
+    it("エスケープされたシングルクォート '' は文字列内扱い", () => {
+      const sql = "INSERT INTO t VALUES ('it''s, ok', 1)";
+      const targets = extractInsertTargets(sql);
+      expect(targets[0].valueRows[0]).toHaveLength(2);
+    });
+  });
+
+  describe('複数INSERT文', () => {
+    it('2つのINSERT文を両方抽出', () => {
+      const sql = 'INSERT INTO t1 VALUES (1); INSERT INTO t2 VALUES (2);';
+      const targets = extractInsertTargets(sql);
+      expect(targets).toHaveLength(2);
+      expect(targets[0].tableName).toBe('t1');
+      expect(targets[1].tableName).toBe('t2');
+    });
+  });
+
+  describe('コメント', () => {
+    it('行コメント内のINSERTは無視', () => {
+      const sql = '-- INSERT INTO fake VALUES (1)\nINSERT INTO real VALUES (2)';
+      const targets = extractInsertTargets(sql);
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('real');
+    });
+
+    it('ブロックコメント内のINSERTは無視', () => {
+      const sql = '/* INSERT INTO fake VALUES (1) */ INSERT INTO real VALUES (2)';
+      const targets = extractInsertTargets(sql);
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('real');
+    });
+  });
+
+  describe('異常系', () => {
+    it('INSERT文なし - 空配列', () => {
+      expect(extractInsertTargets('SELECT * FROM t')).toEqual([]);
+    });
+
+    it('空文字列', () => {
+      expect(extractInsertTargets('')).toEqual([]);
+    });
+
+    it('VALUES句なし (書きかけ) - 抽出しない', () => {
+      expect(extractInsertTargets('INSERT INTO t')).toEqual([]);
+    });
+
+    it('閉じ括弧なし - 抽出しない', () => {
+      expect(extractInsertTargets('INSERT INTO t VALUES (1, 2')).toEqual([]);
+    });
+
+    it('INSERT ... SELECT 構文 - VALUES句なしなので抽出しない', () => {
+      const targets = extractInsertTargets('INSERT INTO t SELECT * FROM u');
+      expect(targets).toEqual([]);
+    });
+  });
+
+  describe('空白・改行の柔軟性', () => {
+    it('改行を跨いだINSERT', () => {
+      const sql = 'INSERT INTO t\n  (a, b)\nVALUES\n  (1, 2)';
+      const targets = extractInsertTargets(sql);
+      expect(targets[0].columnNames).toEqual(['a', 'b']);
+      expect(targets[0].valueRows[0]).toHaveLength(2);
+    });
+
+    it('値前後の空白はlengthに含めない', () => {
+      const sql = 'INSERT INTO t VALUES (  42  ,  99  )';
+      const row = extractInsertTargets(sql)[0].valueRows[0];
+      expect(slice(sql, row[0])).toBe('42');
+      expect(slice(sql, row[1])).toBe('99');
+    });
+  });
+});

--- a/frontend/src/utils/insertHintExtractor.ts
+++ b/frontend/src/utils/insertHintExtractor.ts
@@ -1,0 +1,237 @@
+export interface InsertValuePosition {
+  offset: number;
+  length: number;
+}
+
+export interface InsertTarget {
+  tableName: string;
+  columnNames: string[] | null;
+  valueRows: InsertValuePosition[][];
+}
+
+const WS = /\s/;
+
+function normalizeForParsing(sql: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const n = sql.length;
+  while (i < n) {
+    const c = sql[i];
+    if (c === '-' && sql[i + 1] === '-') {
+      while (i < n && sql[i] !== '\n') {
+        out.push(' ');
+        i++;
+      }
+      continue;
+    }
+    if (c === '/' && sql[i + 1] === '*') {
+      out.push(' ', ' ');
+      i += 2;
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) {
+        out.push(sql[i] === '\n' ? '\n' : ' ');
+        i++;
+      }
+      if (i < n) {
+        out.push(' ', ' ');
+        i += 2;
+      }
+      continue;
+    }
+    if (c === "'") {
+      out.push(' ');
+      i++;
+      while (i < n) {
+        if (sql[i] === "'" && sql[i + 1] === "'") {
+          out.push(' ', ' ');
+          i += 2;
+          continue;
+        }
+        if (sql[i] === "'") {
+          out.push(' ');
+          i++;
+          break;
+        }
+        out.push(sql[i] === '\n' ? '\n' : ' ');
+        i++;
+      }
+      continue;
+    }
+    out.push(c);
+    i++;
+  }
+  return out.join('');
+}
+
+const QUOTE_CLOSE: Record<string, string> = { '[': ']', '`': '`', '"': '"' };
+
+function unwrapIdentifier(ident: string): string {
+  if (!ident) return ident;
+  const close = QUOTE_CLOSE[ident[0]];
+  if (close && ident[ident.length - 1] === close) return ident.slice(1, -1);
+  return ident;
+}
+
+function skipWs(s: string, i: number): number {
+  while (i < s.length && WS.test(s[i])) i++;
+  return i;
+}
+
+function readIdentifier(s: string, i: number): { ident: string; end: number } | null {
+  const c = s[i];
+  const close = QUOTE_CLOSE[c];
+  if (close) {
+    const end = s.indexOf(close, i + 1);
+    if (end < 0) return null;
+    return { ident: s.slice(i, end + 1), end: end + 1 };
+  }
+  if (/[A-Za-z_]/.test(c)) {
+    let j = i + 1;
+    while (j < s.length && /[A-Za-z0-9_$]/.test(s[j])) j++;
+    return { ident: s.slice(i, j), end: j };
+  }
+  return null;
+}
+
+function readQualifiedName(s: string, i: number): { parts: string[]; end: number } | null {
+  const parts: string[] = [];
+  let cur = i;
+  while (true) {
+    const r = readIdentifier(s, cur);
+    if (!r) return parts.length === 0 ? null : { parts, end: cur };
+    parts.push(r.ident);
+    cur = r.end;
+    const afterWs = skipWs(s, cur);
+    if (s[afterWs] !== '.') return { parts, end: cur };
+    cur = skipWs(s, afterWs + 1);
+  }
+}
+
+function readKeyword(s: string, i: number, keyword: string): number | null {
+  const upper = keyword.toUpperCase();
+  const slice = s.slice(i, i + upper.length).toUpperCase();
+  if (slice !== upper) return null;
+  const after = s[i + upper.length];
+  if (after !== undefined && /[A-Za-z0-9_$]/.test(after)) return null;
+  return i + upper.length;
+}
+
+function readColumnList(s: string, i: number): { columns: string[]; end: number } | null {
+  if (s[i] !== '(') return null;
+  let cur = skipWs(s, i + 1);
+  const columns: string[] = [];
+  while (cur < s.length && s[cur] !== ')') {
+    const r = readIdentifier(s, cur);
+    if (!r) return null;
+    columns.push(unwrapIdentifier(r.ident));
+    cur = skipWs(s, r.end);
+    if (s[cur] === ',') {
+      cur = skipWs(s, cur + 1);
+      continue;
+    }
+    if (s[cur] === ')') break;
+    return null;
+  }
+  if (s[cur] !== ')') return null;
+  return { columns, end: cur + 1 };
+}
+
+function readValueTuple(
+  scan: string,
+  original: string,
+  i: number
+): { values: InsertValuePosition[]; end: number } | null {
+  if (scan[i] !== '(') return null;
+  let cur = i + 1;
+  while (cur < scan.length && WS.test(original[cur])) cur++;
+  let valueStart = cur;
+  const values: InsertValuePosition[] = [];
+  let depth = 1;
+
+  const flush = (end: number) => {
+    let valueEnd = end;
+    while (valueEnd > valueStart && WS.test(original[valueEnd - 1])) valueEnd--;
+    if (valueEnd > valueStart) {
+      values.push({ offset: valueStart, length: valueEnd - valueStart });
+    }
+  };
+
+  while (cur < scan.length) {
+    const c = scan[cur];
+    if (c === '(') {
+      depth++;
+      cur++;
+      continue;
+    }
+    if (c === ')') {
+      depth--;
+      if (depth === 0) {
+        flush(cur);
+        return { values, end: cur + 1 };
+      }
+      cur++;
+      continue;
+    }
+    if (c === ',' && depth === 1) {
+      flush(cur);
+      cur++;
+      while (cur < scan.length && WS.test(original[cur])) cur++;
+      valueStart = cur;
+      continue;
+    }
+    cur++;
+  }
+  return null;
+}
+
+const INSERT_INTO_RE = /\bINSERT\s+INTO\s+/gi;
+
+export function extractInsertTargets(sql: string): InsertTarget[] {
+  if (!sql) return [];
+
+  const scan = normalizeForParsing(sql);
+  const targets: InsertTarget[] = [];
+
+  for (const match of scan.matchAll(INSERT_INTO_RE)) {
+    const start = match.index + match[0].length;
+    let cur = skipWs(scan, start);
+
+    const nameResult = readQualifiedName(scan, cur);
+    if (!nameResult) continue;
+    const tableName = nameResult.parts.map(unwrapIdentifier).join('.');
+    cur = skipWs(scan, nameResult.end);
+
+    let columnNames: string[] | null = null;
+    if (scan[cur] === '(') {
+      const colResult = readColumnList(scan, cur);
+      if (!colResult) continue;
+      columnNames = colResult.columns;
+      cur = skipWs(scan, colResult.end);
+    }
+
+    const afterValues = readKeyword(scan, cur, 'VALUES');
+    if (afterValues === null) continue;
+    cur = skipWs(scan, afterValues);
+
+    const valueRows: InsertValuePosition[][] = [];
+    let parseFailed = false;
+    while (cur < scan.length && scan[cur] === '(') {
+      const tuple = readValueTuple(scan, sql, cur);
+      if (!tuple) {
+        parseFailed = true;
+        break;
+      }
+      valueRows.push(tuple.values);
+      cur = skipWs(scan, tuple.end);
+      if (scan[cur] === ',') {
+        cur = skipWs(scan, cur + 1);
+        continue;
+      }
+      break;
+    }
+    if (parseFailed || valueRows.length === 0) continue;
+
+    targets.push({ tableName, columnNames, valueRows });
+  }
+
+  return targets;
+}


### PR DESCRIPTION
- extractInsertTargets: INSERT句を解析する純関数 (コメント/文字列/quote対応)
- createInlayHintProvider: Monaco InlayHintsProvider (schemaStore連携)
- SqlEditor: completion + inlay両providerを接続ID変更時に再登録、null遷移時もdispose

Closes #371 (Phase 1: INSERT)