### PR TITLE
feat: 列幅オートアジャスト機能を追加 (#387)

### DIFF
--- a/frontend/src/components/grid/ColumnResizer.tsx
+++ b/frontend/src/components/grid/ColumnResizer.tsx
@@ -1,0 +1,35 @@
+import { type MouseEvent, memo, type TouchEvent, useCallback } from 'react';
+import styles from './ResultGrid.module.css';
+
+interface ColumnResizerProps {
+  columnId: string;
+  /** TanStack header.getResizeHandler() の戻り値 (drag resize 起動) */
+  onResizeStart: (e: MouseEvent | TouchEvent) => void;
+  /** ヘッダー境界ダブルクリック時の列オートアジャスト (Issue #387) */
+  onAutoSizeColumn?: (columnId: string) => void;
+}
+
+function ColumnResizerInner({ columnId, onResizeStart, onAutoSizeColumn }: ColumnResizerProps) {
+  // 列ヘッダー onClick (列選択) への伝播を止める: resizer 領域クリックは選択操作と衝突しない
+  const stopClick = useCallback((e: MouseEvent) => e.stopPropagation(), []);
+
+  const handleDoubleClick = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      onAutoSizeColumn?.(columnId);
+    },
+    [columnId, onAutoSizeColumn]
+  );
+
+  return (
+    <div
+      className={styles.columnResizer}
+      onMouseDown={onResizeStart}
+      onTouchStart={onResizeStart}
+      onClick={stopClick}
+      onDoubleClick={handleDoubleClick}
+    />
+  );
+}
+
+export const ColumnResizer = memo(ColumnResizerInner);

--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -4,6 +4,7 @@ import { type MouseEvent, memo, type RefObject, type UIEvent, useCallback } from
 import { type ColumnMeta, isSystemColumn, type RowData } from '../../types/grid';
 import type { ValidationError } from '../../utils/validation';
 import { ContextMenu } from '../common/ContextMenu';
+import { ColumnResizer } from './ColumnResizer';
 import { useGridContextMenu } from './hooks/useGridContextMenu';
 import styles from './ResultGrid.module.css';
 
@@ -59,6 +60,10 @@ interface GridTableProps {
   tableName?: string;
   /** Scroll 位置保存のためのハンドラ (ResultGrid 側で store 更新) */
   onScroll?: (e: UIEvent<HTMLDivElement>) => void;
+  /** 指定列のみ列幅オートアジャスト (Issue #387) */
+  onAutoSizeColumn?: (columnId: string) => void;
+  /** 全列を列幅オートアジャスト (Issue #387) */
+  onAutoSizeColumns?: () => void;
 }
 
 /** Extract row/cell info from a bubbled event via data attributes */
@@ -88,6 +93,8 @@ function GridTableInner({
   callbacks,
   tableName,
   onScroll,
+  onAutoSizeColumn,
+  onAutoSizeColumns,
 }: GridTableProps) {
   const paddingTop = virtualRows.length > 0 ? (virtualRows[0]?.start ?? 0) : 0;
   const paddingBottom =
@@ -101,6 +108,8 @@ function GridTableInner({
       isEditMode: edit.isEditMode,
       updateCell: callbacks.onUpdateCell,
       tableName,
+      onAutoSizeColumn,
+      onAutoSizeColumns,
     }
   );
 
@@ -179,6 +188,13 @@ function GridTableInner({
                         </span>
                       )}
                     </div>
+                    {header.column.getCanResize() && (
+                      <ColumnResizer
+                        columnId={header.column.id}
+                        onResizeStart={header.getResizeHandler()}
+                        onAutoSizeColumn={onAutoSizeColumn}
+                      />
+                    )}
                   </th>
                 );
               })}

--- a/frontend/src/components/grid/GridToolbar.tsx
+++ b/frontend/src/components/grid/GridToolbar.tsx
@@ -21,6 +21,7 @@ interface GridToolbarProps {
   onSetShowLogicalNames: (value: boolean) => void;
   onToggleColumnFilters: () => void;
   onExport: () => void;
+  onAutoSizeColumns: () => void;
   onChangeViewMode: (mode: GridViewMode) => void;
 }
 
