### PR TITLE
feat: MERGE文のWHEN句にカラム名インレイヒントを追加

### DIFF
--- a/frontend/src/components/editor/inlayHintProvider.ts
+++ b/frontend/src/components/editor/inlayHintProvider.ts
@@ -2,6 +2,7 @@ import type * as Monaco from 'monaco-editor';
 import { languages as MonacoLanguages } from 'monaco-editor';
 import { useSchemaStore } from '../../store/schemaStore';
 import { extractInsertTargets } from '../../utils/insertHintExtractor';
+import { extractMergeTargets } from '../../utils/mergeHintExtractor';
 import { extractUpdateTargets } from '../../utils/updateHintExtractor';
 
 function emptyList(): Monaco.languages.InlayHintList {
@@ -37,6 +38,9 @@ export function createInlayHintProvider(
       const sql = model.getValue();
       const insertTargets = extractInsertTargets(sql);
       const updateTargets = extractUpdateTargets(sql);
+      const merge = extractMergeTargets(sql);
+      insertTargets.push(...merge.insertTargets);
+      updateTargets.push(...merge.updateTargets);
       if (insertTargets.length === 0 && updateTargets.length === 0) return emptyList();
 
       const store = useSchemaStore.getState();

--- a/frontend/src/tests/components/editor/inlayHintProvider.test.ts
+++ b/frontend/src/tests/components/editor/inlayHintProvider.test.ts
@@ -295,4 +295,51 @@ describe('createInlayHintProvider', () => {
       expect(hints[1].position.column).toBe(sql.lastIndexOf('count + 1') + 1);
     });
   });
+
+  describe('MERGE 文', () => {
+    it('WHEN MATCHED THEN UPDATE SET の右辺にカラム名ラベル付与 (schemaStore不要)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel(
+        'MERGE INTO users t USING staging s ON t.id = s.id ' +
+          'WHEN MATCHED THEN UPDATE SET name = s.name, age = s.age;'
+      );
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['name:', 'age:']);
+      expect(vi.mocked(bridge.getColumns)).not.toHaveBeenCalled();
+    });
+
+    it('WHEN NOT MATCHED THEN INSERT (cols) VALUES (vals) にカラム名ラベル付与', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const model = makeModel(
+        'MERGE INTO users USING staging ON users.id = staging.id ' +
+          'WHEN NOT MATCHED THEN INSERT (id, name) VALUES (staging.id, staging.name);'
+      );
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['id:', 'name:']);
+    });
+
+    it('UPDATE + INSERT 両方の WHEN 句にヒント生成 (典型UPSERT)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const sql =
+        'MERGE INTO target t USING source s ON t.id = s.id ' +
+        'WHEN MATCHED THEN UPDATE SET price = s.price ' +
+        'WHEN NOT MATCHED THEN INSERT (id, price) VALUES (s.id, s.price);';
+      const model = makeModel(sql);
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      expect(result?.hints.map((h) => h.label)).toEqual(['id:', 'price:', 'price:']);
+    });
+
+    it('ラベルが値の位置に配置される (ラベル↔値の因果関係)', async () => {
+      const provider = createInlayHintProvider('conn_1');
+      const sql = 'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = 1, b = 2;';
+      const model = makeModel(sql);
+      const result = await provider.provideInlayHints(model, FAKE_RANGE, makeToken());
+      const hints = result?.hints ?? [];
+      expect(hints).toHaveLength(2);
+      expect(hints[0].label).toBe('a:');
+      expect(hints[0].position.column).toBe(sql.indexOf('1') + 1);
+      expect(hints[1].label).toBe('b:');
+      expect(hints[1].position.column).toBe(sql.indexOf('2') + 1);
+    });
+  });
 });

