### PR TITLE
feat: UPDATE文のSET句にカラム名インレイヒントを追加

### DIFF
--- a/frontend/src/components/editor/inlayHintProvider.ts
+++ b/frontend/src/components/editor/inlayHintProvider.ts
@@ -2,16 +2,30 @@ import type * as Monaco from 'monaco-editor';
 import { languages as MonacoLanguages } from 'monaco-editor';
 import { useSchemaStore } from '../../store/schemaStore';
 import { extractInsertTargets } from '../../utils/insertHintExtractor';
+import { extractUpdateTargets } from '../../utils/updateHintExtractor';
 
 function emptyList(): Monaco.languages.InlayHintList {
   return { hints: [], dispose: () => {} };
+}
+
+function makeHint(
+  model: Monaco.editor.ITextModel,
+  offset: number,
+  label: string
+): Monaco.languages.InlayHint {
+  return {
+    label: `${label}:`,
+    position: model.getPositionAt(offset),
+    kind: MonacoLanguages.InlayHintKind.Parameter,
+    paddingRight: true,
+  };
 }
 
 export function createInlayHintProvider(
   connectionId: string | null
 ): Monaco.languages.InlayHintsProvider {
   return {
-    displayName: 'sqlInsertInlayHints',
+    displayName: 'sqlDmlInlayHints',
 
     provideInlayHints: async (
       model: Monaco.editor.ITextModel,
@@ -21,11 +35,12 @@ export function createInlayHintProvider(
       if (!connectionId) return emptyList();
 
       const sql = model.getValue();
-      const targets = extractInsertTargets(sql);
-      if (targets.length === 0) return emptyList();
+      const insertTargets = extractInsertTargets(sql);
+      const updateTargets = extractUpdateTargets(sql);
+      if (insertTargets.length === 0 && updateTargets.length === 0) return emptyList();
 
       const store = useSchemaStore.getState();
-      const needLoad = targets.filter(
+      const needLoad = insertTargets.filter(
         (t) => t.columnNames === null && !store.getTableColumns(connectionId, t.tableName)
       );
       if (needLoad.length > 0) {
@@ -34,7 +49,8 @@ export function createInlayHintProvider(
       if (token.isCancellationRequested) return emptyList();
 
       const hints: Monaco.languages.InlayHint[] = [];
-      for (const target of targets) {
+
+      for (const target of insertTargets) {
         const names =
           target.columnNames ??
           (useSchemaStore.getState().getTableColumns(connectionId, target.tableName) ?? []).map(
@@ -46,14 +62,14 @@ export function createInlayHintProvider(
           for (let i = 0; i < row.length; i++) {
             const name = names[i];
             if (!name) continue;
-            const pos = model.getPositionAt(row[i].offset);
-            hints.push({
-              label: `${name}:`,
-              position: pos,
-              kind: MonacoLanguages.InlayHintKind.Parameter,
-              paddingRight: true,
-            });
+            hints.push(makeHint(model, row[i].offset, name));
           }
+        }
+      }
+
+      for (const target of updateTargets) {
+        for (const a of target.assignments) {
+          hints.push(makeHint(model, a.value.offset, a.columnName));
         }
       }
 

--- a/frontend/src/tests/components/editor/inlayHintProvider.test.ts
+++ b/frontend/src/tests/components/editor/inlayHintProvider.test.ts
@@ -228,4 +228,71 @@ describe('createInlayHintProvider', () => {
       expect(result?.hints.map((h) => h.label)).toEqual(['uid:', 'uname:', 'oid:', 'uid_fk:']);
     });
   });
+
+  describe('UPDATE 文', () => {
+    it('SET 句の右辺値にカラム名ラベルを付与 (schemaStore不要)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('UPDATE users SET id = 1, name = 2, age = 3');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['id:', 'name:', 'age:']);
+      expect(vi.mocked(bridge.getColumns)).not.toHaveBeenCalled();
+    });
+
+    it('kind が InlayHintKind.Parameter (=2)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('UPDATE t SET a = 1');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints[0].kind).toBe(2);
+      expect(result?.hints[0].paddingRight).toBe(true);
+    });
+
+    it('position.column が値の offset+1 (1-based)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const sql = 'UPDATE t SET a = 1, b = 2, c = 3';
+      const model = makeModel(sql);
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      const hints = result?.hints ?? [];
+      expect(hints[0].position.column).toBe(sql.indexOf('1') + 1);
+      expect(hints[1].position.column).toBe(sql.indexOf('2') + 1);
+      expect(hints[2].position.column).toBe(sql.indexOf('3') + 1);
+    });
+
+    it('WHERE 句は SET 句の終端 (WHERE の式にはヒントなし)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('UPDATE t SET a = 1 WHERE id = 5');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints).toHaveLength(1);
+      expect(result?.hints[0].label).toBe('a:');
+    });
+
+    it('INSERT と UPDATE が混在する SQL: 両方にヒント', async () => {
+      seedTable('conn_1', 'users', [col('uid'), col('uname')]);
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel(
+        'INSERT INTO users VALUES (1, 2); UPDATE users SET uid = 3, uname = 4;'
+      );
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['uid:', 'uname:', 'uid:', 'uname:']);
+    });
+
+    it('複数 UPDATE 文: 各々の SET 句のカラム名で生成', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel('UPDATE t1 SET a = 1; UPDATE t2 SET b = 2, c = 3;');
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['a:', 'b:', 'c:']);
+    });
+
+    it('ラベルが対応する値の位置に配置される (ラベル↔値の因果関係)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const sql = "UPDATE users SET name = 'John', count = count + 1";
+      const model = makeModel(sql);
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      const hints = result?.hints ?? [];
+      expect(hints).toHaveLength(2);
+      expect(hints[0].label).toBe('name:');
+      expect(hints[0].position.column).toBe(sql.indexOf("'John'") + 1);
+      expect(hints[1].label).toBe('count:');
+      expect(hints[1].position.column).toBe(sql.lastIndexOf('count + 1') + 1);
+    });
+  });
 });

