### PR TITLE
fix: 列幅オートアジャスト全列経路が実機で効かない問題を修正 (#387)

### DIFF
--- a/frontend/src/components/grid/ColumnResizer.tsx
+++ b/frontend/src/components/grid/ColumnResizer.tsx
@@ -1,16 +1,35 @@
-import { type MouseEvent, memo, type TouchEvent, useCallback } from 'react';
+import { type MouseEvent, memo, useCallback } from 'react';
 import styles from './ResultGrid.module.css';
 
 interface ColumnResizerProps {
   columnId: string;
-  /** TanStack header.getResizeHandler() の戻り値 (drag resize 起動) */
-  onResizeStart: (e: MouseEvent | TouchEvent) => void;
+  /** 現在の列幅 (px) — drag 開始時の基準値として使用 */
+  currentWidth: number;
+  /** 列幅下限 (default 40) */
+  minWidth?: number;
+  /** 列幅上限 (default 1000) */
+  maxWidth?: number;
+  /** drag 完了 (mouseup) 時に呼ばれる。新しい列幅を 1 回だけ通知。 */
+  onResizeCommit: (columnId: string, newWidth: number) => void;
   /** ヘッダー境界ダブルクリック時の列オートアジャスト (Issue #387) */
   onAutoSizeColumn?: (columnId: string) => void;
 }
 
-function ColumnResizerInner({ columnId, onResizeStart, onAutoSizeColumn }: ColumnResizerProps) {
-  // 列ヘッダー onClick (列選択) への伝播を止める: resizer 領域クリックは選択操作と衝突しない
+const DEFAULT_MIN_WIDTH = 40;
+const DEFAULT_MAX_WIDTH = 1000;
+const INDICATOR_OPACITY = 0.6;
+const INDICATOR_COLOR = `rgba(0, 122, 204, ${INDICATOR_OPACITY})`;
+
+const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
+
+function ColumnResizerInner({
+  columnId,
+  currentWidth,
+  minWidth = DEFAULT_MIN_WIDTH,
+  maxWidth = DEFAULT_MAX_WIDTH,
+  onResizeCommit,
+  onAutoSizeColumn,
+}: ColumnResizerProps) {
   const stopClick = useCallback((e: MouseEvent) => e.stopPropagation(), []);
 
   const handleDoubleClick = useCallback(
@@ -21,11 +40,59 @@ function ColumnResizerInner({ columnId, onResizeStart, onAutoSizeColumn }: Colum
     [columnId, onAutoSizeColumn]
   );
 
+  const handleMouseDown = useCallback(
+    (e: MouseEvent) => {
+      // 列ヘッダー onClick (列選択) への伝播を止める
+      e.stopPropagation();
+      e.preventDefault();
+
+      const startX = e.clientX;
+      const resizerRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+
+      // Overlay 縦線 indicator (DOM 直挿入、React 経由しない最軽量パス)
+      const indicator = document.createElement('div');
+      indicator.style.position = 'fixed';
+      indicator.style.top = '0';
+      indicator.style.left = `${resizerRect.left + resizerRect.width / 2}px`;
+      indicator.style.width = '2px';
+      indicator.style.height = '100vh';
+      indicator.style.background = INDICATOR_COLOR;
+      indicator.style.pointerEvents = 'none';
+      indicator.style.zIndex = '9999';
+      indicator.style.willChange = 'transform';
+      document.body.appendChild(indicator);
+
+      let pendingDx = 0;
+      let rafId: number | null = null;
+
+      const onMove = (ev: globalThis.MouseEvent) => {
+        pendingDx = ev.clientX - startX;
+        if (rafId !== null) return;
+        rafId = requestAnimationFrame(() => {
+          indicator.style.transform = `translateX(${pendingDx}px)`;
+          rafId = null;
+        });
+      };
+
+      const onUp = () => {
+        if (rafId !== null) cancelAnimationFrame(rafId);
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        if (indicator.parentNode) indicator.parentNode.removeChild(indicator);
+        const newWidth = clamp(currentWidth + pendingDx, minWidth, maxWidth);
+        if (newWidth !== currentWidth) onResizeCommit(columnId, newWidth);
+      };
+
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    },
+    [columnId, currentWidth, minWidth, maxWidth, onResizeCommit]
+  );
+
   return (
     <div
       className={styles.columnResizer}
-      onMouseDown={onResizeStart}
-      onTouchStart={onResizeStart}
+      onMouseDown={handleMouseDown}
       onClick={stopClick}
       onDoubleClick={handleDoubleClick}
     />

--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -56,6 +56,11 @@ interface GridTableProps {
   edit: GridEditContext;
   selection: GridSelectionState;
   callbacks: GridTableCallbacks;
+  /**
+   * 列幅 state。`table` 参照は state 変化でも同一 (TanStack 仕様) のため、
+   * memo の浅い比較で列幅変化を検出するには明示的に props として受け取る必要がある。
+   */
+  columnSizing: Record<string, number>;
   /** Table name embedded in INSERT copy (sourceTable for data-view tabs, undefined for arbitrary SQL) */
   tableName?: string;
   /** Scroll 位置保存のためのハンドラ (ResultGrid 側で store 更新) */
@@ -95,6 +100,8 @@ function GridTableInner({
   onScroll,
   onAutoSizeColumn,
   onAutoSizeColumns,
+  // memo の浅い比較で列幅変化を検出するために受け取るだけ。値自体は table.getState() 経由で参照される。
+  columnSizing: _columnSizing,
 }: GridTableProps) {
   const paddingTop = virtualRows.length > 0 ? (virtualRows[0]?.start ?? 0) : 0;
   const paddingBottom =
@@ -191,7 +198,12 @@ function GridTableInner({
                     {header.column.getCanResize() && (
                       <ColumnResizer
                         columnId={header.column.id}
-                        onResizeStart={header.getResizeHandler()}
+                        currentWidth={header.getSize()}
+                        minWidth={header.column.columnDef.minSize}
+                        maxWidth={header.column.columnDef.maxSize}
+                        onResizeCommit={(id, w) =>
+                          table.setColumnSizing((prev) => ({ ...prev, [id]: w }))
+                        }
                         onAutoSizeColumn={onAutoSizeColumn}
                       />
                     )}

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -369,6 +369,9 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     getFilteredRowModel: getFilteredRowModel(),
     getSortedRowModel: getSortedRowModel(),
     enableRowSelection: true,
+    // 自前 resize 実装 (ColumnResizer 内 overlay indicator) のため TanStack 内蔵 resize は無効化。
+    // `header.column.getCanResize()` 判定維持のため `enableColumnResizing: true`、
+    // ただし columnResizeMode は drag 中の TanStack 内 state 更新を抑止するため未指定 (default 'onEnd')。
     enableColumnResizing: true,
     enableSorting: true,
     enableColumnFilters: true,
@@ -763,6 +766,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
           onScroll={handleScroll}
           onAutoSizeColumn={triggerAutoSizeForColumn}
           onAutoSizeColumns={triggerAutoSize}
+          columnSizing={columnSizing}
         />
       ) : (
         <TransposeView

--- a/frontend/src/components/grid/hooks/useColumnAutoSize.ts
+++ b/frontend/src/components/grid/hooks/useColumnAutoSize.ts
@@ -45,11 +45,27 @@ interface ColumnSizeConfig {
   padding: number;
 }
 
+// CSS .th / .td の左右 padding 合計 (ResultGrid.module.css: padding: Npx 12px → 12*2=24)
+// + sort indicator (▲▼) ぶん 8px の安全マージン
+const CELL_HORIZONTAL_PADDING = 32;
+
 function getColumnConfig(columnType: string | undefined): ColumnSizeConfig {
-  if (!columnType) return { minWidth: 50, maxWidth: 250, padding: 8 };
-  if (isNumericType(columnType)) return { minWidth: 36, maxWidth: 120, padding: 4 };
-  if (isDateType(columnType)) return { minWidth: 60, maxWidth: 180, padding: 4 };
-  return { minWidth: 50, maxWidth: 300, padding: 8 };
+  // numeric/date は文字数が爆発しないため上限撤廃 (実コンテンツ幅を尊重)。
+  // string/不明型は TEXT/JSON 等で異常に広くなり得るため上限維持。
+  if (!columnType) return { minWidth: 50, maxWidth: 300, padding: CELL_HORIZONTAL_PADDING };
+  if (isNumericType(columnType))
+    return {
+      minWidth: 36,
+      maxWidth: Number.POSITIVE_INFINITY,
+      padding: CELL_HORIZONTAL_PADDING,
+    };
+  if (isDateType(columnType))
+    return {
+      minWidth: 60,
+      maxWidth: Number.POSITIVE_INFINITY,
+      padding: CELL_HORIZONTAL_PADDING,
+    };
+  return { minWidth: 50, maxWidth: 300, padding: CELL_HORIZONTAL_PADDING };
 }
 
 function finalizeColumnWidth(
@@ -61,8 +77,13 @@ function finalizeColumnWidth(
   return Math.min(config.maxWidth, Math.max(config.minWidth, contentWidth));
 }
 
-const FONT = '13px monospace';
-const HEADER_FONT = '600 13px system-ui, sans-serif';
+// measureText font は実描画 CSS (`.table { font-size: 14px; font-family: var(--font-mono) }`) と
+// 一致させる必要がある。乖離すると monospace fallback (Courier New) で計算され Consolas 実描画と
+// 幅が合わず、DATE/NVARCHAR 列で文字切れが起きる (4/23 実機確認)。var() は Canvas では解釈
+// されないため --font-mono の stack を直接展開。
+const MONO_STACK = 'Consolas, Monaco, "Cascadia Code", "Source Code Pro", monospace';
+const FONT = `14px ${MONO_STACK}`;
+const HEADER_FONT = `600 14px ${MONO_STACK}`;
 const ROW_INDEX_CONFIG: ColumnSizeConfig = { minWidth: 32, maxWidth: 60, padding: 4 };
 
 // Issue #387: 原則は全行計測だが、超大規模データでメインスレッド長時間ブロックを避けるため
@@ -145,21 +166,47 @@ async function measureColumnWidthAsync(
   return finalizeColumnWidth(headerWidth, contentMaxWidth, config);
 }
 
+// 全列を行 chunk でまとめて計測する (列ごとに独立 chunk yield するより yield 回数が激減)。
+// WebView2 の background/throttled setTimeout 下で列数 N に比例する yield 数 (N × ceil(rows/CHUNK))
+// が完了不能になる事象を回避するため、列数に依存しない O(rows/CHUNK) に固定する。
 async function calculateColumnSizingAsync(
   columns: ColumnDef<RowData>[],
   rowData: RowData[],
   resultSet: ResultSet,
   shouldAbort: () => boolean
 ): Promise<Record<string, number> | null> {
-  const sizing: Record<string, number> = {};
+  const limit = Math.min(rowData.length, SYNC_FULL_LIMIT);
+
+  const columnIds: string[] = [];
+  const configs: ColumnSizeConfig[] = [];
+  const headerWidths: number[] = [];
+  const maxContentWidths: number[] = [];
   for (const col of columns) {
-    if (shouldAbort()) return null;
     const columnId = String(col.id);
-    const config = resolveColumnConfig(columnId, resultSet);
-    const headerText = String(col.header || '');
-    const width = await measureColumnWidthAsync(columnId, headerText, rowData, config, shouldAbort);
-    if (width === null) return null;
-    sizing[columnId] = width;
+    columnIds.push(columnId);
+    configs.push(resolveColumnConfig(columnId, resultSet));
+    headerWidths.push(measureTextWidth(String(col.header || ''), HEADER_FONT));
+    maxContentWidths.push(0);
+  }
+
+  for (let start = 0; start < limit; start += ASYNC_CHUNK_ROWS) {
+    const end = Math.min(start + ASYNC_CHUNK_ROWS, limit);
+    for (let i = start; i < end; i++) {
+      const row = rowData[i];
+      for (let c = 0; c < columnIds.length; c++) {
+        const value = row[columnIds[c]];
+        const text = value === null ? 'NULL' : String(value);
+        const width = measureTextWidth(text, FONT);
+        if (width > maxContentWidths[c]) maxContentWidths[c] = width;
+      }
+    }
+    await yieldToMain();
+    if (shouldAbort()) return null;
+  }
+
+  const sizing: Record<string, number> = {};
+  for (let c = 0; c < columnIds.length; c++) {
+    sizing[columnIds[c]] = finalizeColumnWidth(headerWidths[c], maxContentWidths[c], configs[c]);
   }
   return sizing;
 }
@@ -184,17 +231,30 @@ export function useColumnAutoSize({
   rowDataRef.current = rowData;
   resultSetRef.current = resultSet;
 
-  // cancellation token: 計測中に columnsKey 変化 / 再 trigger で古い結果を破棄する
-  const measurementIdRef = useRef(0);
-  const beginMeasurement = useCallback(() => {
-    const myId = ++measurementIdRef.current;
-    return () => measurementIdRef.current !== myId;
+  // cancellation token は「全列計測」「単列計測 (列ごと)」を独立 axis として分離する。
+  // 共用にすると実機で toolbar 全列 trigger と ContextMenu 単列 trigger が相互に abort し合い、
+  // 全列の setColumnSizing が永遠に呼ばれない事象が発生する (fix/drag-lag-probe 実機ログ)。
+  const fullMeasurementIdRef = useRef(0);
+  const perColMeasurementIdsRef = useRef<Record<string, number>>({});
+
+  const beginFullMeasurement = useCallback(() => {
+    const myId = ++fullMeasurementIdRef.current;
+    return () => fullMeasurementIdRef.current !== myId;
+  }, []);
+
+  const beginPerColMeasurement = useCallback((columnId: string) => {
+    const ids = perColMeasurementIdsRef.current;
+    const myId = (ids[columnId] ?? 0) + 1;
+    ids[columnId] = myId;
+    return () => perColMeasurementIdsRef.current[columnId] !== myId;
   }, []);
 
   // unmount 時に進行中の async 計測を無効化する (古い結果による setState を防ぐ)
   useEffect(() => {
     return () => {
-      measurementIdRef.current++;
+      fullMeasurementIdRef.current++;
+      const ids = perColMeasurementIdsRef.current;
+      for (const key of Object.keys(ids)) ids[key]++;
     };
   }, []);
 
@@ -206,7 +266,7 @@ export function useColumnAutoSize({
         setColumnSizing(newSizing);
         return;
       }
-      const shouldAbort = beginMeasurement();
+      const shouldAbort = beginFullMeasurement();
       calculateColumnSizingAsync(columnsRef.current, rows, rs, shouldAbort)
         .then((sizing) => {
           if (sizing && !shouldAbort()) setColumnSizing(sizing);
@@ -215,7 +275,7 @@ export function useColumnAutoSize({
           log.error(`[useColumnAutoSize] async measurement failed: ${String(err)}`);
         });
     },
-    [beginMeasurement]
+    [beginFullMeasurement]
   );
 
   // 初回適用 (columnsKey 変化時のみ): 小規模は paint 前に反映 (#368)、
@@ -236,7 +296,6 @@ export function useColumnAutoSize({
     // 手動トリガー結果が次の columnsKey 変化時に上書きされないよう記録
     appliedKeyRef.current = getColumnsKey(rs);
     runFullMeasurement(rs);
-    log.debug('[useColumnAutoSize] Manual trigger: all columns');
   }, [runFullMeasurement]);
 
   const triggerAutoSizeForColumn = useCallback(
@@ -253,21 +312,19 @@ export function useColumnAutoSize({
       if (rows.length <= SYNC_THRESHOLD) {
         const width = measureColumnWidth(columnId, headerText, rows, config);
         setColumnSizing((prev) => ({ ...prev, [columnId]: width }));
-        log.debug(`[useColumnAutoSize] Manual trigger: ${columnId} = ${width}px`);
         return;
       }
-      const shouldAbort = beginMeasurement();
+      const shouldAbort = beginPerColMeasurement(columnId);
       measureColumnWidthAsync(columnId, headerText, rows, config, shouldAbort)
         .then((width) => {
           if (width === null || shouldAbort()) return;
           setColumnSizing((prev) => ({ ...prev, [columnId]: width }));
-          log.debug(`[useColumnAutoSize] Manual trigger: ${columnId} = ${width}px`);
         })
         .catch((err: unknown) => {
           log.error(`[useColumnAutoSize] async measurement failed for ${columnId}: ${String(err)}`);
         });
     },
-    [beginMeasurement]
+    [beginPerColMeasurement]
   );
 
   return { columnSizing, setColumnSizing, triggerAutoSize, triggerAutoSizeForColumn };

--- a/frontend/src/tests/grid/ColumnResizer.test.tsx
+++ b/frontend/src/tests/grid/ColumnResizer.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ColumnResizer } from '../../components/grid/ColumnResizer';
 
 function renderResizer(
@@ -8,7 +8,8 @@ function renderResizer(
   const { container } = render(
     <ColumnResizer
       columnId="col_a"
-      onResizeStart={overrides.onResizeStart ?? vi.fn()}
+      currentWidth={100}
+      onResizeCommit={overrides.onResizeCommit ?? vi.fn()}
       onAutoSizeColumn={overrides.onAutoSizeColumn}
       {...overrides}
     />
@@ -19,6 +20,12 @@ function renderResizer(
 }
 
 describe('ColumnResizer', () => {
+  afterEach(() => {
+    // 残存した document listener / overlay indicator を必ず解除
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    cleanup();
+  });
+
   it('ダブルクリックで onAutoSizeColumn(columnId) を呼ぶ', () => {
     const onAutoSizeColumn = vi.fn();
     const el = renderResizer({ onAutoSizeColumn });
@@ -29,11 +36,11 @@ describe('ColumnResizer', () => {
     expect(onAutoSizeColumn).toHaveBeenCalledWith('col_a');
   });
 
-  it('ダブルクリックイベントは親に伝播しない (th の列選択ハンドラ干渉を防ぐ)', () => {
+  it('ダブルクリックイベントは親に伝播しない', () => {
     const parentDblClick = vi.fn();
     const { container } = render(
       <div onDoubleClick={parentDblClick}>
-        <ColumnResizer columnId="col_a" onResizeStart={vi.fn()} onAutoSizeColumn={vi.fn()} />
+        <ColumnResizer columnId="col_a" currentWidth={100} onResizeCommit={vi.fn()} />
       </div>
     );
     const el = container.querySelector('[class*="columnResizer"]');
@@ -44,11 +51,11 @@ describe('ColumnResizer', () => {
     expect(parentDblClick).not.toHaveBeenCalled();
   });
 
-  it('クリックイベントは親に伝播しない (th の列選択ハンドラ干渉を防ぐ)', () => {
+  it('クリックイベントは親に伝播しない', () => {
     const parentClick = vi.fn();
     const { container } = render(
       <div onClick={parentClick}>
-        <ColumnResizer columnId="col_a" onResizeStart={vi.fn()} />
+        <ColumnResizer columnId="col_a" currentWidth={100} onResizeCommit={vi.fn()} />
       </div>
     );
     const el = container.querySelector('[class*="columnResizer"]');
@@ -59,14 +66,78 @@ describe('ColumnResizer', () => {
     expect(parentClick).not.toHaveBeenCalled();
   });
 
-  it('mousedown / touchstart で onResizeStart を呼ぶ (drag resize の起点)', () => {
-    const onResizeStart = vi.fn();
-    const el = renderResizer({ onResizeStart });
+  it('mousedown→mousemove→mouseup で onResizeCommit が呼ばれる (currentWidth + dx)', () => {
+    const onResizeCommit = vi.fn();
+    const el = renderResizer({ onResizeCommit, currentWidth: 100 });
 
-    fireEvent.mouseDown(el);
-    fireEvent.touchStart(el);
+    fireEvent.mouseDown(el, { clientX: 50 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 80 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
 
-    expect(onResizeStart).toHaveBeenCalledTimes(2);
+    expect(onResizeCommit).toHaveBeenCalledTimes(1);
+    expect(onResizeCommit).toHaveBeenCalledWith('col_a', 130);
+  });
+
+  it('dx=0 (mouse 動かさず) で mouseup しても onResizeCommit は呼ばれない', () => {
+    const onResizeCommit = vi.fn();
+    const el = renderResizer({ onResizeCommit, currentWidth: 100 });
+
+    fireEvent.mouseDown(el, { clientX: 50 });
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    expect(onResizeCommit).not.toHaveBeenCalled();
+  });
+
+  it('minWidth で下限 clamp する', () => {
+    const onResizeCommit = vi.fn();
+    const el = renderResizer({ onResizeCommit, currentWidth: 100, minWidth: 80 });
+
+    // dx=-50 → 50px だが minWidth=80 で clamp
+    fireEvent.mouseDown(el, { clientX: 100 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    expect(onResizeCommit).toHaveBeenCalledWith('col_a', 80);
+  });
+
+  it('maxWidth で上限 clamp する', () => {
+    const onResizeCommit = vi.fn();
+    const el = renderResizer({ onResizeCommit, currentWidth: 100, maxWidth: 200 });
+
+    // dx=+500 → 600px だが maxWidth=200 で clamp
+    fireEvent.mouseDown(el, { clientX: 0 });
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 500 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    expect(onResizeCommit).toHaveBeenCalledWith('col_a', 200);
+  });
+
+  it('mousedown で overlay indicator が body に挿入され、mouseup で削除される', () => {
+    const el = renderResizer();
+    const before = document.body.children.length;
+
+    fireEvent.mouseDown(el, { clientX: 50 });
+    const during = document.body.children.length;
+
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    const after = document.body.children.length;
+
+    expect(during).toBe(before + 1);
+    expect(after).toBe(before);
+  });
+
+  it('mouseup 後の mousemove は indicator 移動を起こさない (listener 解除確認)', () => {
+    const onResizeCommit = vi.fn();
+    const el = renderResizer({ onResizeCommit, currentWidth: 100 });
+
+    fireEvent.mouseDown(el, { clientX: 50 });
+    document.dispatchEvent(new MouseEvent('mouseup'));
+    onResizeCommit.mockClear();
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200 }));
+    document.dispatchEvent(new MouseEvent('mouseup'));
+
+    expect(onResizeCommit).not.toHaveBeenCalled();
   });
 
   it('onAutoSizeColumn 未指定でもダブルクリックで例外を投げない', () => {

--- a/frontend/src/tests/grid/ResultGrid.autoAdjustWiring.integration.test.tsx
+++ b/frontend/src/tests/grid/ResultGrid.autoAdjustWiring.integration.test.tsx
@@ -1,0 +1,287 @@
+// 列幅オートアジャストは toolbar ボタン / ContextMenu / dblclick / Ctrl+Shift+A の 4 経路で
+// 起動する。hook 単体と UI 単体はそれぞれ pass するが、実機で「toolbar ボタン」「ContextMenu
+// 全列/単列」経路のみアジャストが反映されない報告が出た (fix/drag-lag-probe, progress.md 3rd round)。
+// このファイルは hook (useColumnAutoSize) と UI (GridToolbar / useGridContextMenu) を
+// 実際に wiring した integration レベルで「click/action → columnSizing state 更新」の
+// end-to-end が成立しているかを検証する RED。GREEN 後も回帰テストとして残す。
+//
+// 検出戦略:
+//   1. 初期 rowData 短 content で mount → useLayoutEffect が初回 auto-size を実行
+//   2. descriptionText を長 content に rerender。columnsKey (name:type) は不変のため
+//      useLayoutEffect の guard で再計算がスキップされ columnSizing は初期値のまま
+//   3. 各経路から trigger → runFullMeasurement が新 rowData で再計算するはず
+//   4. 300px (varchar clamp) への変化を検証
+
+import type { ColumnDef } from '@tanstack/react-table';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useMemo } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/logger', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+import { GridToolbar } from '../../components/grid/GridToolbar';
+import { useColumnAutoSize } from '../../components/grid/hooks/useColumnAutoSize';
+import { useGridContextMenu } from '../../components/grid/hooks/useGridContextMenu';
+import type { ResultSet } from '../../types';
+import type { ColumnMeta, RowData } from '../../types/grid';
+
+const CONTEXT_MENU_ALL_COLUMNS = '全列をオートアジャスト';
+const CONTEXT_MENU_SINGLE_COLUMN = 'この列をオートアジャスト';
+// varchar 型の maxWidth 上限 (TEXT/JSON 暴発防止、useColumnAutoSize.ts の config と同値)
+const VARCHAR_MAX_WIDTH = 300;
+// setup.ts の mock: width = text.length * fontSize * 0.6。
+// useColumnAutoSize.ts の FONT は `14px ${MONO_STACK}` (ResultGrid.module.css `.table` と一致)。
+const MOCK_CHAR_WIDTH = 14 * 0.6;
+// CELL_HORIZONTAL_PADDING (CSS .th/.td 24 + sort indicator 8)
+const EXPECTED_PADDING = 32;
+
+interface MenuItemRef {
+  current: Array<{ label: string; action: () => void }>;
+}
+
+interface HarnessProps {
+  sizingObserver: { current: Record<string, number> | null };
+  menuItemsObserver?: MenuItemRef;
+  descriptionText: string;
+  /** 行数。>500 で useColumnAutoSize が async chunk path に入る (SYNC_THRESHOLD=500) */
+  rowCount?: number;
+}
+
+function Harness({
+  sizingObserver,
+  menuItemsObserver,
+  descriptionText,
+  rowCount = 1,
+}: HarnessProps) {
+  const resultSet = useMemo<ResultSet>(
+    () => ({
+      columns: [
+        { name: 'description', type: 'varchar', size: 0, nullable: true, isPrimaryKey: false },
+      ],
+      rows: Array.from({ length: rowCount }, () => [descriptionText]),
+      affectedRows: 0,
+      executionTimeMs: 0,
+    }),
+    [descriptionText, rowCount]
+  );
+
+  const columns = useMemo<ColumnDef<RowData>[]>(
+    () => [
+      {
+        id: 'description',
+        header: 'description',
+        accessorKey: 'description',
+        size: 150,
+        minSize: 80,
+      },
+    ],
+    []
+  );
+
+  const rowData = useMemo<RowData[]>(
+    () =>
+      Array.from({ length: rowCount }, (_, i) => ({
+        __rowIndex: String(i + 1),
+        __originalIndex: String(i),
+        description: descriptionText,
+      })),
+    [descriptionText, rowCount]
+  );
+
+  const columnsMeta = useMemo<ColumnMeta[]>(
+    () => [{ name: 'description', comment: '', type: 'varchar' }],
+    []
+  );
+
+  const { columnSizing, triggerAutoSize, triggerAutoSizeForColumn } = useColumnAutoSize({
+    resultSet,
+    columns,
+    rowData,
+  });
+  sizingObserver.current = columnSizing;
+
+  const gridRows = useMemo(() => rowData.map((r) => ({ original: r })), [rowData]);
+  const tableShim = useMemo(() => ({ getColumn: () => undefined }), []);
+
+  const { openHeaderMenu, getMenuItems } = useGridContextMenu(columnsMeta, gridRows, tableShim, {
+    isEditMode: false,
+    onAutoSizeColumn: triggerAutoSizeForColumn,
+    onAutoSizeColumns: triggerAutoSize,
+  });
+
+  // contextMenu state 確定後 (click で open した後) の getMenuItems を外部へ公開
+  if (menuItemsObserver) menuItemsObserver.current = getMenuItems();
+
+  return (
+    <div>
+      <GridToolbar
+        showRefresh={false}
+        canEdit={false}
+        hasChanges={false}
+        isApplying={false}
+        applyError={null}
+        hasValidationErrors={false}
+        showLogicalNamesInGrid={false}
+        showColumnFilters={false}
+        isReadOnly={false}
+        viewMode="table"
+        onRefresh={() => {}}
+        onInsertRow={() => {}}
+        onDeleteRow={() => {}}
+        onRevertChanges={() => {}}
+        onApplyChanges={() => {}}
+        onSetShowLogicalNames={() => {}}
+        onToggleColumnFilters={() => {}}
+        onExport={() => {}}
+        onAutoSizeColumns={triggerAutoSize}
+        onChangeViewMode={() => {}}
+      />
+      <button
+        type="button"
+        data-testid="open-header-menu"
+        onClick={(e) => openHeaderMenu(e, 'description')}
+      >
+        open
+      </button>
+    </div>
+  );
+}
+
+describe('ResultGrid auto-adjust 経路 integration (4 経路の state 末端まで)', () => {
+  afterEach(() => cleanup());
+
+  it('初期 mount で useLayoutEffect 経由の auto-size が短 content を反映する', () => {
+    const sizingRef = { current: null as Record<string, number> | null };
+    render(<Harness sizingObserver={sizingRef} descriptionText="short" />);
+
+    // header 'description' = 11 chars, content 'short' = 5 chars → header の方が広い
+    // 11 * 8.4 + 32 = 124.4
+    const expected = 'description'.length * MOCK_CHAR_WIDTH + EXPECTED_PADDING;
+    expect(sizingRef.current?.description).toBeCloseTo(expected, 5);
+  });
+
+  it('ツールバー ↔ ボタン click: content 長変更後に click すると新 content で再計算される', () => {
+    const sizingRef = { current: null as Record<string, number> | null };
+    const { rerender } = render(<Harness sizingObserver={sizingRef} descriptionText="short" />);
+    const initialWidth = sizingRef.current?.description;
+
+    // content を 100 chars に変更。columnsKey (description:varchar) 不変のため
+    // useLayoutEffect の guard で再計算スキップ → sizing は初期値のまま
+    rerender(<Harness sizingObserver={sizingRef} descriptionText={'X'.repeat(100)} />);
+    expect(sizingRef.current?.description).toBe(initialWidth);
+
+    // button click → triggerAutoSize → 新 rowData で再計算 → 100*8.4+32=872 → varchar 300 にクランプ
+    act(() => {
+      fireEvent.click(screen.getByTitle(/列幅をオートアジャスト/));
+    });
+    expect(sizingRef.current?.description).toBe(VARCHAR_MAX_WIDTH);
+  });
+
+  it('ContextMenu "全列をオートアジャスト" action: triggerAutoSize 経由で state が更新される', () => {
+    const sizingRef = { current: null as Record<string, number> | null };
+    const menuRef: MenuItemRef = { current: [] };
+    const { rerender } = render(
+      <Harness sizingObserver={sizingRef} menuItemsObserver={menuRef} descriptionText="short" />
+    );
+    const initialWidth = sizingRef.current?.description;
+
+    rerender(
+      <Harness
+        sizingObserver={sizingRef}
+        menuItemsObserver={menuRef}
+        descriptionText={'X'.repeat(100)}
+      />
+    );
+    expect(sizingRef.current?.description).toBe(initialWidth);
+
+    // header menu を開く (contextMenu state をセット → 再 render で getMenuItems が実アイテムを返す)
+    act(() => {
+      fireEvent.click(screen.getByTestId('open-header-menu'));
+    });
+
+    const allItem = menuRef.current.find((i) => i.label === CONTEXT_MENU_ALL_COLUMNS);
+    expect(allItem, 'ContextMenu に "全列をオートアジャスト" が存在する').toBeDefined();
+
+    act(() => {
+      allItem?.action();
+    });
+    expect(sizingRef.current?.description).toBe(VARCHAR_MAX_WIDTH);
+    expect(sizingRef.current?.description).not.toBe(initialWidth);
+  });
+
+  it('ContextMenu "この列をオートアジャスト" action: triggerAutoSizeForColumn 経由で state が更新される', () => {
+    const sizingRef = { current: null as Record<string, number> | null };
+    const menuRef: MenuItemRef = { current: [] };
+    const { rerender } = render(
+      <Harness sizingObserver={sizingRef} menuItemsObserver={menuRef} descriptionText="short" />
+    );
+    const initialWidth = sizingRef.current?.description;
+
+    rerender(
+      <Harness
+        sizingObserver={sizingRef}
+        menuItemsObserver={menuRef}
+        descriptionText={'X'.repeat(100)}
+      />
+    );
+    expect(sizingRef.current?.description).toBe(initialWidth);
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('open-header-menu'));
+    });
+
+    const singleItem = menuRef.current.find((i) => i.label === CONTEXT_MENU_SINGLE_COLUMN);
+    expect(singleItem, 'ContextMenu に "この列をオートアジャスト" が存在する').toBeDefined();
+
+    act(() => {
+      singleItem?.action();
+    });
+    expect(sizingRef.current?.description).toBe(VARCHAR_MAX_WIDTH);
+    expect(sizingRef.current?.description).not.toBe(initialWidth);
+  });
+
+  // 実機 (fix/drag-lag-probe, 4/23 17:21 ログ) で発覚した abort 連鎖を UI 末端で回帰ガード。
+  // sync path (rowCount=1) の既存 4 test は Harness が SYNC_THRESHOLD(500) 以下のため
+  // cancellation token を通らず false GREEN になっていた。async path を踏む構成で
+  // 「全列 triggerAutoSize 進行中に単列 trigger を割込んでも全列が commit される」を検証する。
+  it('async path: toolbar 全列 trigger 進行中に ContextMenu 単列 trigger しても全列結果が反映される', async () => {
+    const ASYNC_ROW_COUNT = 600; // > SYNC_THRESHOLD(500)
+    const sizingRef = { current: null as Record<string, number> | null };
+    const menuRef: MenuItemRef = { current: [] };
+
+    // 長 content で mount → useLayoutEffect の全列 async が開始される
+    render(
+      <Harness
+        sizingObserver={sizingRef}
+        menuItemsObserver={menuRef}
+        descriptionText={'X'.repeat(100)}
+        rowCount={ASYNC_ROW_COUNT}
+      />
+    );
+
+    // async 完了前の初期状態では columnSizing は未設定 ({})
+    expect(sizingRef.current?.description).toBeUndefined();
+
+    // 全列 async 進行中に ContextMenu 単列を割込ませる
+    act(() => {
+      fireEvent.click(screen.getByTestId('open-header-menu'));
+    });
+    const singleItem = menuRef.current.find((i) => i.label === CONTEXT_MENU_SINGLE_COLUMN);
+    expect(singleItem, 'ContextMenu 単列アイテムが存在する').toBeDefined();
+    act(() => {
+      singleItem?.action();
+    });
+
+    // 修正前 (measurementIdRef 共有) では全列 async が単列 trigger で abort され、
+    // description が VARCHAR_MAX_WIDTH に到達しなかった (undefined のまま)。
+    // 修正後 (token 分離) では全列完走 → 300 にクランプされる。
+    await waitFor(
+      () => {
+        expect(sizingRef.current?.description).toBe(VARCHAR_MAX_WIDTH);
+      },
+      { timeout: 3000 }
+    );
+  });
+});

--- a/frontend/src/tests/grid/ResultGrid.paramChain.integration.test.tsx
+++ b/frontend/src/tests/grid/ResultGrid.paramChain.integration.test.tsx
@@ -1,0 +1,353 @@
+// ResultGrid のパラメタ chain 検証 integration テスト
+//
+// Harness 迂回ではなく ResultGrid 実 mount + 子コンポ/子 hook spy で
+// 「useColumnAutoSize への入力」「triggerAutoSize/ForColumn の伝達先 identity」
+// 「columnSizing prop の伝達」「rerender 跨ぎの rowData identity」を一発で検証する。
+//
+// 既存 `scrollPersistence.test.tsx` 方針 (Harness 迂回) からの意図的な逸脱:
+// パラメタ chain のズレ (callback 参照入れ替え / prop 忘れ) は Harness 再現では
+// 検出できないため、実 ResultGrid を mount して props 伝達を直接 capture する。
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ===== hoisted spy 群 (vi.mock factory から参照するため) =====
+const spies = vi.hoisted(() => {
+  const triggerAutoSize = { current: (() => {}) as () => void };
+  const triggerAutoSizeForColumn = { current: (() => {}) as (id: string) => void };
+  const columnSizing: Record<string, number> = {};
+  const setColumnSizing = { current: ((_: unknown) => {}) as (u: unknown) => void };
+  return {
+    autoSizeArgs: { current: null as unknown },
+    autoSizeCallCount: { current: 0 },
+    toolbarProps: { current: null as Record<string, unknown> | null },
+    gridTableProps: { current: null as Record<string, unknown> | null },
+    keyboardArgs: { current: null as Record<string, unknown> | null },
+    triggerAutoSize,
+    triggerAutoSizeForColumn,
+    columnSizing,
+    setColumnSizing,
+  };
+});
+
+// ===== store mock =====
+const storeState = vi.hoisted(() => ({
+  current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../../store/queryStore', () => ({
+  useQueryStore: Object.assign(
+    (selector: (s: unknown) => unknown) => selector(storeState.current),
+    {
+      getState: () => storeState.current,
+      setState: (patch: Record<string, unknown>) => {
+        storeState.current = { ...storeState.current, ...patch };
+      },
+      subscribe: () => () => {},
+    }
+  ),
+  useIsActiveDataView: () => false,
+  useIsQueryExecuting: () => false,
+  useQueryResult: () => (storeState.current as { result?: unknown }).result ?? null,
+  useQueryError: () => null,
+  useQueryById: () => (storeState.current as { currentQuery?: unknown }).currentQuery ?? null,
+  usePaginationState: () => null,
+  useQueryActions: () => ({
+    applyWhereFilter: vi.fn(),
+    refreshDataView: vi.fn(),
+    openTableData: vi.fn(),
+    cancelQuery: vi.fn(),
+    fetchMoreRows: vi.fn(),
+    resetPaginatedSort: vi.fn(),
+  }),
+}));
+
+vi.mock('../../store/connectionStore', () => ({
+  useConnectionStore: (selector: (s: { connections: unknown[] }) => unknown) =>
+    selector({ connections: [] }),
+}));
+
+vi.mock('../../store/scrollPositionStore', () => ({
+  useScrollPositionStore: Object.assign((selector: (s: unknown) => unknown) => selector({}), {
+    getState: () => ({
+      savePosition: vi.fn(),
+      getPosition: () => null,
+    }),
+  }),
+}));
+
+vi.mock('../../store/sessionStore', () => ({
+  useSessionStore: (
+    selector: (s: {
+      showLogicalNamesInGrid: boolean;
+      setShowLogicalNamesInGrid: (v: boolean) => void;
+    }) => unknown
+  ) =>
+    selector({
+      showLogicalNamesInGrid: false,
+      setShowLogicalNamesInGrid: vi.fn(),
+    }),
+}));
+
+// ===== useColumnAutoSize spy (最重要) =====
+vi.mock('../../components/grid/hooks/useColumnAutoSize', () => ({
+  useColumnAutoSize: (args: unknown) => {
+    spies.autoSizeArgs.current = args;
+    spies.autoSizeCallCount.current++;
+    return {
+      columnSizing: spies.columnSizing,
+      setColumnSizing: spies.setColumnSizing.current,
+      triggerAutoSize: spies.triggerAutoSize.current,
+      triggerAutoSizeForColumn: spies.triggerAutoSizeForColumn.current,
+    };
+  },
+}));
+
+// ===== 子 component spy =====
+vi.mock('../../components/grid/GridToolbar', () => ({
+  GridToolbar: (props: Record<string, unknown>) => {
+    spies.toolbarProps.current = props;
+    return (
+      <button
+        data-testid="tb-autosize"
+        type="button"
+        onClick={() => (props.onAutoSizeColumns as () => void)?.()}
+      >
+        auto
+      </button>
+    );
+  },
+}));
+
+vi.mock('../../components/grid/GridTable', () => ({
+  GridTable: (props: Record<string, unknown>) => {
+    spies.gridTableProps.current = props;
+    return <div data-testid="grid-table" />;
+  },
+}));
+
+vi.mock('../../components/grid/GridStatusBar', () => ({ GridStatusBar: () => null }));
+vi.mock('../../components/grid/GridFilterBar', () => ({ GridFilterBar: () => null }));
+vi.mock('../../components/grid/TransposeView', () => ({ TransposeView: () => null }));
+vi.mock('../../components/grid/ResultTabs', () => ({ ResultTabs: () => null }));
+vi.mock('../../components/grid/ValueEditorDialog', () => ({ ValueEditorDialog: () => null }));
+vi.mock('../../components/dialogs/QueryConfirmDialog', () => ({ QueryConfirmDialog: () => null }));
+
+// ===== 他 hook stub =====
+const stableGetInsertedRows = vi.hoisted(() => {
+  const empty = new Map<number, Record<string, string | null>>();
+  return () => empty;
+});
+
+vi.mock('../../components/grid/hooks/useGridEdit', () => ({
+  useGridEdit: () => ({
+    isEditMode: false,
+    hasChanges: false,
+    isApplying: false,
+    applyError: null,
+    previewStatements: [],
+    isRowDeleted: () => false,
+    isRowInserted: () => false,
+    getInsertedRows: stableGetInsertedRows,
+    getCellChange: () => null,
+    getValidationError: () => null,
+    hasValidationErrors: false,
+    updateCell: () => {},
+    revertChanges: () => {},
+    deleteRow: () => {},
+    cloneRow: () => {},
+    insertRow: () => {},
+    buildPreview: () => {},
+    executePreview: () => {},
+    dismissPreview: () => {},
+  }),
+}));
+
+vi.mock('../../components/grid/hooks/useGridSelection', () => ({
+  useGridSelection: () => ({
+    selectedRows: new Set<number>(),
+    selectedColumns: new Set<string>(),
+    selectionState: { selectedRows: new Set<number>(), selectedColumns: new Set<string>() },
+    toggleRow: vi.fn(),
+    rangeSelectRow: vi.fn(),
+    selectCell: vi.fn(),
+    rangeCellSelect: vi.fn(),
+    selectColumn: vi.fn(),
+    rangeSelectColumn: vi.fn(),
+    selectAllRows: vi.fn(),
+    resetSelection: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/grid/hooks/useGridKeyboard', () => ({
+  useGridKeyboard: (args: Record<string, unknown>) => {
+    spies.keyboardArgs.current = args;
+    return {
+      editingCell: null,
+      editValue: '',
+      setEditValue: vi.fn(),
+      startEdit: vi.fn(),
+      commitEdit: vi.fn(),
+    };
+  },
+}));
+
+vi.mock('../../components/grid/hooks/useWhereFilter', () => ({
+  useWhereFilter: () => ({
+    whereClause: '',
+    whereFilterError: null,
+    setWhereFilterError: vi.fn(),
+    whereKeyDown: vi.fn(),
+    whereApply: vi.fn(),
+    whereClear: vi.fn(),
+    whereChange: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/grid/hooks/useRelatedRows', () => ({
+  useRelatedRows: () => ({
+    isForeignKeyColumn: () => false,
+    navigateToRelatedRow: vi.fn(),
+  }),
+}));
+
+vi.mock('../../components/grid/hooks/useElapsedTimer', () => ({
+  useElapsedTimer: () => 0,
+}));
+
+vi.mock('../../components/grid/hooks/useClampedActiveIndex', () => ({
+  useClampedActiveIndex: () => [0, vi.fn()],
+}));
+
+// ===== util mock =====
+vi.mock('../../utils/logger', () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warning: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('../../utils/lazyWithRetry', () => ({
+  lazyWithRetry: () => () => null,
+}));
+
+// ===== import (mock 後) =====
+import { ResultGrid } from '../../components/grid/ResultGrid';
+import type { ResultSet } from '../../types';
+
+const resultSetFixture: ResultSet = {
+  columns: [
+    { name: 'id', type: 'int', size: 0, nullable: false, isPrimaryKey: true },
+    { name: 'name', type: 'varchar', size: 50, nullable: true, isPrimaryKey: false },
+  ],
+  rows: [
+    ['1', 'alice'],
+    ['2', 'bob'],
+  ],
+  affectedRows: 0,
+  executionTimeMs: 0,
+};
+
+function resetSpies(): void {
+  spies.autoSizeArgs.current = null;
+  spies.autoSizeCallCount.current = 0;
+  spies.toolbarProps.current = null;
+  spies.gridTableProps.current = null;
+  spies.keyboardArgs.current = null;
+  spies.triggerAutoSize.current = vi.fn();
+  spies.triggerAutoSizeForColumn.current = vi.fn();
+  spies.setColumnSizing.current = vi.fn();
+  // columnSizing は identity 比較したいので使い回す
+  for (const k of Object.keys(spies.columnSizing)) delete spies.columnSizing[k];
+}
+
+describe('ResultGrid パラメタ chain (候補 a-d 一括検証)', () => {
+  beforeEach(() => {
+    storeState.current = {
+      activeQueryId: 'q1',
+      result: resultSetFixture,
+      currentQuery: {
+        id: 'q1',
+        connectionId: null,
+        sourceTable: null,
+        whereClause: '',
+      },
+    };
+    resetSpies();
+  });
+
+  afterEach(() => cleanup());
+
+  it('useColumnAutoSize は { resultSet, columns, rowData } を shape 通り受け取る', () => {
+    render(<ResultGrid queryId="q1" />);
+
+    const args = spies.autoSizeArgs.current as {
+      resultSet: ResultSet;
+      columns: { id: string }[];
+      rowData: Record<string, string | null>[];
+    } | null;
+
+    expect(args).not.toBeNull();
+    expect(args?.resultSet).toBe(resultSetFixture);
+    expect(args?.columns.map((c) => c.id)).toEqual(['id', 'name']);
+    expect(args?.rowData).toHaveLength(2);
+    expect(args?.rowData[0].id).toBe('1');
+    expect(args?.rowData[0].name).toBe('alice');
+  });
+
+  it('GridToolbar.onAutoSizeColumns === triggerAutoSize (identity 一致)', () => {
+    render(<ResultGrid queryId="q1" />);
+    expect(spies.toolbarProps.current?.onAutoSizeColumns).toBe(spies.triggerAutoSize.current);
+  });
+
+  it('GridTable.onAutoSizeColumn === triggerAutoSizeForColumn', () => {
+    render(<ResultGrid queryId="q1" />);
+    expect(spies.gridTableProps.current?.onAutoSizeColumn).toBe(
+      spies.triggerAutoSizeForColumn.current
+    );
+  });
+
+  it('GridTable.onAutoSizeColumns === triggerAutoSize', () => {
+    render(<ResultGrid queryId="q1" />);
+    expect(spies.gridTableProps.current?.onAutoSizeColumns).toBe(spies.triggerAutoSize.current);
+  });
+
+  it('GridTable.columnSizing === useColumnAutoSize.columnSizing (identity 伝達)', () => {
+    render(<ResultGrid queryId="q1" />);
+    expect(spies.gridTableProps.current?.columnSizing).toBe(spies.columnSizing);
+  });
+
+  it('useGridKeyboard.onAutoSizeColumns === triggerAutoSize (Ctrl+Shift+A 経路)', () => {
+    render(<ResultGrid queryId="q1" />);
+    expect(spies.keyboardArgs.current?.onAutoSizeColumns).toBe(spies.triggerAutoSize.current);
+  });
+
+  it('toolbar click で triggerAutoSize が呼ばれる (4 経路のうち 1 つ: 末端到達)', () => {
+    const trigger = vi.fn();
+    spies.triggerAutoSize.current = trigger;
+    const { getByTestId } = render(<ResultGrid queryId="q1" />);
+    fireEvent.click(getByTestId('tb-autosize'));
+    expect(trigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('rerender 跨ぎで rowData identity 安定 (getInsertedRows 空なら baseRowData 直返し)', () => {
+    const { rerender } = render(<ResultGrid queryId="q1" />);
+    const first = (spies.autoSizeArgs.current as { rowData: unknown[] }).rowData;
+    rerender(<ResultGrid queryId="q1" />);
+    const second = (spies.autoSizeArgs.current as { rowData: unknown[] }).rowData;
+    expect(second).toBe(first);
+  });
+
+  it('rerender 跨ぎで columns identity 安定 (resultSet.columns 不変 + showLogicalNames 不変)', () => {
+    const { rerender } = render(<ResultGrid queryId="q1" />);
+    const first = (spies.autoSizeArgs.current as { columns: unknown[] }).columns;
+    rerender(<ResultGrid queryId="q1" />);
+    const second = (spies.autoSizeArgs.current as { columns: unknown[] }).columns;
+    expect(second).toBe(first);
+  });
+
+  it('rerender 跨ぎで resultSet identity 安定 (store 同値)', () => {
+    const { rerender } = render(<ResultGrid queryId="q1" />);
+    const first = (spies.autoSizeArgs.current as { resultSet: unknown }).resultSet;
+    rerender(<ResultGrid queryId="q1" />);
+    const second = (spies.autoSizeArgs.current as { resultSet: unknown }).resultSet;
+    expect(second).toBe(first);
+  });
+});

--- a/frontend/src/tests/grid/useColumnAutoSize.test.ts
+++ b/frontend/src/tests/grid/useColumnAutoSize.test.ts
@@ -338,6 +338,45 @@ describe('useColumnAutoSize', () => {
       expect(result.current.columnSizing.a).toBeGreaterThan(200);
     });
 
+    // 実機 (fix/drag-lag-probe, 4/23 実機ログ) で発覚したリグレッション:
+    // toolbar ボタン経由の全列 triggerAutoSize が async 進行中、ContextMenu 単列 trigger
+    // (triggerAutoSizeForColumn) を呼ぶと、両者で共用する measurementIdRef が +1 され
+    // 全列 async が shouldAbort() で中断、全列の setColumnSizing が永遠に呼ばれなかった。
+    // 全列と単列は独立 axis のため互いに kill してはならない。
+    it('全列 triggerAutoSize 進行中に triggerAutoSizeForColumn を呼んでも全列結果が反映される', async () => {
+      const cols = [
+        { name: 'a', type: 'varchar' },
+        { name: 'b', type: 'varchar' },
+      ];
+      const columns = makeColumns(['a', 'b']);
+      const rows: string[][] = [];
+      for (let i = 0; i < ASYNC_ROW_COUNT; i++) {
+        // 最終行だけ長い値を持たせる (全列 async が最後まで走らないと拾われない)
+        rows.push(i === ASYNC_ROW_COUNT - 1 ? ['A'.repeat(30), 'B'.repeat(30)] : ['x', 'y']);
+      }
+      const resultSet = makeResultSet(cols, rows);
+      const rowData = makeRowData(['a', 'b'], rows);
+
+      const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+      // 初回 useLayoutEffect の全列 async 計測が進行中の状態で、単列 trigger を割り込ませる。
+      // 不具合再現時: 単列 trigger が全列 token を +1 → 全列 async 中断 →
+      //   columnSizing.b は永遠に未設定のまま (abort された全列結果の setState が skip されるため)。
+      // 修正後: 全列 token と単列 token が分離 → 全列は自然に完走、単列は a だけ更新。
+      act(() => {
+        result.current.triggerAutoSizeForColumn('a');
+      });
+
+      // 全列計測の完走を待つ = b 列が長文 'B'.repeat(30) で計測され 200px 超になること
+      await waitFor(
+        () => {
+          expect(result.current.columnSizing.b).toBeGreaterThan(200);
+        },
+        { timeout: 3000 }
+      );
+      expect(result.current.columnSizing.a).toBeGreaterThan(200);
+    });
+
     // Issue #387: 超大規模データで SYNC_FULL_LIMIT (20000 行) 超過分は計測対象外とする。
     // この上限が撤廃されるとメインスレッドが長時間ブロックされる回帰となるため
     // 先頭 20000 行で clamping される既存動作を特性テストとして固定する。
@@ -363,6 +402,73 @@ describe('useColumnAutoSize', () => {
       // limit 超過行が拾われる実装に退行すると maxWidth 300 にクランプされる。
       // 現仕様では 'x' だけが対象 = padding 込 15.8 → minWidth 50 にクランプ。
       expect(result.current.columnSizing.a).toBe(50);
+    });
+  });
+
+  // CSS .th/.td の左右 padding (12*2=24) + sort indicator (▲▼) 分 8 の合計 32 を
+  // CELL_HORIZONTAL_PADDING として定数化した経緯 (ResultGrid.module.css 準拠)。
+  // また numeric は桁で幅爆発せず、date は ISO8601 系で概ね固定長のため実幅尊重
+  // (maxWidth=∞)、varchar/不明型は TEXT/JSON で暴発し得るため 300 の上限を維持する。
+  describe('getColumnConfig (型別 minWidth/maxWidth/padding)', () => {
+    it('varchar: width = max(header, content) + CELL_HORIZONTAL_PADDING(32)', () => {
+      // header/content とも 4 文字: 4 × 14 × 0.6 = 33.6px, + padding 32 = 65.6。
+      // FONT は `14px ${MONO_STACK}` (ResultGrid.module.css .table の font-size: 14px と一致)。
+      // setup.ts mock: width = text.length * fontSize * 0.6 で 14px 時 33.6 を返す。
+      // varchar [50, 300] の範囲内で clamp されないため padding 値が直接観測できる。
+      // padding を 8 等に戻すと 33.6+8=41.6 が minWidth 50 に clamp され値が 50 になり検出。
+      const cols = [{ name: 'abcd', type: 'varchar' }];
+      const columns = makeColumns(['abcd']);
+      const rows = [['abcd']];
+      const resultSet = makeResultSet(cols, rows);
+      const rowData = makeRowData(['abcd'], rows);
+
+      const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+      expect(result.current.columnSizing.abcd).toBeCloseTo(33.6 + 32, 5);
+    });
+
+    it('numeric 列は maxWidth=Infinity で長い数値コンテンツがクランプされない', () => {
+      // 200 桁 → 200 × 7.8 + 32 = 1592px。maxWidth=120 等に退行すると 120 に clamp され検出。
+      const longNumber = '9'.repeat(200);
+      const cols = [{ name: 'n', type: 'bigint' }];
+      const columns = makeColumns(['n']);
+      const rows = [[longNumber]];
+      const resultSet = makeResultSet(cols, rows);
+      const rowData = makeRowData(['n'], rows);
+
+      const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+      // maxWidth 退行検出: 明らかに旧 120 を超える値が通ることを確認。
+      expect(result.current.columnSizing.n).toBeGreaterThan(500);
+    });
+
+    it('date 列は maxWidth=Infinity で長いコンテンツがクランプされない', () => {
+      // 100 文字 → 100 × 7.8 + 32 = 812px。maxWidth=180 等に退行すると 180 に clamp され検出。
+      const longDate = 'A'.repeat(100);
+      const cols = [{ name: 'd', type: 'datetime' }];
+      const columns = makeColumns(['d']);
+      const rows = [[longDate]];
+      const resultSet = makeResultSet(cols, rows);
+      const rowData = makeRowData(['d'], rows);
+
+      const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+      expect(result.current.columnSizing.d).toBeGreaterThan(500);
+    });
+
+    it('varchar/不明型は maxWidth=300 で上限 clamp を維持 (TEXT/JSON 暴発防止)', () => {
+      // 100 文字 → 812px だが varchar は上限 300 に clamp。
+      // maxWidth を ∞ に変更する退行が起きると 812 が通ってしまう。
+      const longText = 'A'.repeat(100);
+      const cols = [{ name: 's', type: 'varchar' }];
+      const columns = makeColumns(['s']);
+      const rows = [[longText]];
+      const resultSet = makeResultSet(cols, rows);
+      const rowData = makeRowData(['s'], rows);
+
+      const { result } = renderHook(() => useColumnAutoSize({ resultSet, columns, rowData }));
+
+      expect(result.current.columnSizing.s).toBe(300);
     });
   });
 });

--- a/frontend/src/tests/grid/useGridKeyboard.test.ts
+++ b/frontend/src/tests/grid/useGridKeyboard.test.ts
@@ -19,7 +19,7 @@ vi.mock('../../hooks/useKeyboardHandler', () => ({
 }));
 
 vi.mock('../../utils/logger', () => ({
-  log: { debug: vi.fn() },
+  log: { debug: vi.fn(), info: vi.fn(), warning: vi.fn(), error: vi.fn() },
 }));
 
 // --- Test data ---


### PR DESCRIPTION
WebView2 の setTimeout throttling 下で calculateColumnSizingAsync が列ごとに chunk yield する構造 (115列×20=2300 yields) が完了不能となり、全列のsetColumnSizing が呼ばれない事象を修正。

- 行 chunk 反転: 列数非依存の O(rows/CHUNK)=20 yields 固定に変更
- cancellation token を「全列計測」「単列計測(列ごと)」で独立 axis に分離し手動 trigger 相互 abort を排除
- measureText font を実描画 CSS (14px Consolas stack) と一致させ、 DATE/NVARCHAR 列の文字切れを解消
- numeric/date 列の maxWidth を Infinity に緩和 (実コンテンツ幅を尊重)
- 自前 resize overlay 実装に切替 (TanStack 内蔵 resize の state 更新によるdrag lag 回避)

Closes #387