--- a/frontend/src/tests/utils/mergeHintExtractor.test.ts
+++ b/frontend/src/tests/utils/mergeHintExtractor.test.ts
@@ -1,0 +1,346 @@
+import { describe, expect, it } from 'vitest';
+import { extractMergeTargets } from '../../utils/mergeHintExtractor';
+import { sliceAt as slice } from './_helpers';
+
+describe('extractMergeTargets', () => {
+  describe('基本的なMERGE構文 (SQL Server / PostgreSQL 共通)', () => {
+    it('MERGE INTO ... USING ... ON ... WHEN MATCHED THEN UPDATE SET ...', () => {
+      const sql =
+        'MERGE INTO users AS t USING staging AS s ON t.id = s.id WHEN MATCHED THEN UPDATE SET name = s.name, age = s.age;';
+      const { updateTargets, insertTargets } = extractMergeTargets(sql);
+      expect(insertTargets).toHaveLength(0);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('users');
+      expect(updateTargets[0].assignments.map((a) => a.columnName)).toEqual(['name', 'age']);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('s.name');
+      expect(slice(sql, updateTargets[0].assignments[1].value)).toBe('s.age');
+    });
+
+    it('WHEN NOT MATCHED THEN INSERT (cols) VALUES (vals) - 明示カラムリスト', () => {
+      const sql =
+        'MERGE INTO users USING staging ON users.id = staging.id WHEN NOT MATCHED THEN INSERT (id, name) VALUES (staging.id, staging.name);';
+      const { insertTargets, updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(0);
+      expect(insertTargets).toHaveLength(1);
+      expect(insertTargets[0].tableName).toBe('users');
+      expect(insertTargets[0].columnNames).toEqual(['id', 'name']);
+      expect(insertTargets[0].valueRows).toHaveLength(1);
+      expect(slice(sql, insertTargets[0].valueRows[0][0])).toBe('staging.id');
+      expect(slice(sql, insertTargets[0].valueRows[0][1])).toBe('staging.name');
+    });
+
+    it('WHEN MATCHED UPDATE + WHEN NOT MATCHED INSERT の両方', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id ' +
+        'WHEN MATCHED THEN UPDATE SET a = s.a, b = s.b ' +
+        'WHEN NOT MATCHED THEN INSERT (a, b) VALUES (s.a, s.b);';
+      const { updateTargets, insertTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(insertTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('t');
+      expect(insertTargets[0].tableName).toBe('t');
+      expect(updateTargets[0].assignments.map((a) => a.columnName)).toEqual(['a', 'b']);
+      expect(insertTargets[0].columnNames).toEqual(['a', 'b']);
+    });
+
+    it('大文字小文字を区別しない', () => {
+      const sql =
+        'merge into t using s on t.id = s.id when matched then update set a = 1 when not matched then insert (a) values (2);';
+      const { updateTargets, insertTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].tableName).toBe('t');
+      expect(updateTargets[0].assignments[0].columnName).toBe('a');
+      expect(insertTargets[0].columnNames).toEqual(['a']);
+    });
+  });
+
+  describe('WHEN 句のバリエーション', () => {
+    it('AND 条件付き WHEN MATCHED', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED AND s.active = 1 THEN UPDATE SET x = s.x;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].assignments[0].columnName).toBe('x');
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('s.x');
+    });
+
+    it('WHEN NOT MATCHED BY TARGET - PostgreSQL / SQL Server 両対応', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED BY TARGET THEN INSERT (a) VALUES (s.a);';
+      const { insertTargets } = extractMergeTargets(sql);
+      expect(insertTargets).toHaveLength(1);
+      expect(insertTargets[0].columnNames).toEqual(['a']);
+    });
+
+    it('WHEN NOT MATCHED BY SOURCE - UPDATE 適用 (SQL Server / PostgreSQL)', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED BY SOURCE THEN UPDATE SET flag = 0;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].assignments[0].columnName).toBe('flag');
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('0');
+    });
+
+    it('DELETE / DO NOTHING 句はスキップ', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id ' +
+        'WHEN MATCHED AND s.del = 1 THEN DELETE ' +
+        'WHEN MATCHED THEN UPDATE SET x = s.x ' +
+        'WHEN NOT MATCHED THEN DO NOTHING;';
+      const { updateTargets, insertTargets } = extractMergeTargets(sql);
+      expect(insertTargets).toHaveLength(0);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].assignments[0].columnName).toBe('x');
+    });
+
+    it('複数の UPDATE 句 (BY SOURCE + BY TARGET)', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id ' +
+        'WHEN MATCHED THEN UPDATE SET a = s.a ' +
+        'WHEN NOT MATCHED BY SOURCE THEN UPDATE SET b = 0;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(2);
+      expect(updateTargets[0].assignments[0].columnName).toBe('a');
+      expect(updateTargets[1].assignments[0].columnName).toBe('b');
+    });
+  });
+
+  describe('テーブル修飾とエイリアス', () => {
+    it('WITH (NOLOCK) テーブルヒントをスキップ (SQL Server)', () => {
+      const sql =
+        'MERGE INTO users WITH (HOLDLOCK) AS t USING staging s ON t.id = s.id WHEN MATCHED THEN UPDATE SET name = s.name;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('users');
+      expect(updateTargets[0].assignments[0].columnName).toBe('name');
+    });
+
+    it('INTO 省略 (SQL Server 旧構文)', () => {
+      const sql =
+        'MERGE users t USING staging s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].tableName).toBe('users');
+    });
+
+    it('schema.table 形式', () => {
+      const sql =
+        'MERGE INTO public.users USING staging ON users.id = staging.id WHEN MATCHED THEN UPDATE SET a = 1;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].tableName).toBe('public.users');
+    });
+
+    it('[bracket] テーブル名', () => {
+      const sql =
+        'MERGE INTO [my table] USING src ON [my table].id = src.id WHEN MATCHED THEN UPDATE SET a = 1;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].tableName).toBe('my table');
+    });
+  });
+
+  describe('終端キーワード', () => {
+    it('OUTPUT 句で WHEN 句群が終端 (SQL Server)', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a OUTPUT $action, inserted.id;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].assignments).toHaveLength(1);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('s.a');
+    });
+
+    it('OPTION 句で終端 (SQL Server)', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a OPTION (RECOMPILE);';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].assignments).toHaveLength(1);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('s.a');
+    });
+
+    it('RETURNING 句で終端 (PostgreSQL)', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a RETURNING *;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].assignments).toHaveLength(1);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('s.a');
+    });
+
+    it('; で終端', () => {
+      const sql = 'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = 1, b = 2;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].assignments).toHaveLength(2);
+      expect(slice(sql, updateTargets[0].assignments[1].value)).toBe('2');
+    });
+  });
+
+  describe('値の特殊パターン', () => {
+    it('関数呼び出し・式を含む値', () => {
+      const sql =
+        "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET name = COALESCE(s.name, 'unknown'), ts = NOW();";
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].assignments).toHaveLength(2);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe("COALESCE(s.name, 'unknown')");
+      expect(slice(sql, updateTargets[0].assignments[1].value)).toBe('NOW()');
+    });
+
+    it('文字列リテラル内のカンマは値区切りとみなさない', () => {
+      const sql =
+        "MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED THEN INSERT (a, b) VALUES ('x, y', 'z');";
+      const { insertTargets } = extractMergeTargets(sql);
+      expect(insertTargets[0].valueRows[0]).toHaveLength(2);
+      expect(slice(sql, insertTargets[0].valueRows[0][0])).toBe("'x, y'");
+      expect(slice(sql, insertTargets[0].valueRows[0][1])).toBe("'z'");
+    });
+
+    it('INSERT の複数行 VALUES は通常 MERGE では非対応 (1行想定)', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED THEN INSERT (a) VALUES (1);';
+      const { insertTargets } = extractMergeTargets(sql);
+      expect(insertTargets[0].valueRows).toHaveLength(1);
+      expect(insertTargets[0].valueRows[0]).toHaveLength(1);
+    });
+  });
+
+  describe('コメント', () => {
+    it('ブロックコメント内の MERGE は無視', () => {
+      const sql =
+        '/* MERGE INTO fake USING fakesrc ON true WHEN MATCHED THEN UPDATE SET x = 1 */ ' +
+        'MERGE INTO real USING src ON real.id = src.id WHEN MATCHED THEN UPDATE SET y = src.y;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('real');
+      expect(updateTargets[0].assignments[0].columnName).toBe('y');
+    });
+
+    it('行コメント内の MERGE は無視', () => {
+      const sql =
+        '-- MERGE INTO fake USING s ON true WHEN MATCHED THEN UPDATE SET z = 1\n' +
+        'MERGE INTO real USING s ON real.id = s.id WHEN MATCHED THEN UPDATE SET y = s.y;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('real');
+    });
+  });
+
+  describe('複数MERGE文', () => {
+    it('2つの MERGE 文を両方抽出', () => {
+      const sql =
+        'MERGE INTO t1 USING s ON t1.id = s.id WHEN MATCHED THEN UPDATE SET a = 1; ' +
+        'MERGE INTO t2 USING s ON t2.id = s.id WHEN NOT MATCHED THEN INSERT (x) VALUES (2);';
+      const { updateTargets, insertTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(insertTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('t1');
+      expect(insertTargets[0].tableName).toBe('t2');
+    });
+  });
+
+  describe('異常系', () => {
+    it('MERGE文なし - 空', () => {
+      const result = extractMergeTargets('SELECT * FROM t');
+      expect(result.insertTargets).toEqual([]);
+      expect(result.updateTargets).toEqual([]);
+    });
+
+    it('空文字列 - 空', () => {
+      const result = extractMergeTargets('');
+      expect(result.insertTargets).toEqual([]);
+      expect(result.updateTargets).toEqual([]);
+    });
+
+    it('WHEN 句なし (書きかけ) - 空', () => {
+      const result = extractMergeTargets('MERGE INTO t USING s ON t.id = s.id');
+      expect(result.insertTargets).toEqual([]);
+      expect(result.updateTargets).toEqual([]);
+    });
+
+    it('テーブル名なしの MERGE - 抽出しない', () => {
+      const result = extractMergeTargets(
+        'MERGE USING s ON true WHEN MATCHED THEN UPDATE SET a = 1'
+      );
+      expect(result.updateTargets).toEqual([]);
+    });
+  });
+
+  describe('実用的な MERGE クエリ (UPSERT パターン)', () => {
+    it('典型的な UPSERT (UPDATE + INSERT) パターン', () => {
+      const sql = `MERGE INTO target AS t
+USING (SELECT id, name, price FROM staging) AS s
+ON t.id = s.id
+WHEN MATCHED AND t.price <> s.price THEN
+  UPDATE SET name = s.name, price = s.price, updated_at = NOW()
+WHEN NOT MATCHED THEN
+  INSERT (id, name, price) VALUES (s.id, s.name, s.price);`;
+      const { updateTargets, insertTargets } = extractMergeTargets(sql);
+
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('target');
+      expect(updateTargets[0].assignments.map((a) => a.columnName)).toEqual([
+        'name',
+        'price',
+        'updated_at',
+      ]);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('s.name');
+      expect(slice(sql, updateTargets[0].assignments[1].value)).toBe('s.price');
+      expect(slice(sql, updateTargets[0].assignments[2].value)).toBe('NOW()');
+
+      expect(insertTargets).toHaveLength(1);
+      expect(insertTargets[0].tableName).toBe('target');
+      expect(insertTargets[0].columnNames).toEqual(['id', 'name', 'price']);
+      expect(slice(sql, insertTargets[0].valueRows[0][0])).toBe('s.id');
+      expect(slice(sql, insertTargets[0].valueRows[0][1])).toBe('s.name');
+      expect(slice(sql, insertTargets[0].valueRows[0][2])).toBe('s.price');
+    });
+
+    it('CASE 式を UPDATE SET の値として含む', () => {
+      const sql =
+        "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET status = CASE WHEN s.v > 0 THEN 'A' ELSE 'B' END, flag = 1;";
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].assignments).toHaveLength(2);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe(
+        "CASE WHEN s.v > 0 THEN 'A' ELSE 'B' END"
+      );
+      expect(slice(sql, updateTargets[0].assignments[1].value)).toBe('1');
+    });
+
+    it('サブクエリを UPDATE SET の値として含む', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET total = (SELECT SUM(x) FROM items WHERE items.tid = t.id);';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets[0].assignments).toHaveLength(1);
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe(
+        '(SELECT SUM(x) FROM items WHERE items.tid = t.id)'
+      );
+    });
+
+    it('USING (SELECT ...) - source がサブクエリ (実用で頻出)', () => {
+      const sql =
+        'MERGE INTO users t USING (SELECT id, name FROM staging WHERE active = 1) s ON t.id = s.id WHEN MATCHED THEN UPDATE SET name = s.name;';
+      const { updateTargets } = extractMergeTargets(sql);
+      expect(updateTargets).toHaveLength(1);
+      expect(updateTargets[0].tableName).toBe('users');
+      expect(updateTargets[0].assignments[0].columnName).toBe('name');
+      expect(slice(sql, updateTargets[0].assignments[0].value)).toBe('s.name');
+    });
+
+    it('ラベル↔値の因果: 多列 UPDATE で各値 offset が左辺カラムに対応', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET col_a = 10, col_b = 20, col_c = 30;';
+      const { updateTargets } = extractMergeTargets(sql);
+      const a = updateTargets[0].assignments;
+      expect(a[0].columnName).toBe('col_a');
+      expect(a[0].value.offset).toBe(sql.indexOf('10'));
+      expect(a[1].columnName).toBe('col_b');
+      expect(a[1].value.offset).toBe(sql.indexOf('20'));
+      expect(a[2].columnName).toBe('col_c');
+      expect(a[2].value.offset).toBe(sql.indexOf('30'));
+    });
+
+    it('ラベル↔値の因果: INSERT VALUES 各値 offset が columnNames 順に対応', () => {
+      const sql =
+        'MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED THEN INSERT (ca, cb, cc) VALUES (111, 222, 333);';
+      const { insertTargets } = extractMergeTargets(sql);
+      const row = insertTargets[0].valueRows[0];
+      expect(insertTargets[0].columnNames).toEqual(['ca', 'cb', 'cc']);
+      expect(row[0].offset).toBe(sql.indexOf('111'));
+      expect(row[1].offset).toBe(sql.indexOf('222'));
+      expect(row[2].offset).toBe(sql.indexOf('333'));
+    });
+  });
+});

