### PR TITLE
fix: クエリタイムアウト設定の全経路を整備

### DIFF
--- a/backend/contexts/system_context.cpp
+++ b/backend/contexts/system_context.cpp
@@ -25,7 +25,7 @@ SystemContext::SystemContext()
     , m_exports(std::make_unique<ExportProvider>(*m_connections))
     , m_search(std::make_unique<SearchProvider>(*m_connections))
     , m_utility(std::make_unique<UtilityProvider>())
-    , m_settings(std::make_unique<SettingsProvider>())
+    , m_settings(std::make_unique<SettingsProvider>(m_connections.get()))
     , m_io(std::make_unique<IOProvider>())
     , m_lint(std::make_unique<LintProvider>()) {}
 

--- a/backend/database/connection_registry.cpp
+++ b/backend/database/connection_registry.cpp
@@ -125,6 +125,15 @@ SshTunnel* ConnectionRegistry::getTunnel(std::string_view connectionId) const {
     return nullptr;
 }
 
+void ConnectionRegistry::forEachQueryDriver(const std::function<void(IDatabaseDriver&)>& fn) const {
+    std::shared_lock lock(m_mutex);
+    for (const auto& [id, entry] : m_connections) {
+        if (entry.queryDriver) {
+            fn(*entry.queryDriver);
+        }
+    }
+}
+
 void ConnectionRegistry::clear() {
     std::lock_guard lock(m_mutex);
 

--- a/backend/database/connection_registry.h
+++ b/backend/database/connection_registry.h
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <expected>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <shared_mutex>
@@ -67,6 +68,10 @@ public:
 
     /// Remove and close all connections
     void clear();
+
+    /// Invoke callback for each active query driver (under read lock).
+    /// Used to propagate settings changes (e.g. query timeout) to all live connections.
+    void forEachQueryDriver(const std::function<void(IDatabaseDriver&)>& fn) const;
 
 private:
     struct ConnectionEntry {

--- a/backend/interfaces/providers/connection_provider.h
+++ b/backend/interfaces/providers/connection_provider.h
@@ -32,6 +32,10 @@ public:
 
     /// Get stored effective connection parameters (for psql delegation)
     [[nodiscard]] virtual std::optional<DatabaseConnectionParams> getConnectionParams(std::string_view connectionId) const = 0;
+
+    /// Set default query timeout (seconds) applied to newly-registered drivers,
+    /// and propagate to all currently active query drivers.
+    virtual void setDefaultQueryTimeoutSeconds(int seconds) = 0;
 };
 
 }  // namespace velocitydb

--- a/backend/providers/connection_provider.cpp
+++ b/backend/providers/connection_provider.cpp
@@ -7,6 +7,7 @@
 #include "../utils/json_utils.h"
 #include "simdjson.h"
 