--- a/frontend/src/tests/utils/_helpers.ts
+++ b/frontend/src/tests/utils/_helpers.ts
@@ -1,0 +1,2 @@
+export const sliceAt = (sql: string, p: { offset: number; length: number }) =>
+  sql.slice(p.offset, p.offset + p.length);

--- a/frontend/src/tests/utils/insertHintExtractor.test.ts
+++ b/frontend/src/tests/utils/insertHintExtractor.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { extractInsertTargets } from '../../utils/insertHintExtractor';
-
-const slice = (sql: string, p: { offset: number; length: number }) =>
-  sql.slice(p.offset, p.offset + p.length);
+import { sliceAt as slice } from './_helpers';
 
 describe('extractInsertTargets', () => {
   describe('基本的なINSERT構文', () => {

--- a/frontend/src/tests/utils/updateHintExtractor.test.ts
+++ b/frontend/src/tests/utils/updateHintExtractor.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+import { extractUpdateTargets } from '../../utils/updateHintExtractor';
+import { sliceAt as slice } from './_helpers';
+
+describe('extractUpdateTargets', () => {
+  describe('基本的なUPDATE構文', () => {
+    it('UPDATE t SET c1=1, c2=2 - 2カラム代入', () => {
+      const sql = 'UPDATE users SET id = 1, name = 2';
+      const targets = extractUpdateTargets(sql);
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('users');
+      expect(targets[0].assignments).toHaveLength(2);
+      expect(targets[0].assignments[0].columnName).toBe('id');
+      expect(targets[0].assignments[1].columnName).toBe('name');
+    });
+
+    it('値のoffset/lengthが元SQLの値と一致', () => {
+      const sql = 'UPDATE t SET a = 42, b = 100';
+      const [t] = extractUpdateTargets(sql);
+      expect(slice(sql, t.assignments[0].value)).toBe('42');
+      expect(slice(sql, t.assignments[1].value)).toBe('100');
+    });
+
+    it('大文字小文字を区別しない (update ... set)', () => {
+      const targets = extractUpdateTargets('update users set name = 1');
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('users');
+      expect(targets[0].assignments[0].columnName).toBe('name');
+    });
+  });
+
+  describe('終端キーワード', () => {
+    it('WHERE で SET 句が終端', () => {
+      const sql = 'UPDATE t SET a = 1, b = 2 WHERE id = 5';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(slice(sql, t.assignments[1].value)).toBe('2');
+    });
+
+    it('FROM で SET 句が終端 (SQL Server / PostgreSQL)', () => {
+      const sql = 'UPDATE t SET a = s.v FROM src s WHERE t.id = s.id';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(1);
+      expect(slice(sql, t.assignments[0].value)).toBe('s.v');
+    });
+
+    it('RETURNING で SET 句が終端 (PostgreSQL)', () => {
+      const sql = 'UPDATE t SET a = 1 RETURNING id';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(1);
+      expect(slice(sql, t.assignments[0].value)).toBe('1');
+    });
+
+    it('; で SET 句が終端', () => {
+      const sql = 'UPDATE t SET a = 1, b = 2;';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(slice(sql, t.assignments[1].value)).toBe('2');
+    });
+
+    it('EOF で SET 句が終端 (WHERE無し)', () => {
+      const sql = 'UPDATE t SET a = 1, b = 2';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(slice(sql, t.assignments[1].value)).toBe('2');
+    });
+
+    it('LIMIT で SET 句が終端 (MySQL)', () => {
+      const sql = 'UPDATE t SET a = 1 LIMIT 10';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(1);
+      expect(slice(sql, t.assignments[0].value)).toBe('1');
+    });
+
+    it('ORDER BY で SET 句が終端 (MySQL)', () => {
+      const sql = 'UPDATE t SET a = 1 ORDER BY id';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(1);
+      expect(slice(sql, t.assignments[0].value)).toBe('1');
+    });
+  });
+
+  describe('alias (PostgreSQL / MySQL)', () => {
+    it('AS 付き alias: UPDATE t AS x SET ...', () => {
+      const sql = 'UPDATE users AS u SET name = 1';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.tableName).toBe('users');
+      expect(t.assignments).toHaveLength(1);
+      expect(t.assignments[0].columnName).toBe('name');
+    });
+
+    it('AS なし alias: UPDATE t x SET ...', () => {
+      const sql = 'UPDATE users u SET name = 1';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.tableName).toBe('users');
+      expect(t.assignments).toHaveLength(1);
+      expect(t.assignments[0].columnName).toBe('name');
+    });
+  });
+
+  describe('識別子quote', () => {
+    it('[bracket] テーブル名', () => {
+      const targets = extractUpdateTargets('UPDATE [my table] SET a = 1');
+      expect(targets[0].tableName).toBe('my table');
+    });
+
+    it('`backtick` テーブル名', () => {
+      const targets = extractUpdateTargets('UPDATE `my-table` SET a = 1');
+      expect(targets[0].tableName).toBe('my-table');
+    });
+
+    it('"doubleQuote" テーブル名', () => {
+      const targets = extractUpdateTargets('UPDATE "my.table" SET a = 1');
+      expect(targets[0].tableName).toBe('my.table');
+    });
+
+    it('schema.table 形式', () => {
+      const targets = extractUpdateTargets('UPDATE public.users SET a = 1');
+      expect(targets[0].tableName).toBe('public.users');
+    });
+
+    it('カラム名のquote解除', () => {
+      const sql = 'UPDATE t SET [col 1] = 1, `col-2` = 2, "col.3" = 3';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments.map((a) => a.columnName)).toEqual(['col 1', 'col-2', 'col.3']);
+    });
+  });
+
+  describe('値内の特殊文字', () => {
+    it('文字列リテラル内のカンマは値区切りとみなさない', () => {
+      const sql = "UPDATE t SET a = 'x, y', b = 'z'";
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(t.assignments[0].columnName).toBe('a');
+      expect(t.assignments[1].columnName).toBe('b');
+    });
+
+    it("文字列リテラル値のoffset/lengthが '...' 全体を指す", () => {
+      const sql = "UPDATE t SET a = 'x, y', b = 'z'";
+      const [t] = extractUpdateTargets(sql);
+      expect(slice(sql, t.assignments[0].value)).toBe("'x, y'");
+      expect(slice(sql, t.assignments[1].value)).toBe("'z'");
+    });
+
+    it('関数呼び出しのネスト括弧', () => {
+      const sql = 'UPDATE t SET a = COALESCE(x, y), b = 1';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(slice(sql, t.assignments[0].value)).toBe('COALESCE(x, y)');
+      expect(slice(sql, t.assignments[1].value)).toBe('1');
+    });
+
+    it("エスケープされたシングルクォート '' は文字列内扱い", () => {
+      const sql = "UPDATE t SET a = 'it''s, ok', b = 1";
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(t.assignments[0].columnName).toBe('a');
+      expect(t.assignments[1].columnName).toBe('b');
+    });
+  });
+
+  describe('複数UPDATE文', () => {
+    it('2つのUPDATE文を両方抽出', () => {
+      const sql = 'UPDATE t1 SET a = 1; UPDATE t2 SET b = 2;';
+      const targets = extractUpdateTargets(sql);
+      expect(targets).toHaveLength(2);
+      expect(targets[0].tableName).toBe('t1');
+      expect(targets[1].tableName).toBe('t2');
+    });
+  });
+
+  describe('コメント', () => {
+    it('行コメント内のUPDATEは無視', () => {
+      const sql = '-- UPDATE fake SET a = 1\nUPDATE real SET b = 2';
+      const targets = extractUpdateTargets(sql);
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('real');
+    });
+
+    it('ブロックコメント内のUPDATEは無視', () => {
+      const sql = '/* UPDATE fake SET a = 1 */ UPDATE real SET b = 2';
+      const targets = extractUpdateTargets(sql);
+      expect(targets).toHaveLength(1);
+      expect(targets[0].tableName).toBe('real');
+    });
+  });
+
+  describe('異常系', () => {
+    it('UPDATE文なし - 空配列', () => {
+      expect(extractUpdateTargets('SELECT * FROM t')).toEqual([]);
+    });
+
+    it('空文字列', () => {
+      expect(extractUpdateTargets('')).toEqual([]);
+    });
+
+    it('SET句なし (書きかけ) - 抽出しない', () => {
+      expect(extractUpdateTargets('UPDATE t')).toEqual([]);
+    });
+
+    it('= のない SET 項目 - 該当項目のみスキップ', () => {
+      const sql = 'UPDATE t SET invalid, a = 1';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(1);
+      expect(t.assignments[0].columnName).toBe('a');
+    });
+
+    it('UPDATE 直後にテーブル名なしで SET 開始 (不正SQL) - 抽出しない', () => {
+      expect(extractUpdateTargets('UPDATE SET a = 1')).toEqual([]);
+    });
+
+    it('値が空 - 抽出しない', () => {
+      const sql = 'UPDATE t SET a = , b = 1';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(1);
+      expect(t.assignments[0].columnName).toBe('b');
+    });
+  });
+
+  describe('実用的な UPDATE クエリ', () => {
+    it('式・関数呼び出し・文字列の混在', () => {
+      const sql = "UPDATE users SET name = 'John', count = count + 1, updated_at = NOW()";
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(3);
+      expect(t.assignments.map((a) => a.columnName)).toEqual(['name', 'count', 'updated_at']);
+      expect(slice(sql, t.assignments[0].value)).toBe("'John'");
+      expect(slice(sql, t.assignments[1].value)).toBe('count + 1');
+      expect(slice(sql, t.assignments[2].value)).toBe('NOW()');
+    });
+
+    it('CASE 式を値として含む', () => {
+      const sql =
+        "UPDATE t SET status = CASE WHEN x > 0 THEN 'active' ELSE 'inactive' END, flag = 1";
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(t.assignments[0].columnName).toBe('status');
+      expect(slice(sql, t.assignments[0].value)).toBe(
+        "CASE WHEN x > 0 THEN 'active' ELSE 'inactive' END"
+      );
+      expect(slice(sql, t.assignments[1].value)).toBe('1');
+    });
+
+    it('サブクエリを値として含む', () => {
+      const sql = 'UPDATE t SET total = (SELECT SUM(x) FROM items WHERE t.id = items.tid)';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(1);
+      expect(slice(sql, t.assignments[0].value)).toBe(
+        '(SELECT SUM(x) FROM items WHERE t.id = items.tid)'
+      );
+    });
+
+    it('WHERE 句ありで複数列を更新する典型パターン', () => {
+      const sql =
+        "UPDATE orders SET status = 'shipped', shipped_at = NOW() WHERE id = 123 AND status = 'pending'";
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(slice(sql, t.assignments[0].value)).toBe("'shipped'");
+      expect(slice(sql, t.assignments[1].value)).toBe('NOW()');
+    });
+  });
+
+  describe('空白・改行の柔軟性', () => {
+    it('改行を跨いだUPDATE', () => {
+      const sql = 'UPDATE t\nSET\n  a = 1,\n  b = 2\nWHERE id = 3';
+      const [t] = extractUpdateTargets(sql);
+      expect(t.assignments).toHaveLength(2);
+      expect(t.assignments.map((x) => x.columnName)).toEqual(['a', 'b']);
+    });
+
+    it('値前後の空白はlengthに含めない', () => {
+      const sql = 'UPDATE t SET a =  42  , b =  99  ';
+      const [t] = extractUpdateTargets(sql);
+      expect(slice(sql, t.assignments[0].value)).toBe('42');
+      expect(slice(sql, t.assignments[1].value)).toBe('99');
+    });
+  });
+});

--- a/frontend/src/utils/insertHintExtractor.ts
+++ b/frontend/src/utils/insertHintExtractor.ts
@@ -1,3 +1,13 @@
+import {
+  normalizeForParsing,
+  readIdentifier,
+  readKeyword,
+  readQualifiedName,
+  skipWs,
+  unwrapIdentifier,
+  WS,
+} from './sqlTokenParser';
+
 export interface InsertValuePosition {
   offset: number;
   length: number;
@@ -7,112 +17,6 @@ export interface InsertTarget {
   tableName: string;
   columnNames: string[] | null;
   valueRows: InsertValuePosition[][];
-}
-
-const WS = /\s/;
-
-function normalizeForParsing(sql: string): string {
-  const out: string[] = [];
-  let i = 0;
-  const n = sql.length;
-  while (i < n) {
-    const c = sql[i];
-    if (c === '-' && sql[i + 1] === '-') {
-      while (i < n && sql[i] !== '\n') {
-        out.push(' ');
-        i++;
-      }
-      continue;
-    }
-    if (c === '/' && sql[i + 1] === '*') {
-      out.push(' ', ' ');
-      i += 2;
-      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) {
-        out.push(sql[i] === '\n' ? '\n' : ' ');
-        i++;
-      }
-      if (i < n) {
-        out.push(' ', ' ');
-        i += 2;
-      }
-      continue;
-    }
-    if (c === "'") {
-      out.push(' ');
-      i++;
-      while (i < n) {
-        if (sql[i] === "'" && sql[i + 1] === "'") {
-          out.push(' ', ' ');
-          i += 2;
-          continue;
-        }
-        if (sql[i] === "'") {
-          out.push(' ');
-          i++;
-          break;
-        }
-        out.push(sql[i] === '\n' ? '\n' : ' ');
-        i++;
-      }
-      continue;
-    }
-    out.push(c);
-    i++;
-  }
-  return out.join('');
-}
-
-const QUOTE_CLOSE: Record<string, string> = { '[': ']', '`': '`', '"': '"' };
-
-function unwrapIdentifier(ident: string): string {
-  if (!ident) return ident;
-  const close = QUOTE_CLOSE[ident[0]];
-  if (close && ident[ident.length - 1] === close) return ident.slice(1, -1);
-  return ident;
-}
-
-function skipWs(s: string, i: number): number {
-  while (i < s.length && WS.test(s[i])) i++;
-  return i;
-}
-
-function readIdentifier(s: string, i: number): { ident: string; end: number } | null {
-  const c = s[i];
-  const close = QUOTE_CLOSE[c];
-  if (close) {
-    const end = s.indexOf(close, i + 1);
-    if (end < 0) return null;
-    return { ident: s.slice(i, end + 1), end: end + 1 };
-  }
-  if (/[A-Za-z_]/.test(c)) {
-    let j = i + 1;
-    while (j < s.length && /[A-Za-z0-9_$]/.test(s[j])) j++;
-    return { ident: s.slice(i, j), end: j };
-  }
-  return null;
-}
-
-function readQualifiedName(s: string, i: number): { parts: string[]; end: number } | null {
-  const parts: string[] = [];
-  let cur = i;
-  while (true) {
-    const r = readIdentifier(s, cur);
-    if (!r) return parts.length === 0 ? null : { parts, end: cur };
-    parts.push(r.ident);
-    cur = r.end;
-    const afterWs = skipWs(s, cur);
-    if (s[afterWs] !== '.') return { parts, end: cur };
-    cur = skipWs(s, afterWs + 1);
-  }
-}
-
-function readKeyword(s: string, i: number, keyword: string): number | null {
-  const upper = keyword.toUpperCase();
-  const slice = s.slice(i, i + upper.length).toUpperCase();
-  if (slice !== upper) return null;
-  const after = s[i + upper.length];
-  if (after !== undefined && /[A-Za-z0-9_$]/.test(after)) return null;
-  return i + upper.length;
 }
 
 function readColumnList(s: string, i: number): { columns: string[]; end: number } | null {
@@ -142,7 +46,7 @@ function readValueTuple(
 ): { values: InsertValuePosition[]; end: number } | null {
   if (scan[i] !== '(') return null;
   let cur = i + 1;
-  while (cur < scan.length && WS.test(original[cur])) cur++;
+  cur = skipWs(original, cur);
   let valueStart = cur;
   const values: InsertValuePosition[] = [];
   let depth = 1;
@@ -174,7 +78,7 @@ function readValueTuple(
     if (c === ',' && depth === 1) {
       flush(cur);
       cur++;
-      while (cur < scan.length && WS.test(original[cur])) cur++;
+      cur = skipWs(original, cur);
       valueStart = cur;
       continue;
     }
@@ -185,6 +89,11 @@ function readValueTuple(
 
 const INSERT_INTO_RE = /\bINSERT\s+INTO\s+/gi;
 
+/**
+ * SQL から INSERT 文の VALUES 句を解析し、テーブル名・カラム名リスト・各値行の位置情報を返す。
+ * カラムリストが省略されたときは schemaStore から取得する前提で `columnNames: null` を返す。
+ * コメント・文字列リテラルは normalize 時に空白化され、値区切りとして誤認しない。
+ */
 export function extractInsertTargets(sql: string): InsertTarget[] {
   if (!sql) return [];
 

--- a/frontend/src/utils/sqlTokenParser.ts
+++ b/frontend/src/utils/sqlTokenParser.ts
@@ -1,0 +1,105 @@
+export const WS = /\s/;
+
+export const QUOTE_CLOSE: Record<string, string> = { '[': ']', '`': '`', '"': '"' };
+
+export function normalizeForParsing(sql: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const n = sql.length;
+  while (i < n) {
+    const c = sql[i];
+    if (c === '-' && sql[i + 1] === '-') {
+      while (i < n && sql[i] !== '\n') {
+        out.push(' ');
+        i++;
+      }
+      continue;
+    }
+    if (c === '/' && sql[i + 1] === '*') {
+      out.push(' ', ' ');
+      i += 2;
+      while (i < n && !(sql[i] === '*' && sql[i + 1] === '/')) {
+        out.push(sql[i] === '\n' ? '\n' : ' ');
+        i++;
+      }
+      if (i < n) {
+        out.push(' ', ' ');
+        i += 2;
+      }
+      continue;
+    }
+    if (c === "'") {
+      out.push(' ');
+      i++;
+      while (i < n) {
+        if (sql[i] === "'" && sql[i + 1] === "'") {
+          out.push(' ', ' ');
+          i += 2;
+          continue;
+        }
+        if (sql[i] === "'") {
+          out.push(' ');
+          i++;
+          break;
+        }
+        out.push(sql[i] === '\n' ? '\n' : ' ');
+        i++;
+      }
+      continue;
+    }
+    out.push(c);
+    i++;
+  }
+  return out.join('');
+}
+
+export function unwrapIdentifier(ident: string): string {
+  if (!ident) return ident;
+  const close = QUOTE_CLOSE[ident[0]];
+  if (close && ident[ident.length - 1] === close) return ident.slice(1, -1);
+  return ident;
+}
+
+export function skipWs(s: string, i: number): number {
+  while (i < s.length && WS.test(s[i])) i++;
+  return i;
+}
+
+export function readIdentifier(s: string, i: number): { ident: string; end: number } | null {
+  const c = s[i];
+  const close = QUOTE_CLOSE[c];
+  if (close) {
+    const end = s.indexOf(close, i + 1);
+    if (end < 0) return null;
+    return { ident: s.slice(i, end + 1), end: end + 1 };
+  }
+  if (/[A-Za-z_]/.test(c)) {
+    let j = i + 1;
+    while (j < s.length && /[A-Za-z0-9_$]/.test(s[j])) j++;
+    return { ident: s.slice(i, j), end: j };
+  }
+  return null;
+}
+
+export function readQualifiedName(s: string, i: number): { parts: string[]; end: number } | null {
+  const parts: string[] = [];
+  let cur = i;
+  while (true) {
+    const r = readIdentifier(s, cur);
+    if (!r) return parts.length === 0 ? null : { parts, end: cur };
+    parts.push(r.ident);
+    cur = r.end;
+    const afterWs = skipWs(s, cur);
+    if (s[afterWs] !== '.') return { parts, end: cur };
+    cur = skipWs(s, afterWs + 1);
+  }
+}
+
+export function readKeyword(s: string, i: number, keyword: string): number | null {
+  const upper = keyword.toUpperCase();
+  const slice = s.slice(i, i + upper.length).toUpperCase();
+  if (slice !== upper) return null;
+  const after = s[i + upper.length];
+  if (after !== undefined && /[A-Za-z0-9_$]/.test(after)) return null;
+  return i + upper.length;
+}

--- a/frontend/src/utils/updateHintExtractor.ts
+++ b/frontend/src/utils/updateHintExtractor.ts
@@ -1,0 +1,165 @@
+import {
+  normalizeForParsing,
+  readIdentifier,
+  readKeyword,
+  readQualifiedName,
+  skipWs,
+  unwrapIdentifier,
+  WS,
+} from './sqlTokenParser';
+
+export interface UpdateValuePosition {
+  offset: number;
+  length: number;
+}
+
+export interface UpdateAssignment {
+  columnName: string;
+  value: UpdateValuePosition;
+}
+
+export interface UpdateTarget {
+  tableName: string;
+  assignments: UpdateAssignment[];
+}
+
+const UPDATE_RE = /\bUPDATE\s+/gi;
+// ORDER は `ORDER BY` の先頭のみを検出 (word boundary で単独 ORDER も同等に扱う)
+// LIMIT / ORDER は MySQL UPDATE 構文の終端
+const END_KEYWORDS = ['FROM', 'WHERE', 'RETURNING', 'LIMIT', 'ORDER'] as const;
+
+function isSetClauseTerminator(scan: string, i: number): boolean {
+  if (i >= scan.length) return true;
+  const c = scan[i];
+  if (c === ';') return true;
+  for (const kw of END_KEYWORDS) {
+    if (readKeyword(scan, i, kw) !== null) return true;
+  }
+  return false;
+}
+
+function skipToSetKeyword(scan: string, i: number): number | null {
+  let cur = i;
+  while (cur < scan.length) {
+    const afterSet = readKeyword(scan, cur, 'SET');
+    if (afterSet !== null) return afterSet;
+    if (WS.test(scan[cur])) {
+      cur++;
+      continue;
+    }
+    const ident = readIdentifier(scan, cur);
+    if (ident) {
+      cur = ident.end;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+function findValueEnd(scan: string, start: number): number {
+  let cur = start;
+  let depth = 0;
+  while (cur < scan.length) {
+    const c = scan[cur];
+    if (c === '(') {
+      depth++;
+      cur++;
+      continue;
+    }
+    if (c === ')') {
+      if (depth === 0) return cur;
+      depth--;
+      cur++;
+      continue;
+    }
+    if (depth === 0) {
+      if (c === ',' || c === ';') return cur;
+      if (isSetClauseTerminator(scan, cur)) return cur;
+    }
+    cur++;
+  }
+  return cur;
+}
+
+interface ReadAssignmentResult {
+  assignment: UpdateAssignment | null;
+  next: number;
+  done: boolean;
+}
+
+function readSingleAssignment(scan: string, original: string, cur: number): ReadAssignmentResult {
+  const idResult = readIdentifier(scan, cur);
+  if (!idResult) return { assignment: null, next: cur, done: true };
+  const columnName = unwrapIdentifier(idResult.ident);
+  const afterId = skipWs(scan, idResult.end);
+
+  if (scan[afterId] !== '=') {
+    const skipTo = findValueEnd(scan, afterId);
+    if (scan[skipTo] !== ',') return { assignment: null, next: skipTo, done: true };
+    return { assignment: null, next: skipWs(scan, skipTo + 1), done: false };
+  }
+
+  const valStart = skipWs(original, afterId + 1);
+  const valEnd = findValueEnd(scan, valStart);
+
+  let trimmedEnd = valEnd;
+  while (trimmedEnd > valStart && WS.test(original[trimmedEnd - 1])) trimmedEnd--;
+
+  const assignment =
+    trimmedEnd > valStart
+      ? { columnName, value: { offset: valStart, length: trimmedEnd - valStart } }
+      : null;
+
+  if (scan[valEnd] === ',') {
+    return { assignment, next: skipWs(scan, valEnd + 1), done: false };
+  }
+  return { assignment, next: valEnd, done: true };
+}
+
+function readAssignments(scan: string, original: string, startIdx: number): UpdateAssignment[] {
+  const assignments: UpdateAssignment[] = [];
+  let cur = skipWs(scan, startIdx);
+
+  while (cur < scan.length) {
+    if (isSetClauseTerminator(scan, cur)) break;
+    const { assignment, next, done } = readSingleAssignment(scan, original, cur);
+    if (assignment) assignments.push(assignment);
+    if (done) break;
+    cur = next;
+  }
+
+  return assignments;
+}
+
+/**
+ * SQL から UPDATE 文の SET 句を解析し、各代入の左辺カラム名と右辺値の位置情報を返す。
+ * コメント・文字列リテラルは normalize 時に空白化され、値区切りとして誤認しない。
+ * 終端キーワード: WHERE / FROM / RETURNING / LIMIT / ORDER / ;
+ */
+export function extractUpdateTargets(sql: string): UpdateTarget[] {
+  if (!sql) return [];
+
+  const scan = normalizeForParsing(sql);
+  const targets: UpdateTarget[] = [];
+
+  for (const match of scan.matchAll(UPDATE_RE)) {
+    const start = match.index + match[0].length;
+    let cur = skipWs(scan, start);
+
+    const nameResult = readQualifiedName(scan, cur);
+    if (!nameResult) continue;
+    const tableName = nameResult.parts.map(unwrapIdentifier).join('.');
+    cur = skipWs(scan, nameResult.end);
+
+    const afterSet = skipToSetKeyword(scan, cur);
+    if (afterSet === null) continue;
+
+    const assignments = readAssignments(scan, sql, afterSet);
+    if (assignments.length === 0) continue;
+
+    targets.push({ tableName, assignments });
+  }
+
+  return targets;
+}


### PR DESCRIPTION
- updateHintExtractor を新規追加 (`MySQL/PostgreSQL/SQL Server` 終端KW対応: `WHERE/FROM/RETURNING/LIMIT/ORDER/;`)
- 共通パーサ sqlTokenParser.ts を抽出し insertHintExtractor と共有
- inlayHintProvider を DML 全体に拡張 (displayName: sqlDmlInlayHints)
- 実用SQLパターン (式/関数/CASE/サブクエリ) + ラベル↔値因果検証テストを追加

Closes #383