@@ -43,6 +44,7 @@ function GridToolbarInner({
   onSetShowLogicalNames,
   onToggleColumnFilters,
   onExport,
+  onAutoSizeColumns,
   onChangeViewMode,
 }: GridToolbarProps) {
   const isTableMode = viewMode === 'table';
@@ -157,6 +159,15 @@ function GridToolbarInner({
         title="列フィルタを表示/非表示"
       >
         ≡
+      </button>
+      <button
+        type="button"
+        onClick={onAutoSizeColumns}
+        className={styles.iconButton}
+        disabled={!isTableMode}
+        title="列幅をオートアジャスト (Ctrl+Shift+A)"
+      >
+        ↔
       </button>
       <button
         type="button"

--- a/frontend/src/components/grid/ResultGrid.module.css
+++ b/frontend/src/components/grid/ResultGrid.module.css
@@ -380,14 +380,22 @@
   position: relative;
 }
 
-.th::after {
-  content: "";
+/* .columnResizer が列境界の drag/double-click target を担う (#387) */
+.columnResizer {
   position: absolute;
   right: 0;
-  top: 25%;
-  height: 50%;
-  width: 3px;
+  top: 0;
+  height: 100%;
+  width: 5px;
   cursor: col-resize;
+  user-select: none;
+  touch-action: none;
+  z-index: 1;
+}
+
+.columnResizer:hover {
+  background-color: var(--accent-color, #3a6d8c);
+  opacity: 0.4;
 }
 
 .th:last-child {

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -43,6 +43,7 @@ import { GridStatusBar } from './GridStatusBar';
 import { GridTable } from './GridTable';
 import { GridToolbar } from './GridToolbar';
 import { useClampedActiveIndex } from './hooks/useClampedActiveIndex';
+import { useColumnAutoSize } from './hooks/useColumnAutoSize';
 import { useElapsedTimer } from './hooks/useElapsedTimer';
 import { useGridEdit } from './hooks/useGridEdit';
 import { useGridKeyboard } from './hooks/useGridKeyboard';
@@ -227,10 +228,6 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   }, [resultSetColumns]);
 
   // --- Hooks ---
-  // 列幅は columnDef.size=150 を初期値に固定。ユーザー drag resize 時のみ columnSizing に
-  // 値が入る。動的 auto-size は #368 の安定性問題のため廃止 (progress.md 参照)。
-  const [columnSizing, setColumnSizing] = useState<Record<string, number>>({});
-
   const {
     isEditMode,
     hasChanges,
@@ -269,6 +266,12 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     });
     return combined;
   }, [baseRowData, getInsertedRows]);
+
+  // 列幅オートアジャスト (Issue #387):
+  // - 初回 (columnsKey 変化時) のみ自動で全行の MAX 幅に合わせる (#368 flash 回避)
+  // - ユーザー drag resize は維持 (triggerAutoSize/ForColumn で明示再計算も可)
+  const { columnSizing, setColumnSizing, triggerAutoSize, triggerAutoSizeForColumn } =
+    useColumnAutoSize({ resultSet, columns, rowData });
 
   const openRelatedTable = useCallback(
     (tableName: string, fkWhereClause: string) => {
@@ -328,6 +331,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     onNavigateRelated: navigateRelated,
     onOpenValueEditor: openValueEditor,
     onSelectAll: selectAllRows,
+    onAutoSizeColumns: triggerAutoSize,
   });
 
   const isPaginated = !!pagination;
@@ -718,6 +722,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
         onSetShowLogicalNames={setShowLogicalNamesInGrid}
         onToggleColumnFilters={toggleColumnFilters}
         onExport={openExportDialog}
+        onAutoSizeColumns={triggerAutoSize}
         onChangeViewMode={changeViewMode}
       />
 
@@ -747,6 +752,8 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
           callbacks={gridCallbacks}
           tableName={currentQuery?.sourceTable}
           onScroll={handleScroll}