--- a/frontend/src/utils/insertHintExtractor.ts
+++ b/frontend/src/utils/insertHintExtractor.ts
@@ -1,90 +1,18 @@
+import { readColumnList, readValueTuple, type ValuePosition } from './sqlDmlParser';
 import {
   normalizeForParsing,
-  readIdentifier,
   readKeyword,
   readQualifiedName,
   skipWs,
   unwrapIdentifier,
-  WS,
 } from './sqlTokenParser';
 
-export interface InsertValuePosition {
-  offset: number;
-  length: number;
-}
+export type InsertValuePosition = ValuePosition;
 
 export interface InsertTarget {
   tableName: string;
   columnNames: string[] | null;
   valueRows: InsertValuePosition[][];
-}
-
-function readColumnList(s: string, i: number): { columns: string[]; end: number } | null {
-  if (s[i] !== '(') return null;
-  let cur = skipWs(s, i + 1);
-  const columns: string[] = [];
-  while (cur < s.length && s[cur] !== ')') {
-    const r = readIdentifier(s, cur);
-    if (!r) return null;
-    columns.push(unwrapIdentifier(r.ident));
-    cur = skipWs(s, r.end);
-    if (s[cur] === ',') {
-      cur = skipWs(s, cur + 1);
-      continue;
-    }
-    if (s[cur] === ')') break;
-    return null;
-  }
-  if (s[cur] !== ')') return null;
-  return { columns, end: cur + 1 };
-}
-
-function readValueTuple(
-  scan: string,
-  original: string,
-  i: number
-): { values: InsertValuePosition[]; end: number } | null {
-  if (scan[i] !== '(') return null;
-  let cur = i + 1;
-  cur = skipWs(original, cur);
-  let valueStart = cur;
-  const values: InsertValuePosition[] = [];
-  let depth = 1;
-
-  const flush = (end: number) => {
-    let valueEnd = end;
-    while (valueEnd > valueStart && WS.test(original[valueEnd - 1])) valueEnd--;
-    if (valueEnd > valueStart) {
-      values.push({ offset: valueStart, length: valueEnd - valueStart });
-    }
-  };
-
-  while (cur < scan.length) {
-    const c = scan[cur];
-    if (c === '(') {
-      depth++;
-      cur++;
-      continue;
-    }
-    if (c === ')') {
-      depth--;
-      if (depth === 0) {
-        flush(cur);
-        return { values, end: cur + 1 };
-      }
-      cur++;
-      continue;
-    }
-    if (c === ',' && depth === 1) {
-      flush(cur);
-      cur++;
-      cur = skipWs(original, cur);
-      valueStart = cur;
-      continue;
-    }
-    cur++;
-  }
-  return null;
 }
 
 const INSERT_INTO_RE = /\bINSERT\s+INTO\s+/gi;

