### PR TITLE
fix: Ctrl+W で複数タブが閉じる二重登録を解消 (#391)

### DIFF
--- a/frontend/e2e/tab-close-shortcut.spec.ts
+++ b/frontend/e2e/tab-close-shortcut.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+
+// Issue #391: Ctrl+W で複数タブが閉じる回帰防止 E2E。
+// MainLayout と EditorTabs で keydown を二重登録すると 1 押下で 2 タブ閉じる。
+// window.invoke を全 method に対し success 応答で mock し、接続・永続化を排除する。
+
+const MOCK_INVOKE_SCRIPT = `
+  window.invoke = async (requestStr) => {
+    try {
+      const req = JSON.parse(requestStr);
+      if (req.method === 'loadSession') {
+        return JSON.stringify({
+          success: true,
+          data: { queries: [], activeQueryId: null, connectionProfiles: [], window: {} },
+        });
+      }
+      return JSON.stringify({ success: true, data: {} });
+    } catch (e) {
+      return JSON.stringify({ success: true, data: {} });
+    }
+  };
+`;
+
+test.describe('#391 Ctrl+W tab close shortcut', () => {
+  test('Ctrl+W 1回押下で閉じるタブは1つのみ', async ({ page }) => {
+    await page.addInitScript(MOCK_INVOKE_SCRIPT);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // 3タブ以上になるよう Ctrl+N で追加
+    await page.keyboard.press('Control+n');
+    await page.keyboard.press('Control+n');
+    await page.keyboard.press('Control+n');
+    await page.waitForTimeout(100);
+
+    const tabs = page.locator('[role="tab"]');
+    const before = await tabs.count();
+    expect(before).toBeGreaterThanOrEqual(3);
+
+    await page.keyboard.press('Control+w');
+    await page.waitForTimeout(200);
+
+    const after = await tabs.count();
+    expect(before - after).toBe(1);
+  });
+});

--- a/frontend/src/components/editor/EditorTabs.tsx
+++ b/frontend/src/components/editor/EditorTabs.tsx
@@ -91,17 +91,6 @@ export function EditorTabs() {
   );
   const { addQuery, removeQuery, setActive, reorderQuery, openERDiagram } = useQueryActions();
 
-  // Ctrl+W: close active tab
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.ctrlKey && e.key === 'w') {
-        e.preventDefault();
-        if (activeQueryId) removeQuery(activeQueryId);
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [activeQueryId, removeQuery]);
   const activeQuery = queries.find((q) => q.id === activeQueryId);
   const activeQueryConnectionId = activeQuery?.connectionId ?? null;
 

--- a/frontend/src/tests/editor/EditorTabs.test.tsx
+++ b/frontend/src/tests/editor/EditorTabs.test.tsx
@@ -10,11 +10,12 @@ const mockSetActive = vi.fn();
 const mockReorderQuery = vi.fn();
 const mockOpenERDiagram = vi.fn().mockReturnValue('new-er-id');
 let mockQueries: Query[] = [];
+let mockActiveQueryId: string | null = null;
 
 vi.mock('../../store/queryStore', () => ({
   useQueries: () => mockQueries,
   useQueryStore: (selector: (s: { activeQueryId: string | null }) => string | null) =>
-    selector({ activeQueryId: null }),
+    selector({ activeQueryId: mockActiveQueryId }),
   useQueryActions: () => ({
     addQuery: mockAddQuery,
     removeQuery: mockRemoveQuery,
@@ -41,6 +42,7 @@ describe('EditorTabs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockQueries = [];
+    mockActiveQueryId = null;
   });
 
   describe('新規タブメニュー', () => {
@@ -100,6 +102,30 @@ describe('EditorTabs', () => {
       fireEvent.click(screen.getByText('新規ER図'));
 
       expect(mockOpenERDiagram).toHaveBeenCalledWith('ER図 2');
+    });
+  });
+
+  describe('キーボードショートカット', () => {
+    // Ctrl+W のショートカットは MainLayout 側で一元管理する。
+    // EditorTabs が独自に window.keydown を購読すると二重発火で複数タブが閉じる (#391)。
+    it('Ctrl+W を EditorTabs 単体では購読せず removeQuery を呼ばない', () => {
+      mockActiveQueryId = 'q1';
+      mockQueries = [
+        {
+          id: 'q1',
+          name: 'Test',
+          content: '',
+          connectionId: null,
+          isDirty: false,
+          isERDiagram: false,
+        },
+      ];
+
+      render(<EditorTabs />);
+
+      window.dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'w' }));
+
+      expect(mockRemoveQuery).not.toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/tests/integration/tabCloseShortcut.test.tsx
+++ b/frontend/src/tests/integration/tabCloseShortcut.test.tsx
@@ -1,0 +1,36 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../../App';
+import { useQueryStore } from '../../store/queryStore';
+
+// #391: Ctrl+W 1回押下で複数タブが閉じる二重登録を検知する統合テスト。
+// 単体テスト (EditorTabs.test.tsx) は実装詳細 (購読しないこと) しか見ないため、
+// App 全体をレンダーして removeQuery の呼び出し回数を直接検証する。
+//
+// 注意: queries.length の変化では検知できない。二重発火しても 2回目は
+// 存在しないidに対する no-op になり -1 で止まってしまうため、spy で回数を見る。
+describe('Ctrl+W tab close shortcut (#391)', () => {
+  let snapshot: ReturnType<typeof useQueryStore.getState>;
+
+  beforeEach(() => {
+    snapshot = { ...useQueryStore.getState() };
+  });
+
+  afterEach(() => {
+    useQueryStore.setState(snapshot, true);
+  });
+
+  it('Ctrl+W 1回で removeQuery は1回だけ呼ばれる (2回呼ばれれば #391 再発)', () => {
+    const removeSpy = vi.fn();
+    useQueryStore.setState({ removeQuery: removeSpy, activeQueryId: 'q-test-1' });
+
+    render(<App />);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'w' }));
+    });
+
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledWith('q-test-1');
+  });
+});


### PR DESCRIPTION
`MainLayout` (`useKeyboardHandler`) と `EditorTabs` (`window.addEventListener`)で `Ctrl+W` ハンドラが二重登録されており、
1回押下で `removeQuery` が2回呼ばれ結果として2タブ閉じていた。
ショートカット登録は `MainLayout` に一元化する方針で `EditorTabs` 側の重複ハンドラを削除。

Close #391