+          onAutoSizeColumn={triggerAutoSizeForColumn}
+          onAutoSizeColumns={triggerAutoSize}
         />
       ) : (
         <TransposeView

--- a/frontend/src/components/grid/hooks/useColumnAutoSize.ts
+++ b/frontend/src/components/grid/hooks/useColumnAutoSize.ts
@@ -1,5 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import type { ResultSet } from '../../../types';
 import { isDateType, isNumericType, type RowData } from '../../../types/grid';
 import { log } from '../../../utils/logger';
@@ -13,16 +13,18 @@ interface UseColumnAutoSizeOptions {
 interface UseColumnAutoSizeResult {
   columnSizing: Record<string, number>;
   setColumnSizing: React.Dispatch<React.SetStateAction<Record<string, number>>>;
+  /** 全列を強制的に再計算する */
+  triggerAutoSize: () => void;
+  /** 指定列のみ再計算する (他列の現在幅は保持) */
+  triggerAutoSizeForColumn: (columnId: string) => void;
 }
 
-// Text measurement using canvas (Electron-only, no SSR concerns)
 function createMeasureContext(): CanvasRenderingContext2D | null {
   const canvas = document.createElement('canvas');
   return canvas.getContext('2d');
 }
 
-// Cache a context per font string so we avoid re-assigning ctx.font on every
-// measureText call (10000+ calls per auto-size; font re-set is measurable).
+// font 別 context をキャッシュ (全行 × 列で measureText 大量発行、font 再設定コスト削減)
 const contextByFont: Record<string, CanvasRenderingContext2D> = {};
 
 function measureTextWidth(text: string, font: string): number {
@@ -43,27 +45,48 @@ interface ColumnSizeConfig {
   padding: number;
 }
 
-// CSS already has cell padding (12px horizontal), so JS padding is minimal
 function getColumnConfig(columnType: string | undefined): ColumnSizeConfig {
-  if (!columnType) {
-    return { minWidth: 50, maxWidth: 250, padding: 8 };
-  }
-
-  if (isNumericType(columnType)) {
-    return { minWidth: 36, maxWidth: 120, padding: 4 };
-  }
-
-  if (isDateType(columnType)) {
-    return { minWidth: 60, maxWidth: 180, padding: 4 };
-  }
-
-  // Text/varchar types
+  if (!columnType) return { minWidth: 50, maxWidth: 250, padding: 8 };
+  if (isNumericType(columnType)) return { minWidth: 36, maxWidth: 120, padding: 4 };
+  if (isDateType(columnType)) return { minWidth: 60, maxWidth: 180, padding: 4 };
   return { minWidth: 50, maxWidth: 300, padding: 8 };
 }
 
 const FONT = '13px monospace';
 const HEADER_FONT = '600 13px system-ui, sans-serif';
-const ROW_INDEX_CONFIG = { minWidth: 32, maxWidth: 60, padding: 4 };
+const ROW_INDEX_CONFIG: ColumnSizeConfig = { minWidth: 32, maxWidth: 60, padding: 4 };
+
+// Issue #387: 原則は全行計測だが、超大規模データでメインスレッド長時間ブロックを避けるため
+// 閾値超過時は先頭 SYNC_FULL_LIMIT 行にフォールバックする。
+// 将来 requestIdleCallback 等で非同期化する場合はこのガードを撤去する。
+const SYNC_FULL_LIMIT = 20000;
+
+function resolveColumnConfig(columnId: string, resultSet: ResultSet): ColumnSizeConfig {
+  if (columnId === '__rowIndex') return ROW_INDEX_CONFIG;
+  const type = resultSet.columns.find((c) => c.name === columnId)?.type;
+  return getColumnConfig(type);
+}
+
+function measureColumnWidth(
+  columnId: string,
+  headerText: string,
+  rowData: RowData[],
+  config: ColumnSizeConfig
+): number {
+  const headerWidth = measureTextWidth(headerText, HEADER_FONT);
+
+  let contentMaxWidth = 0;
+  const limit = rowData.length > SYNC_FULL_LIMIT ? SYNC_FULL_LIMIT : rowData.length;
+  for (let i = 0; i < limit; i++) {
+    const value = rowData[i][columnId];
+    const text = value === null ? 'NULL' : String(value);
+    const width = measureTextWidth(text, FONT);
+    if (width > contentMaxWidth) contentMaxWidth = width;
+  }
+
+  const contentWidth = Math.max(headerWidth, contentMaxWidth) + config.padding;
+  return Math.min(config.maxWidth, Math.max(config.minWidth, contentWidth));
+}
 
 function calculateColumnSizing(
   columns: ColumnDef<RowData>[],
@@ -71,37 +94,15 @@ function calculateColumnSizing(
   resultSet: ResultSet
 ): Record<string, number> {
   const sizing: Record<string, number> = {};
-  const columnTypeMap = new Map(resultSet.columns.map((c) => [c.name, c.type]));
-
   for (const col of columns) {
     const columnId = String(col.id);
-    const isRowIndex = columnId === '__rowIndex';
-
-    const config = isRowIndex ? ROW_INDEX_CONFIG : getColumnConfig(columnTypeMap.get(columnId));
-
-    // Measure header width
+    const config = resolveColumnConfig(columnId, resultSet);
     const headerText = String(col.header || '');
-    const headerWidth = measureTextWidth(headerText, HEADER_FONT);
-
-    // Measure content width (sample up to 100 rows for performance)
-    let contentMaxWidth = 0;
-    const sampleSize = Math.min(rowData.length, 100);
-    for (let i = 0; i < sampleSize; i++) {
-      const value = rowData[i][columnId];
-      const text = value === null ? 'NULL' : String(value);
-      const width = measureTextWidth(text, FONT);
-      contentMaxWidth = Math.max(contentMaxWidth, width);
-    }
-
-    // Calculate final width: max of header/content + padding, clamped to min/max
-    const contentWidth = Math.max(headerWidth, contentMaxWidth) + config.padding;
-    sizing[columnId] = Math.min(config.maxWidth, Math.max(config.minWidth, contentWidth));
+    sizing[columnId] = measureColumnWidth(columnId, headerText, rowData, config);
   }
-
   return sizing;
 }
 
-// Generate a stable key for column structure (name + type)
 function getColumnsKey(resultSet: ResultSet | null): string | null {
   if (!resultSet) return null;
   return resultSet.columns.map((c) => `${c.name}:${c.type}`).join(',');
@@ -115,18 +116,16 @@ export function useColumnAutoSize({
   const [columnSizing, setColumnSizing] = useState<Record<string, number>>({});
   const appliedKeyRef = useRef<string | null>(null);
 
-  // Keep latest values in refs for stable effect
   const columnsRef = useRef(columns);
   const rowDataRef = useRef(rowData);
+  const resultSetRef = useRef(resultSet);
   columnsRef.current = columns;
   rowDataRef.current = rowData;
+  resultSetRef.current = resultSet;
 
-  // Auto-size only when column structure changes (new query result).
-  // useLayoutEffect: 初回 paint 前に計算を完了させ、default (size: 150) で一瞬表示されてから
-  // auto-size 値へ切り替わる「スクロール時の列幅変化」に見える flash を防ぐ (#368)
+  // 初回適用 (columnsKey 変化時のみ): paint 前に反映し default size からの flash を防ぐ (#368)
   useLayoutEffect(() => {
     if (!resultSet || rowDataRef.current.length === 0) return;
-
     const columnsKey = getColumnsKey(resultSet);
     if (columnsKey === appliedKeyRef.current) return;
 
@@ -136,5 +135,29 @@ export function useColumnAutoSize({
     log.debug(`[useColumnAutoSize] Auto-sized for key: ${columnsKey}`);
   }, [resultSet]);
 
-  return { columnSizing, setColumnSizing };
+  const triggerAutoSize = useCallback(() => {
+    const rs = resultSetRef.current;
+    if (!rs || rowDataRef.current.length === 0) return;
+    // 手動トリガー結果が次の columnsKey 変化時に上書きされないよう記録
+    appliedKeyRef.current = getColumnsKey(rs);
+    const newSizing = calculateColumnSizing(columnsRef.current, rowDataRef.current, rs);
+    setColumnSizing(newSizing);
+    log.debug('[useColumnAutoSize] Manual trigger: all columns');
+  }, []);
+
+  const triggerAutoSizeForColumn = useCallback((columnId: string) => {
+    const rs = resultSetRef.current;
+    if (!rs || rowDataRef.current.length === 0) return;
+    const col = columnsRef.current.find((c) => String(c.id) === columnId);
+    if (!col) return;
+
+    const config = resolveColumnConfig(columnId, rs);
+    const headerText = String(col.header || '');
+    const width = measureColumnWidth(columnId, headerText, rowDataRef.current, config);
+
+    setColumnSizing((prev) => ({ ...prev, [columnId]: width }));
+    log.debug(`[useColumnAutoSize] Manual trigger: ${columnId} = ${width}px`);
+  }, []);
+
+  return { columnSizing, setColumnSizing, triggerAutoSize, triggerAutoSizeForColumn };
 }

--- a/frontend/src/components/grid/hooks/useGridContextMenu.ts
+++ b/frontend/src/components/grid/hooks/useGridContextMenu.ts
@@ -61,13 +61,23 @@ interface UseGridContextMenuOptions {
   ) => void;
   /** INSERT文に埋め込むテーブル名。未指定時は `table_name` プレースホルダ */
   tableName?: string;
+  /** 指定列のみ列幅オートアジャスト (Issue #387) */
+  onAutoSizeColumn?: (columnId: string) => void;
+  /** 全列を列幅オートアジャスト (Issue #387) */
+  onAutoSizeColumns?: () => void;
 }
 
 export function useGridContextMenu(
   columnsMeta: ColumnMeta[],
   rows: GridRow[],
   table: GridTable,
-  { isEditMode = false, updateCell, tableName }: UseGridContextMenuOptions = { isEditMode: false }
+  {
+    isEditMode = false,
+    updateCell,
+    tableName,
+    onAutoSizeColumn,
+    onAutoSizeColumns,
+  }: UseGridContextMenuOptions = { isEditMode: false }
 ) {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const copyToClipboard = useCopyToClipboard();
@@ -144,6 +154,22 @@ export function useGridContextMenu(
         label: '降順でソート',
         action: () => column?.toggleSorting(true),
       });
+
+      if (onAutoSizeColumn || onAutoSizeColumns) {
+        items.push({ label: '', action: () => {}, separator: true });
+        if (onAutoSizeColumn) {
+          items.push({
+            label: 'この列をオートアジャスト',
+            action: () => onAutoSizeColumn(contextMenu.columnId),
+          });
+        }
+        if (onAutoSizeColumns) {
+          items.push({
+            label: '全列をオートアジャスト',
+            action: () => onAutoSizeColumns(),
+          });
+        }
+      }
       return items;
     }
 
@@ -206,7 +232,18 @@ export function useGridContextMenu(
     });
 
     return items;
-  }, [contextMenu, columnsMeta, rows, table, copyToClipboard, isEditMode, updateCell, tableName]);
+  }, [
+    contextMenu,
+    columnsMeta,
+    rows,
+    table,
+    copyToClipboard,
+    isEditMode,
+    updateCell,
+    tableName,
+    onAutoSizeColumn,
+    onAutoSizeColumns,
+  ]);
 
   return {
     contextMenu,

--- a/frontend/src/components/grid/hooks/useGridKeyboard.ts
+++ b/frontend/src/components/grid/hooks/useGridKeyboard.ts
@@ -31,6 +31,7 @@ interface UseGridKeyboardOptions {
   onNavigateRelated?: (rowIndex: number, columnName: string) => void;
   onOpenValueEditor?: (rowIndex: number, columnName: string, currentValue: string | null) => void;
   onSelectAll?: () => void;
+  onAutoSizeColumns?: () => void;
 }
 
 interface UseGridKeyboardResult {
@@ -60,6 +61,7 @@ export function useGridKeyboard({
   onNavigateRelated,
   onOpenValueEditor,
   onSelectAll,
+  onAutoSizeColumns,
 }: UseGridKeyboardOptions): UseGridKeyboardResult {
   const [editingCell, setEditingCell] = useState<EditingCell | null>(null);
   const [editValue, setEditValue] = useState<string>('');
@@ -232,6 +234,13 @@ export function useGridKeyboard({
     if (e.ctrlKey && e.shiftKey && e.key === 'C') {
       e.preventDefault();
       copySqlInsert();
+      return;
+    }
+
+    // Ctrl+Shift+A: 列幅オートアジャスト (Issue #387)
+    if (e.ctrlKey && e.shiftKey && (e.key === 'A' || e.key === 'a')) {
+      e.preventDefault();
+      onAutoSizeColumns?.();
       return;
     }
 

--- a/frontend/src/tests/grid/ColumnResizer.test.tsx
+++ b/frontend/src/tests/grid/ColumnResizer.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ColumnResizer } from '../../components/grid/ColumnResizer';
+
+function renderResizer(
+  overrides: Partial<React.ComponentProps<typeof ColumnResizer>> = {}
+): HTMLElement {
+  const { container } = render(
+    <ColumnResizer
+      columnId="col_a"
+      onResizeStart={overrides.onResizeStart ?? vi.fn()}
+      onAutoSizeColumn={overrides.onAutoSizeColumn}
+      {...overrides}
+    />
+  );
+  const el = container.firstElementChild;
+  if (!el) throw new Error('ColumnResizer rendered no root element');
+  return el as HTMLElement;
+}
+
+describe('ColumnResizer', () => {
+  it('ダブルクリックで onAutoSizeColumn(columnId) を呼ぶ', () => {
+    const onAutoSizeColumn = vi.fn();
+    const el = renderResizer({ onAutoSizeColumn });
+
+    fireEvent.doubleClick(el);
+
+    expect(onAutoSizeColumn).toHaveBeenCalledTimes(1);
+    expect(onAutoSizeColumn).toHaveBeenCalledWith('col_a');
+  });
+
+  it('ダブルクリックイベントは親に伝播しない (th の列選択ハンドラ干渉を防ぐ)', () => {
+    const parentDblClick = vi.fn();
+    const { container } = render(
+      <div onDoubleClick={parentDblClick}>
+        <ColumnResizer columnId="col_a" onResizeStart={vi.fn()} onAutoSizeColumn={vi.fn()} />
+      </div>
+    );
+    const el = container.querySelector('[class*="columnResizer"]');
+    if (!el) throw new Error('ColumnResizer not found');
+
+    fireEvent.doubleClick(el);
+
+    expect(parentDblClick).not.toHaveBeenCalled();
+  });
+
+  it('クリックイベントは親に伝播しない (th の列選択ハンドラ干渉を防ぐ)', () => {
+    const parentClick = vi.fn();
+    const { container } = render(
+      <div onClick={parentClick}>
+        <ColumnResizer columnId="col_a" onResizeStart={vi.fn()} />
+      </div>
+    );
+    const el = container.querySelector('[class*="columnResizer"]');
+    if (!el) throw new Error('ColumnResizer not found');
+
+    fireEvent.click(el);
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('mousedown / touchstart で onResizeStart を呼ぶ (drag resize の起点)', () => {
+    const onResizeStart = vi.fn();
+    const el = renderResizer({ onResizeStart });
+
+    fireEvent.mouseDown(el);
+    fireEvent.touchStart(el);
+
+    expect(onResizeStart).toHaveBeenCalledTimes(2);
+  });
+
+  it('onAutoSizeColumn 未指定でもダブルクリックで例外を投げない', () => {
+    const el = renderResizer({ onAutoSizeColumn: undefined });
+
+    expect(() => fireEvent.doubleClick(el)).not.toThrow();
+  });
+});

--- a/frontend/src/tests/grid/GridToolbar.test.tsx
+++ b/frontend/src/tests/grid/GridToolbar.test.tsx
@@ -21,6 +21,7 @@ const defaultProps = {
   onSetShowLogicalNames: vi.fn(),
   onToggleColumnFilters: vi.fn(),
   onExport: vi.fn(),
+  onAutoSizeColumns: vi.fn(),
   onChangeViewMode: vi.fn(),
 };
 
@@ -106,6 +107,20 @@ describe('GridToolbar', () => {
     it('エクスポートボタンを表示', () => {
       render(<GridToolbar {...defaultProps} />);
       expect(screen.getByTitle('データをエクスポート')).toBeInTheDocument();
+    });
+  });
+
+  describe('auto-size columns', () => {
+    it('オートアジャストボタンをクリックで onAutoSizeColumns を呼ぶ', () => {
+      const onAutoSizeColumns = vi.fn();
+      render(<GridToolbar {...defaultProps} onAutoSizeColumns={onAutoSizeColumns} />);
+      fireEvent.click(screen.getByTitle(/列幅をオートアジャスト/));
+      expect(onAutoSizeColumns).toHaveBeenCalledTimes(1);
+    });
+
+    it('viewMode=transpose でオートアジャストボタンが disabled', () => {
+      render(<GridToolbar {...defaultProps} viewMode="transpose" />);
+      expect(screen.getByTitle(/列幅をオートアジャスト/)).toBeDisabled();
     });
   });
 

--- a/frontend/src/tests/grid/useColumnAutoSize.test.ts
+++ b/frontend/src/tests/grid/useColumnAutoSize.test.ts
@@ -1,5 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { useColumnAutoSize } from '../../components/grid/hooks/useColumnAutoSize';
 import type { ResultSet } from '../../types';
@@ -115,5 +115,113 @@ describe('useColumnAutoSize', () => {
 
     expect(result.current.columnSizing.b).toBeGreaterThan(0);
     expect(result.current.columnSizing.a).toBeUndefined();
+  });
+
+  it('全行計測: 100行を超える rowData でも最終行の長いテキストが反映され maxWidth にクランプされる', () => {
+    // 先頭100行は短い、101行目に長いテキストを置く。100行サンプリングだと見落とす。
+    const cols = [{ name: 'a', type: 'varchar' }];
+    const columns = makeColumns(['a']);
+    const rows: string[][] = [];
+    for (let i = 0; i < 100; i++) rows.push(['x']);
+    rows.push(['AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA']); // 40文字
+    const resultSet = makeResultSet(cols, rows);
+    const rowData = makeRowData(['a'], rows);
+
+    const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+    // setup.ts mock: 40文字 × 13 × 0.6 + padding 8 = 320 → varchar maxWidth 300 にクランプ
+    // 正確値を確認することで (a) 全行計測、(b) maxWidth clamp の双方のミューテーションを検出
+    expect(result.current.columnSizing.a).toBe(300);
+  });
+
+  it('minWidth clamp: 内容もヘッダーも極端に短くても minWidth を下回らない', () => {
+    // varchar minWidth=50, padding=8 → 1文字 'x' は 7.8*1+8=15.8 で下回る
+    const cols = [{ name: 'a', type: 'varchar' }];
+    const columns = makeColumns(['a']);
+    const resultSet = makeResultSet(cols, [['x']]);
+    const rowData = makeRowData(['a'], [['x']]);
+
+    const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+    // minWidth clamp が効かないと 15.8 になり本番でヘッダーが極端に狭くなる回帰
+    expect(result.current.columnSizing.a).toBe(50);
+  });
+
+  it('triggerAutoSize: 同じ columnsKey でも強制再計算する', () => {
+    const cols = [{ name: 'a', type: 'varchar' }];
+    const columns = makeColumns(['a']);
+    const initial = {
+      resultSet: makeResultSet(cols, [['x']]),
+      columns,
+      rowData: makeRowData(['a'], [['x']]),
+    };
+
+    const { result, rerender } = renderHook((props) => useColumnAutoSize(props), {
+      initialProps: initial,
+    });
+
+    const firstSizing = result.current.columnSizing;
+    expect(firstSizing.a).toBeGreaterThan(0);
+
+    // rowData に長いテキストを追加 (columnsKey は不変)
+    rerender({
+      resultSet: makeResultSet(cols, [['x'], ['AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA']]),
+      columns,
+      rowData: makeRowData(['a'], [['x'], ['AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA']]),
+    });
+
+    // 通常 rerender では再計算されない (既存テストで確認済)
+    act(() => {
+      result.current.triggerAutoSize();
+    });
+
+    // 強制再計算で幅が広がっていること
+    expect(result.current.columnSizing.a).toBeGreaterThan(firstSizing.a);
+  });
+
+  it('triggerAutoSizeForColumn: 指定列のみ再計算、他列は保持', () => {
+    const cols = [
+      { name: 'a', type: 'varchar' },
+      { name: 'b', type: 'varchar' },
+    ];
+    const columns = makeColumns(['a', 'b']);
+    const initial = {
+      resultSet: makeResultSet(cols, [['x', 'y']]),
+      columns,
+      rowData: makeRowData(['a', 'b'], [['x', 'y']]),
+    };
+
+    const { result, rerender } = renderHook((props) => useColumnAutoSize(props), {
+      initialProps: initial,
+    });
+
+    const initialA = result.current.columnSizing.a;
+    const initialB = result.current.columnSizing.b;
+    expect(initialA).toBeGreaterThan(0);
+    expect(initialB).toBeGreaterThan(0);
+
+    // b にのみ長いテキスト追加
+    rerender({
+      resultSet: makeResultSet(cols, [
+        ['x', 'y'],
+        ['x', 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'],
+      ]),
+      columns,
+      rowData: makeRowData(
+        ['a', 'b'],
+        [
+          ['x', 'y'],
+          ['x', 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'],
+        ]
+      ),
+    });
+
+    act(() => {
+      result.current.triggerAutoSizeForColumn('b');
+    });
+
+    // b は再計算で広がっている、a は不変
+    expect(result.current.columnSizing.b).toBeGreaterThan(initialB);
+    expect(result.current.columnSizing.a).toBe(initialA);
   });
 });

--- a/frontend/src/tests/grid/useGridContextMenu.test.ts
+++ b/frontend/src/tests/grid/useGridContextMenu.test.ts
@@ -68,6 +68,46 @@ describe('useGridContextMenu', () => {
       expect(labels).not.toContain('論理名をコピー');
     });
 
+    it('onAutoSizeColumn/onAutoSizeColumns 指定でオートアジャストメニューが表示され、アクションが呼ばれる', () => {
+      const onAutoSizeColumn = vi.fn();
+      const onAutoSizeColumns = vi.fn();
+      const { result } = renderHook(() =>
+        useGridContextMenu(mockColumnsMeta, mockRows, mockTable, {
+          isEditMode: false,
+          onAutoSizeColumn,
+          onAutoSizeColumns,
+        })
+      );
+
+      act(() => {
+        result.current.openHeaderMenu(createMockEvent(), 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      const labels = items.filter((i) => !i.separator).map((i) => i.label);
+      expect(labels).toContain('この列をオートアジャスト');
+      expect(labels).toContain('全列をオートアジャスト');
+
+      items.find((i) => i.label === 'この列をオートアジャスト')?.action();
+      expect(onAutoSizeColumn).toHaveBeenCalledWith('name');
+
+      items.find((i) => i.label === '全列をオートアジャスト')?.action();
+      expect(onAutoSizeColumns).toHaveBeenCalledTimes(1);
+    });
+
+    it('onAutoSizeColumn/onAutoSizeColumns 未指定ではオートアジャストメニューが非表示', () => {
+      const { result } = renderHook(() => useGridContextMenu(mockColumnsMeta, mockRows, mockTable));
+
+      act(() => {
+        result.current.openHeaderMenu(createMockEvent(), 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      const labels = items.filter((i) => !i.separator).map((i) => i.label);
+      expect(labels).not.toContain('この列をオートアジャスト');
+      expect(labels).not.toContain('全列をオートアジャスト');
+    });
+
     it('列値をすべてコピーが正しいデータをコピー', () => {
       const { result } = renderHook(() => useGridContextMenu(mockColumnsMeta, mockRows, mockTable));
 

--- a/frontend/src/tests/grid/useGridKeyboard.test.ts
+++ b/frontend/src/tests/grid/useGridKeyboard.test.ts
@@ -239,6 +239,27 @@ describe('useGridKeyboard', () => {
     });
   });
 
+  describe('Ctrl+Shift+A (列幅オートアジャスト)', () => {
+    it('onAutoSizeColumns を呼び preventDefault する', () => {
+      const onAutoSizeColumns = vi.fn();
+      renderHook(() => useGridKeyboard({ ...baseOptions, onAutoSizeColumns }));
+
+      const event = new KeyboardEvent('keydown', { key: 'A', ctrlKey: true, shiftKey: true });
+      const preventDefault = vi.spyOn(event, 'preventDefault');
+      capturedKeydownHandler?.(event);
+
+      expect(onAutoSizeColumns).toHaveBeenCalledTimes(1);
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('onAutoSizeColumns 未指定でも例外を投げない', () => {
+      renderHook(() => useGridKeyboard(baseOptions));
+
+      const event = new KeyboardEvent('keydown', { key: 'A', ctrlKey: true, shiftKey: true });
+      expect(() => capturedKeydownHandler?.(event)).not.toThrow();
+    });
+  });
+
   describe('startEdit', () => {
     it('__rowIndex 列では編集を開始しない', () => {
       const { result } = renderHook(() => useGridKeyboard({ ...baseOptions, isEditMode: true }));

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -15,3 +15,35 @@ Object.defineProperty(globalThis, 'ResizeObserver', {
   },
   writable: true,
 });
+
+// Mock HTMLCanvasElement.getContext('2d') for useColumnAutoSize.
+// jsdom の canvas は 2d context を null で返すため measureText 依存の列幅計算を
+// 再現できない。font サイズから大雑把な width を返すダミー context を返す。
+//
+// 制約: `width = text.length * fontSize * 0.6` は monospace では妥当だが、
+// 比例フォント (system-ui 等) の文字別幅差や太字 (font-weight 600) による幅増加は
+// 再現しない。ヘッダー幅計測 (HEADER_FONT) が本番で想定外に大きくなる回帰は
+// このテストでは検出できないことに注意する。
+const originalGetContext = HTMLCanvasElement.prototype.getContext;
+function mock2dContext() {
+  let font = '10px sans-serif';
+  return {
+    get font() {
+      return font;
+    },
+    set font(value: string) {
+      font = value;
+    },
+    measureText(text: string) {
+      const sizeMatch = /(\d+)px/.exec(font);
+      const fontSize = sizeMatch ? Number(sizeMatch[1]) : 10;
+      return { width: text.length * fontSize * 0.6 };
+    },
+  };
+}
+// biome-ignore lint/suspicious/noExplicitAny: overload dispatch
+HTMLCanvasElement.prototype.getContext = function (this: HTMLCanvasElement, ...args: any[]): any {
+  if (args[0] === '2d') return mock2dContext();
+  // biome-ignore lint/suspicious/noExplicitAny: overload dispatch
+  return (originalGetContext as any).apply(this, args);
+};


### PR DESCRIPTION
全列 MAX 幅に合わせて列幅を自動調整。5つの発動経路を提供:

- 初回クエリ結果表示時に自動適用 (#368 flash 回避継承)
- ツールバー ↔ ボタン / Ctrl+Shift+A / 右クリックメニュー で全列再計算
- ヘッダー境界ダブルクリックで該当列のみ再計算

主要変更:

- useColumnAutoSize: 先頭100行サンプリング → 全行計測 (SYNC_FULL_LIMIT=20000 ガード)
- triggerAutoSize / triggerAutoSizeForColumn API 追加
- ColumnResizer コンポーネント抽出 (drag resize + dblClick auto-size)
- useGridContextMenu にオートアジャスト2項目追加
- useGridKeyboard に Ctrl+Shift+A 追加

Closes #387