--- a/frontend/src/utils/mergeHintExtractor.ts
+++ b/frontend/src/utils/mergeHintExtractor.ts
@@ -1,0 +1,280 @@
+import type { InsertTarget } from './insertHintExtractor';
+import { readAssignments, readColumnList, readValueTuple } from './sqlDmlParser';
+import {
+  normalizeForParsing,
+  readIdentifier,
+  readKeyword,
+  readQualifiedName,
+  skipWs,
+  unwrapIdentifier,
+} from './sqlTokenParser';
+import type { UpdateTarget } from './updateHintExtractor';
+
+const MERGE_RE = /\bMERGE\s+/gi;
+
+/**
+ * MERGE の WHEN 句群の終端キーワード。
+ * - SQL Server: `OUTPUT`, `OPTION`
+ * - PostgreSQL: `RETURNING`
+ * - 共通: `;` / EOF (呼び出し側でも判定)
+ */
+const MERGE_END_KEYWORDS = ['OUTPUT', 'OPTION', 'RETURNING'] as const;
+
+function isMergeEnd(scan: string, i: number): boolean {
+  if (i >= scan.length) return true;
+  if (scan[i] === ';') return true;
+  for (const kw of MERGE_END_KEYWORDS) {
+    if (readKeyword(scan, i, kw) !== null) return true;
+  }
+  return false;
+}
+
+/**
+ * WHEN 句内 UPDATE SET の終端: 次の `WHEN` 句、MERGE 全体の終端、または `;`。
+ */
+function isMergeSetTerminator(scan: string, i: number): boolean {
+  if (i >= scan.length) return true;
+  if (scan[i] === ';') return true;
+  if (readKeyword(scan, i, 'WHEN') !== null) return true;
+  for (const kw of MERGE_END_KEYWORDS) {
+    if (readKeyword(scan, i, kw) !== null) return true;
+  }
+  return false;
+}
+
+/**
+ * `(` から対応する `)` の直後までスキップ。ネスト対応。
+ * `)` が見つからない場合は終端 (length) を返す。
+ */
+function skipParenBlock(scan: string, i: number): number {
+  if (scan[i] !== '(') return i;
+  let cur = i + 1;
+  let depth = 1;
+  while (cur < scan.length && depth > 0) {
+    const c = scan[cur];
+    if (c === '(') depth++;
+    else if (c === ')') depth--;
+    cur++;
+  }
+  return cur;
+}
+
+/**
+ * `WITH ( ... )` テーブルヒントまたはエイリアス (`AS alias` / `alias`) をスキップする。
+ * USING キーワードの手前まで進める。
+ */
+function skipToUsing(scan: string, i: number): number | null {
+  let cur = i;
+  while (cur < scan.length) {
+    cur = skipWs(scan, cur);
+    const afterUsing = readKeyword(scan, cur, 'USING');
+    if (afterUsing !== null) return afterUsing;
+    if (scan[cur] === '(') {
+      cur = skipParenBlock(scan, cur);
+      continue;
+    }
+    const ident = readIdentifier(scan, cur);
+    if (ident) {
+      cur = ident.end;
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
+ * USING 句以降の `ON <condition>` をスキップし、最初の `WHEN` キーワードの位置を返す。
+ * MERGE 終端 (`;` / `OUTPUT` / `OPTION` / `RETURNING` / EOF) に先に到達した場合は null。
+ */
+function skipToFirstWhen(scan: string, startIdx: number): number | null {
+  let cur = startIdx;
+  let depth = 0;
+  while (cur < scan.length) {
+    const c = scan[cur];
+    if (c === '(') {
+      depth++;
+      cur++;
+      continue;
+    }
+    if (c === ')') {
+      if (depth > 0) depth--;
+      cur++;
+      continue;
+    }
+    if (depth === 0) {
+      if (isMergeEnd(scan, cur)) return null;
+      const afterWhen = readKeyword(scan, cur, 'WHEN');
+      if (afterWhen !== null) return cur;
+    }
+    cur++;
+  }
+  return null;
+}
+
+/**
+ * `WHEN [NOT] MATCHED [BY TARGET|BY SOURCE] [AND <cond>] THEN` を読み飛ばし、
+ * THEN の直後のオフセットを返す。`WHEN` キーワード位置 `whenStart` を受け取る。
+ * 解析失敗時は null。
+ */
+function skipWhenHeader(scan: string, whenStart: number): number | null {
+  const afterWhen = readKeyword(scan, whenStart, 'WHEN');
+  if (afterWhen === null) return null;
+  let cur = skipWs(scan, afterWhen);
+
+  const afterNot = readKeyword(scan, cur, 'NOT');
+  if (afterNot !== null) cur = skipWs(scan, afterNot);
+
+  const afterMatched = readKeyword(scan, cur, 'MATCHED');
+  if (afterMatched === null) return null;
+  cur = skipWs(scan, afterMatched);
+
+  const afterBy = readKeyword(scan, cur, 'BY');
+  if (afterBy !== null) {
+    cur = skipWs(scan, afterBy);
+    const afterTarget = readKeyword(scan, cur, 'TARGET');
+    const afterSource = afterTarget === null ? readKeyword(scan, cur, 'SOURCE') : null;
+    if (afterTarget !== null) cur = skipWs(scan, afterTarget);
+    else if (afterSource !== null) cur = skipWs(scan, afterSource);
+    else return null;
+  }
+
+  // THEN まで識別子/括弧/演算子を読み飛ばす (AND cond を含む)
+  let depth = 0;
+  while (cur < scan.length) {
+    if (scan[cur] === '(') {
+      depth++;
+      cur++;
+      continue;
+    }
+    if (scan[cur] === ')') {
+      if (depth > 0) depth--;
+      cur++;
+      continue;
+    }
+    if (depth === 0) {
+      const afterThen = readKeyword(scan, cur, 'THEN');
+      if (afterThen !== null) return afterThen;
+    }
+    cur++;
+  }
+  return null;
+}
+
+interface WhenActionResult {
+  update?: { assignments: ReturnType<typeof readAssignments> };
+  insert?: { columnNames: string[] | null; values: ReturnType<typeof readValueTuple> };
+  next: number;
+}
+
+function parseWhenAction(
+  scan: string,
+  original: string,
+  afterThen: number
+): WhenActionResult | null {
+  let cur = skipWs(scan, afterThen);
+
+  const afterUpdate = readKeyword(scan, cur, 'UPDATE');
+  if (afterUpdate !== null) {
+    cur = skipWs(scan, afterUpdate);
+    const afterSet = readKeyword(scan, cur, 'SET');
+    if (afterSet === null) return null;
+    const assignments = readAssignments(scan, original, afterSet, isMergeSetTerminator);
+    // 終端位置を求めるため走査
+    let next = skipWs(scan, afterSet);
+    while (next < scan.length && !isMergeSetTerminator(scan, next)) next++;
+    return { update: { assignments }, next };
+  }
+
+  const afterInsert = readKeyword(scan, cur, 'INSERT');
+  if (afterInsert !== null) {
+    cur = skipWs(scan, afterInsert);
+    let columnNames: string[] | null = null;
+    if (scan[cur] === '(') {
+      const colResult = readColumnList(scan, cur);
+      if (!colResult) return null;
+      columnNames = colResult.columns;
+      cur = skipWs(scan, colResult.end);
+    }
+    const afterValues = readKeyword(scan, cur, 'VALUES');
+    if (afterValues === null) return null;
+    cur = skipWs(scan, afterValues);
+    const tuple = readValueTuple(scan, original, cur);
+    if (!tuple) return null;
+    return {
+      insert: { columnNames, values: tuple },
+      next: tuple.end,
+    };
+  }
+
+  // DELETE / DO NOTHING / 不明 - 次の WHEN / 終端までスキップ
+  while (cur < scan.length) {
+    if (isMergeEnd(scan, cur) || readKeyword(scan, cur, 'WHEN') !== null) break;
+    cur++;
+  }
+  return { next: cur };
+}
+
+export interface MergeExtractResult {
+  insertTargets: InsertTarget[];
+  updateTargets: UpdateTarget[];
+}
+
+/**
+ * SQL から MERGE 文を解析し、各 WHEN 句の UPDATE SET / INSERT VALUES を
+ * 既存の InsertTarget / UpdateTarget 型で返す。tableName は MERGE INTO のターゲット名を継承。
+ * DELETE / DO NOTHING 句は無視。
+ * 対応方言: SQL Server (OUTPUT/OPTION 終端), PostgreSQL 15+ (RETURNING 終端)。
+ */
+export function extractMergeTargets(sql: string): MergeExtractResult {
+  const result: MergeExtractResult = { insertTargets: [], updateTargets: [] };
+  if (!sql) return result;
+
+  const scan = normalizeForParsing(sql);
+
+  for (const match of scan.matchAll(MERGE_RE)) {
+    const start = match.index + match[0].length;
+    let cur = skipWs(scan, start);
+
+    const afterInto = readKeyword(scan, cur, 'INTO');
+    if (afterInto !== null) cur = skipWs(scan, afterInto);
+
+    const nameResult = readQualifiedName(scan, cur);
+    if (!nameResult) continue;
+    const tableName = nameResult.parts.map(unwrapIdentifier).join('.');
+    cur = skipWs(scan, nameResult.end);
+
+    const usingStart = skipToUsing(scan, cur);
+    if (usingStart === null) continue;
+
+    const whenStart = skipToFirstWhen(scan, usingStart);
+    if (whenStart === null) continue;
+
+    cur = whenStart;
+    while (cur < scan.length && !isMergeEnd(scan, cur)) {
+      const afterThen = skipWhenHeader(scan, cur);
+      if (afterThen === null) break;
+
+      const action = parseWhenAction(scan, sql, afterThen);
+      if (!action) break;
+
+      if (action.update && action.update.assignments.length > 0) {
+        result.updateTargets.push({
+          tableName,
+          assignments: action.update.assignments,
+        });
+      }
+      if (action.insert) {
+        result.insertTargets.push({
+          tableName,
+          columnNames: action.insert.columnNames,
+          valueRows: [action.insert.values.values],
+        });
+      }
+
+      cur = skipWs(scan, action.next);
+    }
+  }
+
+  return result;
+}

--- a/frontend/src/utils/mergeHintExtractor.ts
+++ b/frontend/src/utils/mergeHintExtractor.ts
@@ -1,5 +1,11 @@
 import type { InsertTarget } from './insertHintExtractor';
-import { readAssignments, readColumnList, readValueTuple } from './sqlDmlParser';
+import {
+  type Assignment,
+  readAssignments,
+  readColumnList,
+  readValueTuple,
+  type ValuePosition,
+} from './sqlDmlParser';
 import {
   normalizeForParsing,
   readIdentifier,
@@ -162,8 +168,8 @@ function skipWhenHeader(scan: string, whenStart: number): number | null {
 }
 
 interface WhenActionResult {
-  update?: { assignments: ReturnType<typeof readAssignments> };
-  insert?: { columnNames: string[] | null; values: ReturnType<typeof readValueTuple> };
+  update?: { assignments: Assignment[] };
+  insert?: { columnNames: string[] | null; values: ValuePosition[] };
   next: number;
 }
 
@@ -202,7 +208,7 @@ function parseWhenAction(
     const tuple = readValueTuple(scan, original, cur);
     if (!tuple) return null;
     return {
-      insert: { columnNames, values: tuple },
+      insert: { columnNames, values: tuple.values },
       next: tuple.end,
     };
   }
@@ -268,7 +274,7 @@ export function extractMergeTargets(sql: string): MergeExtractResult {
         result.insertTargets.push({
           tableName,
           columnNames: action.insert.columnNames,
-          valueRows: [action.insert.values.values],
+          valueRows: [action.insert.values],
         });
       }
 

--- a/frontend/src/utils/sqlDmlParser.ts
+++ b/frontend/src/utils/sqlDmlParser.ts
@@ -1,0 +1,171 @@
+import { readIdentifier, skipWs, unwrapIdentifier, WS } from './sqlTokenParser';
+
+export interface ValuePosition {
+  offset: number;
+  length: number;
+}
+
+export interface Assignment {
+  columnName: string;
+  value: ValuePosition;
+}
+
+export type TerminatorCheck = (scan: string, i: number) => boolean;
+
+export function readColumnList(s: string, i: number): { columns: string[]; end: number } | null {
+  if (s[i] !== '(') return null;
+  let cur = skipWs(s, i + 1);
+  const columns: string[] = [];
+  while (cur < s.length && s[cur] !== ')') {
+    const r = readIdentifier(s, cur);
+    if (!r) return null;
+    columns.push(unwrapIdentifier(r.ident));
+    cur = skipWs(s, r.end);
+    if (s[cur] === ',') {
+      cur = skipWs(s, cur + 1);
+      continue;
+    }
+    if (s[cur] === ')') break;
+    return null;
+  }
+  if (s[cur] !== ')') return null;
+  return { columns, end: cur + 1 };
+}
+
+export function readValueTuple(
+  scan: string,
+  original: string,
+  i: number
+): { values: ValuePosition[]; end: number } | null {
+  if (scan[i] !== '(') return null;
+  let cur = i + 1;
+  cur = skipWs(original, cur);
+  let valueStart = cur;
+  const values: ValuePosition[] = [];
+  let depth = 1;
+
+  const flush = (end: number) => {
+    let valueEnd = end;
+    while (valueEnd > valueStart && WS.test(original[valueEnd - 1])) valueEnd--;
+    if (valueEnd > valueStart) {
+      values.push({ offset: valueStart, length: valueEnd - valueStart });
+    }
+  };
+
+  while (cur < scan.length) {
+    const c = scan[cur];
+    if (c === '(') {
+      depth++;
+      cur++;
+      continue;
+    }
+    if (c === ')') {
+      depth--;
+      if (depth === 0) {
+        flush(cur);
+        return { values, end: cur + 1 };
+      }
+      cur++;
+      continue;
+    }
+    if (c === ',' && depth === 1) {
+      flush(cur);
+      cur++;
+      cur = skipWs(original, cur);
+      valueStart = cur;
+      continue;
+    }
+    cur++;
+  }
+  return null;
+}
+
+function findValueEnd(scan: string, start: number, isTerminator: TerminatorCheck): number {
+  let cur = start;
+  let depth = 0;
+  while (cur < scan.length) {
+    const c = scan[cur];
+    if (c === '(') {
+      depth++;
+      cur++;
+      continue;
+    }
+    if (c === ')') {
+      if (depth === 0) return cur;
+      depth--;
+      cur++;
+      continue;
+    }
+    if (depth === 0) {
+      if (c === ',' || c === ';') return cur;
+      if (isTerminator(scan, cur)) return cur;
+    }
+    cur++;
+  }
+  return cur;
+}
+
+interface ReadAssignmentResult {
+  assignment: Assignment | null;
+  next: number;
+  done: boolean;
+}
+
+function readSingleAssignment(
+  scan: string,
+  original: string,
+  cur: number,
+  isTerminator: TerminatorCheck
+): ReadAssignmentResult {
+  const idResult = readIdentifier(scan, cur);
+  if (!idResult) return { assignment: null, next: cur, done: true };
+  const columnName = unwrapIdentifier(idResult.ident);
+  const afterId = skipWs(scan, idResult.end);
+
+  if (scan[afterId] !== '=') {
+    const skipTo = findValueEnd(scan, afterId, isTerminator);
+    if (scan[skipTo] !== ',') return { assignment: null, next: skipTo, done: true };
+    return { assignment: null, next: skipWs(scan, skipTo + 1), done: false };
+  }
+
+  const valStart = skipWs(original, afterId + 1);
+  const valEnd = findValueEnd(scan, valStart, isTerminator);
+
+  let trimmedEnd = valEnd;
+  while (trimmedEnd > valStart && WS.test(original[trimmedEnd - 1])) trimmedEnd--;
+
+  const assignment =
+    trimmedEnd > valStart
+      ? { columnName, value: { offset: valStart, length: trimmedEnd - valStart } }
+      : null;
+
+  if (scan[valEnd] === ',') {
+    return { assignment, next: skipWs(scan, valEnd + 1), done: false };
+  }
+  return { assignment, next: valEnd, done: true };
+}
+
+/**
+ * SET 句の代入リストを解析する。`col = expr, col = expr, ...` を走査し、
+ * `isTerminator` が true を返す位置または `;` / EOF で停止する。
+ * `=` のない項目はスキップ、値が空の項目も除外される。
+ */
+export function readAssignments(
+  scan: string,
+  original: string,
+  startIdx: number,
+  isTerminator: TerminatorCheck
+): Assignment[] {
+  const assignments: Assignment[] = [];
+  let cur = skipWs(scan, startIdx);
+
+  while (cur < scan.length) {
+    if (isTerminator(scan, cur)) break;
+    const { assignment, next, done } = readSingleAssignment(scan, original, cur, isTerminator);
+    if (assignment) assignments.push(assignment);
+    if (done) break;
+    cur = next;
+  }
+
+  return assignments;
+}

--- a/frontend/src/utils/sqlDmlParser.ts
+++ b/frontend/src/utils/sqlDmlParser.ts
@@ -1,4 +1,4 @@
-import { readIdentifier, skipWs, unwrapIdentifier, WS } from './sqlTokenParser';
+import { readIdentifier, readKeyword, skipWs, unwrapIdentifier, WS } from './sqlTokenParser';
 
 export interface ValuePosition {
   offset: number;
@@ -83,6 +83,7 @@ export function readValueTuple(
 function findValueEnd(scan: string, start: number, isTerminator: TerminatorCheck): number {
   let cur = start;
   let depth = 0;
+  let caseDepth = 0;
   while (cur < scan.length) {
     const c = scan[cur];
     if (c === '(') {
@@ -97,6 +98,22 @@ function findValueEnd(scan: string, start: number, isTerminator: TerminatorCheck
       continue;
     }
     if (depth === 0) {
+      const afterCase = readKeyword(scan, cur, 'CASE');
+      if (afterCase !== null) {
+        caseDepth++;
+        cur = afterCase;
+        continue;
+      }
+      if (caseDepth > 0) {
+        const afterEnd = readKeyword(scan, cur, 'END');
+        if (afterEnd !== null) {
+          caseDepth--;
+          cur = afterEnd;
+          continue;
+        }
+        cur++;
+        continue;
+      }
       if (c === ',' || c === ';') return cur;
       if (isTerminator(scan, cur)) return cur;
     }

--- a/frontend/src/utils/updateHintExtractor.ts
+++ b/frontend/src/utils/updateHintExtractor.ts
@@ -1,3 +1,4 @@
+import { type Assignment, readAssignments, type ValuePosition } from './sqlDmlParser';
 import {
   normalizeForParsing,
   readIdentifier,
@@ -8,15 +9,8 @@ import {
   WS,
 } from './sqlTokenParser';
 
-export interface UpdateValuePosition {
-  offset: number;
-  length: number;
-}
-
-export interface UpdateAssignment {
-  columnName: string;
-  value: UpdateValuePosition;
-}
+export type UpdateValuePosition = ValuePosition;
+export type UpdateAssignment = Assignment;
 
 export interface UpdateTarget {
   tableName: string;
@@ -57,81 +51,6 @@ function skipToSetKeyword(scan: string, i: number): number | null {
   return null;
 }
 
-function findValueEnd(scan: string, start: number): number {
-  let cur = start;
-  let depth = 0;
-  while (cur < scan.length) {
-    const c = scan[cur];
-    if (c === '(') {
-      depth++;
-      cur++;
-      continue;
-    }
-    if (c === ')') {
-      if (depth === 0) return cur;
-      depth--;
-      cur++;
-      continue;
-    }
-    if (depth === 0) {
-      if (c === ',' || c === ';') return cur;
-      if (isSetClauseTerminator(scan, cur)) return cur;
-    }
-    cur++;
-  }
-  return cur;
-}
-
-interface ReadAssignmentResult {
-  assignment: UpdateAssignment | null;
-  next: number;
-  done: boolean;
-}
-
-function readSingleAssignment(scan: string, original: string, cur: number): ReadAssignmentResult {
-  const idResult = readIdentifier(scan, cur);
-  if (!idResult) return { assignment: null, next: cur, done: true };
-  const columnName = unwrapIdentifier(idResult.ident);
-  const afterId = skipWs(scan, idResult.end);
-
-  if (scan[afterId] !== '=') {
-    const skipTo = findValueEnd(scan, afterId);
-    if (scan[skipTo] !== ',') return { assignment: null, next: skipTo, done: true };
-    return { assignment: null, next: skipWs(scan, skipTo + 1), done: false };
-  }
-
-  const valStart = skipWs(original, afterId + 1);
-  const valEnd = findValueEnd(scan, valStart);
-
-  let trimmedEnd = valEnd;
-  while (trimmedEnd > valStart && WS.test(original[trimmedEnd - 1])) trimmedEnd--;
-
-  const assignment =
-    trimmedEnd > valStart
-      ? { columnName, value: { offset: valStart, length: trimmedEnd - valStart } }
-      : null;
-
-  if (scan[valEnd] === ',') {
-    return { assignment, next: skipWs(scan, valEnd + 1), done: false };
-  }
-  return { assignment, next: valEnd, done: true };
-}
-
-function readAssignments(scan: string, original: string, startIdx: number): UpdateAssignment[] {
-  const assignments: UpdateAssignment[] = [];
-  let cur = skipWs(scan, startIdx);
-
-  while (cur < scan.length) {
-    if (isSetClauseTerminator(scan, cur)) break;
-    const { assignment, next, done } = readSingleAssignment(scan, original, cur);
-    if (assignment) assignments.push(assignment);
-    if (done) break;
-    cur = next;
-  }
-
-  return assignments;
-}
-
 /**
  * SQL から UPDATE 文の SET 句を解析し、各代入の左辺カラム名と右辺値の位置情報を返す。
  * コメント・文字列リテラルは normalize 時に空白化され、値区切りとして誤認しない。
@@ -155,7 +74,7 @@ export function extractUpdateTargets(sql: string): UpdateTarget[] {
     const afterSet = skipToSetKeyword(scan, cur);
     if (afterSet === null) continue;
 
-    const assignments = readAssignments(scan, sql, afterSet);
+    const assignments = readAssignments(scan, sql, afterSet, isSetClauseTerminator);
     if (assignments.length === 0) continue;
 
     targets.push({ tableName, assignments });


### PR DESCRIPTION
- mergeHintExtractor を新規追加 (SQL Server/PostgreSQL 15+ 対応)
- `WHEN MATCHED THEN UPDATE SET` / `WHEN NOT MATCHED THEN INSERT (cols) VALUES (vals)`
- `BY TARGET/BY SOURCE`、AND 条件、`WITH (NOLOCK)`、`INTO 省略`、`OUTPUT/OPTION/RETURNING` 終端対応
- DML 共通パーサ sqlDmlParser.ts を分離し、既存 insert/update Extractor も共通化
- 実用UPSERTパターンを含む 36 tests 追加

Closes #384