+#include <chrono>
 #include <format>
 
 namespace velocitydb {
@@ -38,6 +39,11 @@ DriverType ConnectionProvider::getDriverType(std::string_view connectionId) cons
 
 std::optional<DatabaseConnectionParams> ConnectionProvider::getConnectionParams(std::string_view connectionId) const {
     return m_registry->getParams(connectionId);
+}
+
+void ConnectionProvider::setDefaultQueryTimeoutSeconds(int seconds) {
+    m_queryTimeoutSeconds.store(seconds, std::memory_order_relaxed);
+    m_registry->forEachQueryDriver([seconds](IDatabaseDriver& driver) { driver.setQueryTimeout(std::chrono::seconds(seconds)); });
 }
 
 std::string ConnectionProvider::disconnect(std::string_view params) {
@@ -97,6 +103,10 @@ std::string ConnectionProvider::getConnectResult(std::string_view params) {
         // Connected: drivers consumed atomically
         if (result.has_value()) {
             auto& drivers = *result;
+            // Apply current query timeout before registering so first execute() picks it up.
+            // metadataDriver keeps the driver default (short metadata lookups don't need tuning).
+            auto timeoutSec = m_queryTimeoutSeconds.load(std::memory_order_relaxed);
+            drivers.queryDriver->setQueryTimeout(std::chrono::seconds(timeoutSec));
             auto connectionId = m_registry->add(drivers.queryDriver, drivers.metadataDriver, drivers.queryDriver->getType());
             m_registry->storeParams(connectionId, drivers.effectiveParams);
             if (drivers.tunnel) {

--- a/backend/providers/connection_provider.h
+++ b/backend/providers/connection_provider.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "../interfaces/providers/connection_provider.h"
+#include "../utils/settings_manager.h"
 
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <string>
@@ -36,9 +38,12 @@ public:
     [[nodiscard]] DriverType getDriverType(std::string_view connectionId) const override;
     [[nodiscard]] std::optional<DatabaseConnectionParams> getConnectionParams(std::string_view connectionId) const override;
 
+    void setDefaultQueryTimeoutSeconds(int seconds) override;
+
 private:
     std::unique_ptr<ConnectionRegistry> m_registry;
     std::unique_ptr<AsyncConnectionExecutor> m_asyncExecutor;
+    std::atomic<int> m_queryTimeoutSeconds{kQueryTimeoutDefaultSec};
 };
 
 }  // namespace velocitydb

--- a/backend/providers/settings_provider.cpp
+++ b/backend/providers/settings_provider.cpp
@@ -1,5 +1,6 @@
 #include "settings_provider.h"
 
+#include "../interfaces/providers/connection_provider.h"
 #include "../utils/glaze_meta.h"
 #include "../utils/json_utils.h"
 #include "../utils/session_manager.h"
@@ -151,9 +152,17 @@ namespace {
 
 }  // namespace
 
-SettingsProvider::SettingsProvider() : m_settingsManager(std::make_unique<SettingsManager>()), m_sessionManager(std::make_unique<SessionManager>()) {
+SettingsProvider::SettingsProvider(IConnectionProvider* connections)
+    : m_settingsManager(std::make_unique<SettingsManager>()), m_sessionManager(std::make_unique<SessionManager>()), m_connections(connections) {
     (void)m_settingsManager->load();
     (void)m_sessionManager->load();
+    applyQueryTimeoutToConnections(m_settingsManager->getSettings().query.timeoutSeconds);
+}
+
+void SettingsProvider::applyQueryTimeoutToConnections(int seconds) {
+    if (m_connections) {
+        m_connections->setDefaultQueryTimeoutSeconds(seconds);
+    }
 }
 
 SettingsProvider::~SettingsProvider() = default;
@@ -212,7 +221,7 @@ std::string SettingsProvider::updateSettings(std::string_view params) {
 
         if (auto query = doc["query"]; !query.error()) {
             if (auto val = query["timeoutSeconds"].get_int64(); !val.error())
-                settings.query.timeoutSeconds = std::clamp(narrowToInt(val.value()), 1, 600);
+                settings.query.timeoutSeconds = std::clamp(narrowToInt(val.value()), kQueryTimeoutMinSec, kQueryTimeoutMaxSec);
         }
 
         if (auto window = doc["window"]; !window.error()) {
@@ -230,6 +239,8 @@ std::string SettingsProvider::updateSettings(std::string_view params) {
 
         m_settingsManager->updateSettings(settings);
         (void)m_settingsManager->save();
+
+        applyQueryTimeoutToConnections(settings.query.timeoutSeconds);
 
         return JsonUtils::successResponse(R"({"saved":true})");
     } catch (const std::exception& e) {

--- a/backend/providers/settings_provider.h
+++ b/backend/providers/settings_provider.h
@@ -10,11 +10,14 @@ namespace velocitydb {
 
 class SettingsManager;
 class SessionManager;
+class IConnectionProvider;
 
 /// Provider for application settings and session management
 class SettingsProvider : public ISettingsProvider {
 public:
-    SettingsProvider();
+    /// @param connections Used to propagate query.timeoutSeconds changes to active drivers.
+    ///                    May be nullptr for unit tests that don't exercise timeout propagation.
+    explicit SettingsProvider(IConnectionProvider* connections = nullptr);
     ~SettingsProvider() override;
 
     SettingsProvider(const SettingsProvider&) = delete;
@@ -39,8 +42,11 @@ public:
     [[nodiscard]] const SessionManager& sessionManager() const { return *m_sessionManager; }
 
 private:
+    void applyQueryTimeoutToConnections(int seconds);
+
     std::unique_ptr<SettingsManager> m_settingsManager;
     std::unique_ptr<SessionManager> m_sessionManager;
+    IConnectionProvider* m_connections;  // Non-owning; may be null in tests
 };
 
 }  // namespace velocitydb

--- a/backend/utils/settings_manager.h
+++ b/backend/utils/settings_manager.h
@@ -71,8 +71,12 @@ struct GeneralSettings {
     std::string language = "en";
 };
 
+inline constexpr int kQueryTimeoutMinSec = 1;
+inline constexpr int kQueryTimeoutMaxSec = 3600;
+inline constexpr int kQueryTimeoutDefaultSec = 300;
+
 struct QuerySettings {
-    int timeoutSeconds = 30;
+    int timeoutSeconds = kQueryTimeoutDefaultSec;
 };
 
 struct WindowSettings {

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import styles from './SettingsDialog.module.css';
-import { type AppSettings, defaultSettings } from './settingsUtils';
+import {
+  type AppSettings,
+  defaultSettings,
+  QUERY_TIMEOUT_DEFAULT_SEC,
+  QUERY_TIMEOUT_MAX_SEC,
+  QUERY_TIMEOUT_MIN_SEC,
+} from './settingsUtils';
 
 interface SettingsDialogProps {
   isOpen: boolean;
@@ -176,20 +182,19 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
                   </label>
                 </div>
                 <div className={styles.setting}>
-                  <label>クエリタイムアウト (ms)</label>
+                  <label htmlFor="setting-query-timeout-sec">クエリタイムアウト (秒)</label>
                   <input
+                    id="setting-query-timeout-sec"
                     type="number"
-                    value={settings.query.timeout}
-                    onChange={(e) =>
-                      updateSetting(
-                        'query',
-                        'timeout',
-                        Number.parseInt(e.target.value, 10) || 30000
-                      )
-                    }
-                    min={1000}
-                    max={600000}
-                    step={1000}
+                    value={Math.round(settings.query.timeout / 1000)}
+                    onChange={(e) => {
+                      const parsed = Number.parseInt(e.target.value, 10);
+                      const sec = Number.isFinite(parsed) ? parsed : QUERY_TIMEOUT_DEFAULT_SEC;
+                      updateSetting('query', 'timeout', sec * 1000);
+                    }}
+                    min={QUERY_TIMEOUT_MIN_SEC}
+                    max={QUERY_TIMEOUT_MAX_SEC}
+                    step={60}
                   />
                 </div>
                 <div className={styles.setting}>

--- a/frontend/src/components/dialogs/settingsUtils.ts
+++ b/frontend/src/components/dialogs/settingsUtils.ts
@@ -1,2 +1,9 @@
 // Re-export from canonical location for backwards compatibility
-export { type AppSettings, defaultSettings, getSettings } from '../../utils/settingsUtils';
+export {
+  type AppSettings,
+  defaultSettings,
+  getSettings,
+  QUERY_TIMEOUT_DEFAULT_SEC,
+  QUERY_TIMEOUT_MAX_SEC,
+  QUERY_TIMEOUT_MIN_SEC,
+} from '../../utils/settingsUtils';

--- a/frontend/src/store/query/helpers/asyncPolling.ts
+++ b/frontend/src/store/query/helpers/asyncPolling.ts
@@ -1,4 +1,5 @@
 import type { AsyncColumn, AsyncPollResult, Column, QueryResult } from '../../../types';
+import { defaultSettings } from '../../../utils/settingsUtils';
 import type { QueryBridgeable } from '../interfaces/QueryBridgeable';
 
 function mapAsyncColumn(c: AsyncColumn): Column {
@@ -12,7 +13,7 @@ function mapAsyncColumn(c: AsyncColumn): Column {
   };
 }
 
-export const DEFAULT_QUERY_TIMEOUT_MS = 5 * 60 * 1000;
+export const DEFAULT_QUERY_TIMEOUT_MS = defaultSettings.query.timeout;
 const POLL_INTERVAL_MS = 100;
 
 interface AbortHandle {

--- a/frontend/src/tests/dialogs/SettingsDialog.test.tsx
+++ b/frontend/src/tests/dialogs/SettingsDialog.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { bridge } from '../../api/bridge';
 import { SettingsDialog } from '../../components/dialogs/SettingsDialog';
 
 vi.mock('../../api/bridge', () => ({
@@ -14,9 +15,18 @@ describe('SettingsDialog', () => {
     onClose: vi.fn(),
   };
 
+  beforeEach(() => {
+    localStorage.clear();
+    vi.mocked(bridge.updateSettings).mockClear();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  function getTimeoutInput(): HTMLInputElement {
+    return screen.getByLabelText('クエリタイムアウト (秒)') as HTMLInputElement;
+  }
 
   it('isOpen=false時に非表示', () => {
     const { container } = render(<SettingsDialog {...defaultProps} isOpen={false} />);
@@ -48,5 +58,57 @@ describe('SettingsDialog', () => {
     if (!(container.firstChild instanceof Element)) throw new Error('overlay not found');
     fireEvent.click(container.firstChild);
     expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  describe('クエリタイムアウト (issue #373)', () => {
+    it('デフォルト300秒が秒単位で表示される (defaultSettings.timeout=300000ms)', () => {
+      render(<SettingsDialog {...defaultProps} />);
+      fireEvent.click(screen.getByText('クエリ'));
+
+      const input = getTimeoutInput();
+      expect(input.value).toBe('300');
+      expect(input.min).toBe('1');
+      expect(input.max).toBe('3600');
+    });
+
+    it('入力値変更で内部状態がms単位で保持される (秒→ms変換)', () => {
+      render(<SettingsDialog {...defaultProps} />);
+      fireEvent.click(screen.getByText('クエリ'));
+
+      const input = getTimeoutInput();
+      fireEvent.change(input, { target: { value: '600' } });
+      expect(input.value).toBe('600');
+
+      fireEvent.click(screen.getByText('保存'));
+      // 保存時は秒単位で Backend へ同期される (Backend の clamp 1-3600 と整合)
+      expect(bridge.updateSettings).toHaveBeenCalledWith({
+        query: { timeoutSeconds: 600 },
+      });
+    });
+
+    it('localStorage に保存された旧値 (30000ms) は秒単位で30と表示される (後方互換)', () => {
+      localStorage.setItem(
+        'app-settings',
+        JSON.stringify({ query: { autoCommit: true, timeout: 30000, maxRows: 10000 } })
+      );
+
+      render(<SettingsDialog {...defaultProps} />);
+      fireEvent.click(screen.getByText('クエリ'));
+
+      const input = getTimeoutInput();
+      expect(input.value).toBe('30');
+    });
+
+    it('上限値3600を入力した場合も保存できる (Backend clamp 上限と整合)', () => {
+      render(<SettingsDialog {...defaultProps} />);
+      fireEvent.click(screen.getByText('クエリ'));
+
+      const input = getTimeoutInput();
+      fireEvent.change(input, { target: { value: '3600' } });
+      fireEvent.click(screen.getByText('保存'));
+      expect(bridge.updateSettings).toHaveBeenCalledWith({
+        query: { timeoutSeconds: 3600 },
+      });
+    });
   });
 });

--- a/frontend/src/tests/helpers/mockSettingsUtils.ts
+++ b/frontend/src/tests/helpers/mockSettingsUtils.ts
@@ -2,7 +2,7 @@ import { vi } from 'vitest';
 
 const mockSettings = {
   editor: { fontSize: 14, tabSize: 4, wordWrap: true, minimap: false },
-  query: { autoCommit: true, timeout: 30000, maxRows: 10000 },
+  query: { autoCommit: true, timeout: 300000, maxRows: 10000 },
   appearance: { theme: 'dark' as const },
   shortcuts: {
     execute: 'F9',

--- a/frontend/src/utils/settingsUtils.ts
+++ b/frontend/src/utils/settingsUtils.ts
@@ -1,5 +1,11 @@
 // Settings utility functions - separated from component for Fast Refresh compatibility
 
+// Query timeout bounds (seconds). Keep in sync with backend kQueryTimeoutMin/Max/DefaultSec
+// in settings_manager.h. Frontend stores ms internally for backward compat with saved localStorage.
+export const QUERY_TIMEOUT_MIN_SEC = 1;
+export const QUERY_TIMEOUT_MAX_SEC = 3600;
+export const QUERY_TIMEOUT_DEFAULT_SEC = 300;
+
 export interface AppSettings {
   editor: {
     fontSize: number;
@@ -32,7 +38,7 @@ export const defaultSettings: AppSettings = {
   },
   query: {
     autoCommit: true,
-    timeout: 30000,
+    timeout: QUERY_TIMEOUT_DEFAULT_SEC * 1000,
     maxRows: 10000,
   },
   appearance: {


### PR DESCRIPTION
既定値を 30s → 300s に引き上げ、UI 上限を 600s → 3600s に拡張。
併せて UI で設定したタイムアウトが実 ODBC クエリに伝搬されていなかった欠陥を修正し、コードレビュー指摘 7 件を一括対応。

Backend:
- IConnectionProvider に setDefaultQueryTimeoutSeconds を追加
- ConnectionRegistry::forEachQueryDriver で全既存接続へ伝搬
- ConnectionProvider が std::atomic<int> で既定値を保持し、getConnectResult で Driver 登録直前に setQueryTimeout を適用
- SettingsProvider に IConnectionProvider* を DI、load 後とupdateSettings の双方で適用 (applyQueryTimeoutToConnections)
- settings_manager.h に kQueryTimeout{Min,Max,Default}Sec 定数

Frontend:
- settingsUtils.ts に QUERY_TIMEOUT_{MIN,MAX,DEFAULT}_SEC を公開
- asyncPolling.ts の DEFAULT_QUERY_TIMEOUT_MS をdefaultSettings.query.timeout 参照に一本化
- SettingsDialog.tsx: label htmlFor/input id 連携、step=60、Number.isFinite による NaN-safe fallback
- mockSettingsUtils.ts の旧値 30000 を 300000 に更新
- SettingsDialog.test.tsx を getByLabelText 経由に簡素化

Closes #373