### PR TITLE
fix: 列幅オートアジャストを非同期化し drag 応答性を改善

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc,css,scss,html,md,yml,yaml}]
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[*.{cpp,cc,cxx,c,h,hpp,hxx}]
+indent_size = 4
+
+[*.{cmake,cmake.in}]
+indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "ms-vscode.cmake-tools",
     "ms-vscode.cpptools",
     "ms-vscode.cpptools-extension-pack",
-    "biomejs.biome"
+    "biomejs.biome",
+    "editorconfig.editorconfig"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,20 +1,53 @@
 {
-	"cmake.useCMakePresets": "always",
-	"cmake.defaultBuildPreset": "release",
-	"cmake.defaultConfigurePreset": "release",
-	"cmake.defaultTestPreset": "release",
-	"cmake.generator": "Ninja",
-	"cmake.configureSettings": {
-		"CMAKE_BUILD_TYPE": "Release"
-	},
-	"cmake.buildDirectory": "${workspaceFolder}/build",
-	"cmake.preferredGenerators": ["Ninja", "Unix Makefiles"],
-	"cmake.configureOnOpen": false,
-	"terminal.integrated.fontFamily": "'MesloLGS Nerd Font', 'MesloLGS NF', 'Hack Nerd Font', monospace",
-	"terminal.integrated.fontWeight": "normal",
-	"[markdown]": {
-		"editor.codeActionsOnSave": {
-			"source.fixAll.markdownlint": "always"
-		}
-	}
+  "cmake.useCMakePresets": "always",
+  "cmake.defaultBuildPreset": "release",
+  "cmake.defaultConfigurePreset": "release",
+  "cmake.defaultTestPreset": "release",
+  "cmake.generator": "Ninja",
+  "cmake.configureSettings": {
+    "CMAKE_BUILD_TYPE": "Release"
+  },
+  "cmake.buildDirectory": "${workspaceFolder}/build",
+  "cmake.preferredGenerators": ["Ninja", "Unix Makefiles"],
+  "cmake.configureOnOpen": false,
+  "terminal.integrated.fontFamily": "'MesloLGS Nerd Font', 'MesloLGS NF', 'Hack Nerd Font', monospace",
+  "terminal.integrated.fontWeight": "normal",
+  "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports.biome": "explicit",
+      "quickfix.biome": "explicit"
+    }
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports.biome": "explicit",
+      "quickfix.biome": "explicit"
+    }
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[markdown]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": "always"
+    }
+  }
 }

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -68,6 +68,14 @@ const ExportDialog = lazyWithRetry(() =>
 const ELAPSED_CAUTION_SECONDS = 10;
 const ELAPSED_WARNING_SECONDS = 30;
 
+// 'onEnd': drag 中は columnSizing state を更新せず、mouseup 時のみ反映。
+// 'onChange' だと drag 中毎frame 全テーブル re-render で応答性が著しく悪化する。
+// drag 中の視覚フィードバック (DataGrip風 overlay 縦線) は
+// Phase 2 で columnSizingInfo.deltaOffset 経由で追加予定。
+// export しているのは回帰防止テスト (ResultGrid.columnResizeMode.test.ts) で
+// 値を直接検証するため (ソース文字列 match は fragile なため)。
+export const COLUMN_RESIZE_MODE = 'onEnd' as const;
+
 interface ResultGridProps {
   queryId?: string;
   excludeDataView?: boolean;
@@ -270,6 +278,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   // 列幅オートアジャスト (Issue #387):
   // - 初回 (columnsKey 変化時) のみ自動で全行の MAX 幅に合わせる (#368 flash 回避)
   // - ユーザー drag resize は維持 (triggerAutoSize/ForColumn で明示再計算も可)
+  // - 500行超は measureText を chunk+yield で非同期化 (メインスレッドブロック回避)
   const { columnSizing, setColumnSizing, triggerAutoSize, triggerAutoSizeForColumn } =
     useColumnAutoSize({ resultSet, columns, rowData });
 
@@ -364,7 +373,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     enableSorting: true,
     enableColumnFilters: true,
     manualSorting: isPaginated,
-    columnResizeMode: 'onChange',
+    columnResizeMode: COLUMN_RESIZE_MODE,
     state: { columnSizing, sorting, columnFilters },
     onColumnSizingChange: setColumnSizing,
     onSortingChange: sortingChangeHandler,

--- a/frontend/src/components/grid/hooks/useColumnAutoSize.ts
+++ b/frontend/src/components/grid/hooks/useColumnAutoSize.ts
@@ -1,5 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table';
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { ResultSet } from '../../../types';
 import { isDateType, isNumericType, type RowData } from '../../../types/grid';
 import { log } from '../../../utils/logger';
@@ -52,14 +52,28 @@ function getColumnConfig(columnType: string | undefined): ColumnSizeConfig {
   return { minWidth: 50, maxWidth: 300, padding: 8 };
 }
 
+function finalizeColumnWidth(
+  headerWidth: number,
+  contentMaxWidth: number,
+  config: ColumnSizeConfig
+): number {
+  const contentWidth = Math.max(headerWidth, contentMaxWidth) + config.padding;
+  return Math.min(config.maxWidth, Math.max(config.minWidth, contentWidth));
+}
+
 const FONT = '13px monospace';
 const HEADER_FONT = '600 13px system-ui, sans-serif';
 const ROW_INDEX_CONFIG: ColumnSizeConfig = { minWidth: 32, maxWidth: 60, padding: 4 };
 
 // Issue #387: 原則は全行計測だが、超大規模データでメインスレッド長時間ブロックを避けるため
 // 閾値超過時は先頭 SYNC_FULL_LIMIT 行にフォールバックする。
-// 将来 requestIdleCallback 等で非同期化する場合はこのガードを撤去する。
 const SYNC_FULL_LIMIT = 20000;
+
+// Phase 2 (Issue #387): SYNC_THRESHOLD を超える rowData は chunk + yield で非同期計測し、
+// メインスレッドを解放する (PROBE 実測で 25-52 秒ブロック → 数秒 UI 応答性維持へ)。
+// 閾値以下は同期を維持 (小規模テーブルでは flash 回避を優先)。
+const SYNC_THRESHOLD = 500;
+const ASYNC_CHUNK_ROWS = 500;
 
 function resolveColumnConfig(columnId: string, resultSet: ResultSet): ColumnSizeConfig {
   if (columnId === '__rowIndex') return ROW_INDEX_CONFIG;
@@ -76,7 +90,7 @@ function measureColumnWidth(
   const headerWidth = measureTextWidth(headerText, HEADER_FONT);
 
   let contentMaxWidth = 0;
-  const limit = rowData.length > SYNC_FULL_LIMIT ? SYNC_FULL_LIMIT : rowData.length;
+  const limit = Math.min(rowData.length, SYNC_FULL_LIMIT);
   for (let i = 0; i < limit; i++) {
     const value = rowData[i][columnId];
     const text = value === null ? 'NULL' : String(value);
@@ -84,8 +98,7 @@ function measureColumnWidth(
     if (width > contentMaxWidth) contentMaxWidth = width;
   }
 
-  const contentWidth = Math.max(headerWidth, contentMaxWidth) + config.padding;
-  return Math.min(config.maxWidth, Math.max(config.minWidth, contentWidth));
+  return finalizeColumnWidth(headerWidth, contentMaxWidth, config);
 }
 
 function calculateColumnSizing(
@@ -99,6 +112,54 @@ function calculateColumnSizing(
     const config = resolveColumnConfig(columnId, resultSet);
     const headerText = String(col.header || '');
     sizing[columnId] = measureColumnWidth(columnId, headerText, rowData, config);
+  }
+  return sizing;
+}
+
+function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// chunk 単位で yield しつつ列幅を計測する。abort 時は null を返す。
+async function measureColumnWidthAsync(
+  columnId: string,
+  headerText: string,
+  rowData: RowData[],
+  config: ColumnSizeConfig,
+  shouldAbort: () => boolean
+): Promise<number | null> {
+  const headerWidth = measureTextWidth(headerText, HEADER_FONT);
+  let contentMaxWidth = 0;
+  const limit = Math.min(rowData.length, SYNC_FULL_LIMIT);
+  for (let start = 0; start < limit; start += ASYNC_CHUNK_ROWS) {
+    const end = Math.min(start + ASYNC_CHUNK_ROWS, limit);
+    for (let i = start; i < end; i++) {
+      const value = rowData[i][columnId];
+      const text = value === null ? 'NULL' : String(value);
+      const width = measureTextWidth(text, FONT);
+      if (width > contentMaxWidth) contentMaxWidth = width;
+    }
+    await yieldToMain();
+    if (shouldAbort()) return null;
+  }
+  return finalizeColumnWidth(headerWidth, contentMaxWidth, config);
+}
+
+async function calculateColumnSizingAsync(
+  columns: ColumnDef<RowData>[],
+  rowData: RowData[],
+  resultSet: ResultSet,
+  shouldAbort: () => boolean
+): Promise<Record<string, number> | null> {
+  const sizing: Record<string, number> = {};
+  for (const col of columns) {
+    if (shouldAbort()) return null;
+    const columnId = String(col.id);
+    const config = resolveColumnConfig(columnId, resultSet);
+    const headerText = String(col.header || '');
+    const width = await measureColumnWidthAsync(columnId, headerText, rowData, config, shouldAbort);
+    if (width === null) return null;
+    sizing[columnId] = width;
   }
   return sizing;
 }
@@ -123,41 +184,91 @@ export function useColumnAutoSize({
   rowDataRef.current = rowData;
   resultSetRef.current = resultSet;
 
-  // 初回適用 (columnsKey 変化時のみ): paint 前に反映し default size からの flash を防ぐ (#368)
+  // cancellation token: 計測中に columnsKey 変化 / 再 trigger で古い結果を破棄する
+  const measurementIdRef = useRef(0);
+  const beginMeasurement = useCallback(() => {
+    const myId = ++measurementIdRef.current;
+    return () => measurementIdRef.current !== myId;
+  }, []);
+
+  // unmount 時に進行中の async 計測を無効化する (古い結果による setState を防ぐ)
+  useEffect(() => {
+    return () => {
+      measurementIdRef.current++;
+    };
+  }, []);
+
+  const runFullMeasurement = useCallback(
+    (rs: ResultSet) => {
+      const rows = rowDataRef.current;
+      if (rows.length <= SYNC_THRESHOLD) {
+        const newSizing = calculateColumnSizing(columnsRef.current, rows, rs);
+        setColumnSizing(newSizing);
+        return;
+      }
+      const shouldAbort = beginMeasurement();
+      calculateColumnSizingAsync(columnsRef.current, rows, rs, shouldAbort)
+        .then((sizing) => {
+          if (sizing && !shouldAbort()) setColumnSizing(sizing);
+        })
+        .catch((err: unknown) => {
+          log.error(`[useColumnAutoSize] async measurement failed: ${String(err)}`);
+        });
+    },
+    [beginMeasurement]
+  );
+
+  // 初回適用 (columnsKey 変化時のみ): 小規模は paint 前に反映 (#368)、
+  // 大規模は async で後追い反映 (メインスレッドブロック回避を優先)
   useLayoutEffect(() => {
     if (!resultSet || rowDataRef.current.length === 0) return;
     const columnsKey = getColumnsKey(resultSet);
     if (columnsKey === appliedKeyRef.current) return;
 
     appliedKeyRef.current = columnsKey;
-    const newSizing = calculateColumnSizing(columnsRef.current, rowDataRef.current, resultSet);
-    setColumnSizing(newSizing);
+    runFullMeasurement(resultSet);
     log.debug(`[useColumnAutoSize] Auto-sized for key: ${columnsKey}`);
-  }, [resultSet]);
+  }, [resultSet, runFullMeasurement]);
 
   const triggerAutoSize = useCallback(() => {
     const rs = resultSetRef.current;
     if (!rs || rowDataRef.current.length === 0) return;
     // 手動トリガー結果が次の columnsKey 変化時に上書きされないよう記録
     appliedKeyRef.current = getColumnsKey(rs);
-    const newSizing = calculateColumnSizing(columnsRef.current, rowDataRef.current, rs);
-    setColumnSizing(newSizing);
+    runFullMeasurement(rs);
     log.debug('[useColumnAutoSize] Manual trigger: all columns');
-  }, []);
+  }, [runFullMeasurement]);
 
-  const triggerAutoSizeForColumn = useCallback((columnId: string) => {
-    const rs = resultSetRef.current;
-    if (!rs || rowDataRef.current.length === 0) return;
-    const col = columnsRef.current.find((c) => String(c.id) === columnId);
-    if (!col) return;
+  const triggerAutoSizeForColumn = useCallback(
+    (columnId: string) => {
+      const rs = resultSetRef.current;
+      if (!rs || rowDataRef.current.length === 0) return;
+      const col = columnsRef.current.find((c) => String(c.id) === columnId);
+      if (!col) return;
 
-    const config = resolveColumnConfig(columnId, rs);
-    const headerText = String(col.header || '');
-    const width = measureColumnWidth(columnId, headerText, rowDataRef.current, config);
+      const config = resolveColumnConfig(columnId, rs);
+      const headerText = String(col.header || '');
+      const rows = rowDataRef.current;
 
-    setColumnSizing((prev) => ({ ...prev, [columnId]: width }));
-    log.debug(`[useColumnAutoSize] Manual trigger: ${columnId} = ${width}px`);
-  }, []);
+      if (rows.length <= SYNC_THRESHOLD) {
+        const width = measureColumnWidth(columnId, headerText, rows, config);
+        setColumnSizing((prev) => ({ ...prev, [columnId]: width }));
+        log.debug(`[useColumnAutoSize] Manual trigger: ${columnId} = ${width}px`);
+        return;
+      }
+      const shouldAbort = beginMeasurement();
+      measureColumnWidthAsync(columnId, headerText, rows, config, shouldAbort)
+        .then((width) => {
+          if (width === null || shouldAbort()) return;
+          setColumnSizing((prev) => ({ ...prev, [columnId]: width }));
+          log.debug(`[useColumnAutoSize] Manual trigger: ${columnId} = ${width}px`);
+        })
+        .catch((err: unknown) => {
+          log.error(`[useColumnAutoSize] async measurement failed for ${columnId}: ${String(err)}`);
+        });
+    },
+    [beginMeasurement]
+  );
 
   return { columnSizing, setColumnSizing, triggerAutoSize, triggerAutoSizeForColumn };
 }

--- a/frontend/src/tests/grid/ResultGrid.columnResizeMode.test.ts
+++ b/frontend/src/tests/grid/ResultGrid.columnResizeMode.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { COLUMN_RESIZE_MODE } from '../../components/grid/ResultGrid';
+
+// Issue: drag resize 応答性が非常に悪い問題。
+// columnResizeMode='onChange' は drag 中毎frame setColumnSizing を呼び、
+// ResultGrid 全体 (thead, colgroup, virtualized tbody) を re-render させる。
+// WebView2 の software compositing 遅延と合わさり体感を著しく悪化させる。
+// 'onEnd' に変更することで state 更新は mouseup 時のみになり、
+// drag 中の re-render を排除できる。
+//
+// ソース文字列 match (?raw import) は prettier/コメント変更で壊れる fragile な
+// 検証だったため、export した定数値を直接検証する形に変更した。
+//
+// TODO (Phase 2): drag 中の視覚フィードバック (columnSizingInfo.deltaOffset による
+// overlay 縦線) 実装時に、mousedown→mousemove→mouseup の実挙動を Playwright E2E
+// で検証する (frontend/e2e/column-resize-performance.spec.ts)。実挙動テストは
+// TanStack Table の内部 document listener を経由するため jsdom では再現困難。
+describe('ResultGrid columnResizeMode (drag resize performance)', () => {
+  it("COLUMN_RESIZE_MODE は 'onEnd' を維持 (onChange への回帰禁止)", () => {
+    expect(COLUMN_RESIZE_MODE).toBe('onEnd');
+  });
+});

--- a/frontend/src/tests/grid/useColumnAutoSize.test.ts
+++ b/frontend/src/tests/grid/useColumnAutoSize.test.ts
@@ -1,5 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table';
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { useColumnAutoSize } from '../../components/grid/hooks/useColumnAutoSize';
 import type { ResultSet } from '../../types';
@@ -223,5 +223,146 @@ describe('useColumnAutoSize', () => {
     // b は再計算で広がっている、a は不変
     expect(result.current.columnSizing.b).toBeGreaterThan(initialB);
     expect(result.current.columnSizing.a).toBe(initialA);
+  });
+
+  // Issue #387 Phase 2: measureText 全行同期ループがメインスレッドを数十秒ブロック
+  // する問題 (PROBE 計測で 25-52 秒ブロック確認) を解消するため、行数が閾値を超えた
+  // 場合は chunk+yield で非同期計測する。計測中に rerender / 再 trigger が起きた
+  // 場合、古い計測結果で上書きされないことを cancellation token で保証する。
+  describe('async chunk measurement (大規模データ)', () => {
+    const ASYNC_ROW_COUNT = 1200; // 閾値 (500) を超えて async path を踏ませる
+
+    function makeLargeRowData(longestAt: number, longestText: string) {
+      const rows: string[][] = [];
+      for (let i = 0; i < ASYNC_ROW_COUNT; i++) {
+        rows.push([i === longestAt ? longestText : 'x']);
+      }
+      return rows;
+    }
+
+    it('大量行の初回計測は非同期に反映される (同期では未計算、await 後に値)', async () => {
+      const cols = [{ name: 'a', type: 'varchar' }];
+      const columns = makeColumns(['a']);
+      const rows = makeLargeRowData(ASYNC_ROW_COUNT - 1, 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA');
+      const resultSet = makeResultSet(cols, rows);
+      const rowData = makeRowData(['a'], rows);
+
+      const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+      // 同期直後は未反映 (初期値 {})。await 後に値が入ることを確認。
+      expect(result.current.columnSizing.a).toBeUndefined();
+
+      await waitFor(() => {
+        expect(result.current.columnSizing.a).toBeGreaterThan(0);
+      });
+
+      // 末尾行の長いテキストが全行計測で拾われていること (sampling へのリグレッション防止)
+      // 32 文字 × 13 × 0.6 + padding 8 = 257.6 → varchar maxWidth 300 には届かず 258
+      expect(result.current.columnSizing.a).toBeGreaterThan(200);
+    });
+
+    // 旧テスト (columnsKey を a→b に差替) は cancellation token 削除ミュータントでも
+    // PASS する偽陽性だったため、同一 columnsKey + rowData 差替 + 連続 trigger の構成に
+    // 書き換えた。short の計測が後追いで long の結果を上書きしないことを値域で検証する。
+    it('同一 columnsKey で連続 trigger した場合、古い計測結果が最新結果を上書きしない', async () => {
+      const cols = [{ name: 'a', type: 'varchar' }];
+      const columns = makeColumns(['a']);
+      const shortRows = makeLargeRowData(-1, ''); // 全て 'x' → minWidth 50
+      const longRows = makeLargeRowData(ASYNC_ROW_COUNT - 1, 'L'.repeat(30)); // 242px
+
+      const { result, rerender } = renderHook((props) => useColumnAutoSize(props), {
+        initialProps: {
+          resultSet: makeResultSet(cols, shortRows),
+          columns,
+          rowData: makeRowData(['a'], shortRows),
+        },
+      });
+
+      // 初回 async 計測 (short) の完了を待たずに rowData を long に差替 + 明示 trigger
+      rerender({
+        resultSet: makeResultSet(cols, longRows),
+        columns,
+        rowData: makeRowData(['a'], longRows),
+      });
+      act(() => {
+        result.current.triggerAutoSize();
+      });
+
+      // 最終値は long 計測 (>200)。cancellation 無しだと short の計測完了が
+      // 後追いで setColumnSizing({ a: 50 }) を呼び、最終値が 50 に落ちて FAIL する。
+      await waitFor(() => {
+        expect(result.current.columnSizing.a).toBeGreaterThan(200);
+      });
+      // 以降も short の結果に上書きされず、long 値で stable であること
+      await act(() => new Promise<void>((r) => queueMicrotask(() => r())));
+      expect(result.current.columnSizing.a).toBeGreaterThan(200);
+    });
+
+    // 旧テストは 2 回目も同じ long rowData での trigger だったため、cancellation が
+    // 無効でも最終値が同じになり偽陽性だった。1 回目 (short) と 2 回目 (long) で
+    // 計測対象を区別し、最終値が最新 trigger 由来の値域に収束することを検証する。
+    it('連続 triggerAutoSize: 1 回目と異なる 2 回目の計測値が最終結果に反映される', async () => {
+      const cols = [{ name: 'a', type: 'varchar' }];
+      const columns = makeColumns(['a']);
+      const shortRows = makeLargeRowData(-1, ''); // 全て 'x' → minWidth 50
+      const longRows = makeLargeRowData(ASYNC_ROW_COUNT - 1, 'L'.repeat(30)); // 242px
+
+      const { result, rerender } = renderHook((props) => useColumnAutoSize(props), {
+        initialProps: {
+          resultSet: makeResultSet(cols, shortRows),
+          columns,
+          rowData: makeRowData(['a'], shortRows),
+        },
+      });
+
+      // 初回 (short) の async 計測を待たずに、1 回目の triggerAutoSize を発火
+      // その直後に rowData を long に差替、2 回目の triggerAutoSize を発火
+      act(() => {
+        result.current.triggerAutoSize();
+      });
+      rerender({
+        resultSet: makeResultSet(cols, longRows),
+        columns,
+        rowData: makeRowData(['a'], longRows),
+      });
+      act(() => {
+        result.current.triggerAutoSize();
+      });
+
+      // 最終値は 2 回目 (long) の結果 > 200
+      await waitFor(() => {
+        expect(result.current.columnSizing.a).toBeGreaterThan(200);
+      });
+      // 追加マイクロタスクを流しても値が stable (short の結果で上書きされない)
+      await act(() => new Promise<void>((r) => queueMicrotask(() => r())));
+      expect(result.current.columnSizing.a).toBeGreaterThan(200);
+    });
+
+    // Issue #387: 超大規模データで SYNC_FULL_LIMIT (20000 行) 超過分は計測対象外とする。
+    // この上限が撤廃されるとメインスレッドが長時間ブロックされる回帰となるため
+    // 先頭 20000 行で clamping される既存動作を特性テストとして固定する。
+    it('SYNC_FULL_LIMIT 超過: 20000 行目以降の長テキストは計測対象外', async () => {
+      const SYNC_FULL_LIMIT = 20000;
+      const cols = [{ name: 'a', type: 'varchar' }];
+      const columns = makeColumns(['a']);
+      const rows: string[][] = [];
+      for (let i = 0; i < SYNC_FULL_LIMIT; i++) rows.push(['x']);
+      rows.push(['A'.repeat(40)]); // 20001 行目: limit 外なので拾われない
+      const resultSet = makeResultSet(cols, rows);
+      const rowData = makeRowData(['a'], rows);
+
+      const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+      await waitFor(
+        () => {
+          expect(result.current.columnSizing.a).toBeGreaterThan(0);
+        },
+        { timeout: 10000 }
+      );
+
+      // limit 超過行が拾われる実装に退行すると maxWidth 300 にクランプされる。
+      // 現仕様では 'x' だけが対象 = padding 込 15.8 → minWidth 50 にクランプ。
+      expect(result.current.columnSizing.a).toBe(50);
+    });
   });
 });


### PR DESCRIPTION
- measureText 同期ブロックを `chunk+yield` で非同期化
- `cancellation token` で `race / unmount` リークを解消
- columnResizeMode='onEnd' で drag 中の全体 re-render を排除
- 回帰テスト追加 (async 経路 / SYNC_FULL_LIMIT 境界 / columnResizeMode 定数)

Closes #387