### PR TITLE
feat: 左ペインのテーブル右クリックに INSERT文をコピー を追加 (#388)

### DIFF
--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useColumnActions } from '../../hooks/useColumnActions';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { useTableActions } from '../../hooks/useTableActions';
 import { useConnectionStore } from '../../store/connectionStore';
+import { useToastStore } from '../../store/toastStore';
 import type { Connection, DatabaseObject, MenuItem } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
 import { log } from '../../utils/logger';
-import { buildSelectSql } from '../../utils/sqlIdentifier';
+import { buildInsertTemplateSql, buildSelectSql } from '../../utils/sqlIdentifier';
 import {
   type ExpandableType,
+  extractBareTableName,
   isExpandableType,
   parseTableNodeId,
   shouldLoadColumns,
@@ -162,6 +165,8 @@ export function ConnectionTreeSection({
     setTreeData,
   });
 
+  const copyToClipboard = useCopyToClipboard();
+
   // Build tree when connection changes
   useEffect(() => {
     let isCancelled = false;
@@ -314,6 +319,30 @@ export function ConnectionTreeSection({
           },
         });
 
+        // INSERT文をコピー (table のみ、view 除外)
+        if (node.type === 'table') {
+          items.push({
+            label: 'INSERT文をコピー',
+            action: async () => {
+              try {
+                const columns = await bridge.getColumns(
+                  connection.id,
+                  extractBareTableName(node.name)
+                );
+                const sql = buildInsertTemplateSql(
+                  node.name,
+                  columns.map((c) => c.name),
+                  connection.dbType
+                );
+                await copyToClipboard(sql, 'INSERT文をコピーしました');
+              } catch (error) {
+                log.error(`Failed to build INSERT template: ${error}`);
+                useToastStore.getState().addToast('INSERT文の生成に失敗しました', 'error');
+              }
+            },
+          });
+        }
+
         // テーブルを開く
         items.push({
           label: 'データを開く',
@@ -330,9 +359,11 @@ export function ConnectionTreeSection({
         items.push({
           label: 'カラム一覧をコピー',
           action: async () => {
-            const tableName = node.name.includes('.') ? node.name.split('.')[1] : node.name;
             try {
-              const columns = await bridge.getColumns(connection.id, tableName);
+              const columns = await bridge.getColumns(
+                connection.id,
+                extractBareTableName(node.name)
+              );
               const columnList = columns.map((c) => c.name).join(', ');
               await navigator.clipboard.writeText(columnList);
             } catch (error) {
@@ -395,6 +426,7 @@ export function ConnectionTreeSection({
       loadTables,
       getColumnMenuItems,
       getTableMenuItems,
+      copyToClipboard,
     ]
   );
 

--- a/frontend/src/tests/components/tree/ConnectionTreeSection.test.tsx
+++ b/frontend/src/tests/components/tree/ConnectionTreeSection.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Connection } from '../../../types';
+
+const { getTablesMock, getColumnsMock } = vi.hoisted(() => ({
+  getTablesMock: vi.fn().mockResolvedValue({
+    tables: [
+      { schema: 'dbo', name: 'Users', type: 'TABLE', comment: '' },
+      { schema: 'dbo', name: 'vw_Users', type: 'VIEW', comment: '' },
+    ],
+    loadTimeMs: 10,
+  }),
+  getColumnsMock: vi.fn().mockResolvedValue([
+    { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+    { name: 'name', type: 'varchar', size: 100, nullable: true, isPrimaryKey: false },
+  ]),
+}));
+
+vi.mock('../../../store/connectionStore', () => {
+  const store = {
+    setTableListLoadTime: vi.fn(),
+    removeConnection: vi.fn(),
+  };
+  const useConnectionStore = (selector?: (s: typeof store) => unknown) =>
+    selector ? selector(store) : store;
+  (useConnectionStore as unknown as { getState: () => typeof store }).getState = () => store;
+  return { useConnectionStore };
+});
+
+vi.mock('../../../store/toastStore', () => {
+  const addToast = vi.fn();
+  const useToastStore = (selector?: (s: { addToast: typeof addToast }) => unknown) =>
+    selector ? selector({ addToast }) : { addToast };
+  return { useToastStore };
+});
+
+vi.mock('../../../api/bridge', () => ({
+  bridge: {
+    getTables: getTablesMock,
+    getColumns: getColumnsMock,
+    getReferencingForeignKeys: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import { ConnectionTreeSection } from '../../../components/tree/ConnectionTreeSection';
+
+const CONNECTION: Connection = {
+  id: 'c1',
+  name: 'test',
+  server: 'localhost',
+  port: 1433,
+  database: 'test',
+  username: 'sa',
+  password: '',
+  useWindowsAuth: false,
+  isActive: true,
+  isProduction: false,
+  isReadOnly: false,
+  environment: 'development',
+  dbType: 'sqlserver',
+};
+
+async function openContextMenuOn(label: string): Promise<void> {
+  // Tables/Views フォルダは初期展開されていないので、まず Tables フォルダをクリックして展開
+  const tablesFolder = await screen.findByText(/^Tables \(/);
+  fireEvent.click(tablesFolder);
+  const viewsFolder = await screen.findByText(/^Views \(/);
+  fireEvent.click(viewsFolder);
+
+  const node = await screen.findByText(label);
+  fireEvent.contextMenu(node);
+}
+
+describe('ConnectionTreeSection context menu', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('テーブルノード右クリックで INSERT文をコピー メニューが表示される', async () => {
+    render(<ConnectionTreeSection connection={CONNECTION} filter="" />);
+    await openContextMenuOn('Users');
+
+    expect(await screen.findByText('INSERT文をコピー')).toBeInTheDocument();
+    expect(screen.getByText('SELECT文をコピー')).toBeInTheDocument();
+  });
+
+  it('view ノードでは INSERT文をコピー メニューが表示されない (SELECT文は表示)', async () => {
+    render(<ConnectionTreeSection connection={CONNECTION} filter="" />);
+    await openContextMenuOn('vw_Users');
+
+    expect(screen.getByText('SELECT文をコピー')).toBeInTheDocument();
+    expect(screen.queryByText('INSERT文をコピー')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/utils/sqlIdentifier.test.ts
+++ b/frontend/src/tests/utils/sqlIdentifier.test.ts
@@ -3,6 +3,7 @@ import {
   buildAlterViewSql,
   buildDropTableSql,
   buildGetViewDefinitionSql,
+  buildInsertTemplateSql,
   buildTruncateTableSql,
   parseDropOrTruncate,
   type ReferencingFK,
@@ -332,5 +333,42 @@ describe('buildTruncateTableSql - schema省略', () => {
   it('schema空・FK無し → テーブル名のみ', () => {
     const sqls = buildTruncateTableSql('', 'locations', 'sqlserver', []);
     expect(sqls).toEqual(['TRUNCATE TABLE [locations]']);
+  });
+});
+
+describe('buildInsertTemplateSql', () => {
+  it('SQL Server: schema.table + 複数カラム → 角括弧でクォート', () => {
+    const sql = buildInsertTemplateSql('dbo.Users', ['id', 'name'], 'sqlserver');
+    expect(sql).toBe('INSERT INTO [dbo].[Users] ([id], [name]) VALUES (?, ?);');
+  });
+
+  it('PostgreSQL: schema.table + 複数カラム → ダブルクォート', () => {
+    const sql = buildInsertTemplateSql('public.users', ['id', 'name'], 'postgresql');
+    expect(sql).toBe('INSERT INTO "public"."users" ("id", "name") VALUES (?, ?);');
+  });
+
+  it('MySQL: schema.table + 複数カラム → バッククォート', () => {
+    const sql = buildInsertTemplateSql('mydb.users', ['id', 'name'], 'mysql');
+    expect(sql).toBe('INSERT INTO `mydb`.`users` (`id`, `name`) VALUES (?, ?);');
+  });
+
+  it('スキーマなし: テーブル名のみで生成', () => {
+    const sql = buildInsertTemplateSql('Users', ['id'], 'sqlserver');
+    expect(sql).toBe('INSERT INTO [Users] ([id]) VALUES (?);');
+  });
+
+  it('単一カラム: プレースホルダも1つ', () => {
+    const sql = buildInsertTemplateSql('dbo.Log', ['message'], 'sqlserver');
+    expect(sql).toBe('INSERT INTO [dbo].[Log] ([message]) VALUES (?);');
+  });
+
+  it('カラム名に特殊文字 (SQL Server)', () => {
+    const sql = buildInsertTemplateSql('dbo.Users', ['user]id'], 'sqlserver');
+    expect(sql).toContain('[user]]id]');
+  });
+
+  it('カラム空: 空のプレースホルダ (呼び出し側が防ぐべき入力を明示的に契約化)', () => {
+    const sql = buildInsertTemplateSql('dbo.Empty', [], 'sqlserver');
+    expect(sql).toBe('INSERT INTO [dbo].[Empty] () VALUES ();');
   });
 });

--- a/frontend/src/utils/sqlIdentifier.ts
+++ b/frontend/src/utils/sqlIdentifier.ts
@@ -49,12 +49,28 @@ export function buildRenameColumnSql(
   }
 }
 
-/** SELECT * FROM schema.table SQL生成 */
-export function buildSelectSql(displayName: string, dbType?: DatabaseType): string {
+/** "schema.table" または "table" を DB別クォートして返す */
+function qualifyDisplayName(displayName: string, dbType?: DatabaseType): string {
   const q = (n: string) => quoteIdentifier(n, dbType);
   const parts = displayName.split('.');
-  const tableName = parts.length >= 2 ? `${q(parts[0])}.${q(parts[1])}` : q(parts[0]);
-  return `SELECT * FROM ${tableName}`;
+  return parts.length >= 2 ? `${q(parts[0])}.${q(parts[1])}` : q(parts[0]);
+}
+
+/** SELECT * FROM schema.table SQL生成 */
+export function buildSelectSql(displayName: string, dbType?: DatabaseType): string {
+  return `SELECT * FROM ${qualifyDisplayName(displayName, dbType)}`;
+}
+
+/** INSERT INTO schema.table (cols...) VALUES (?, ?, ...); テンプレート生成 */
+export function buildInsertTemplateSql(
+  displayName: string,
+  columnNames: readonly string[],
+  dbType?: DatabaseType
+): string {
+  const q = (n: string) => quoteIdentifier(n, dbType);
+  const cols = columnNames.map((c) => q(c)).join(', ');
+  const placeholders = columnNames.map(() => '?').join(', ');
+  return `INSERT INTO ${qualifyDisplayName(displayName, dbType)} (${cols}) VALUES (${placeholders});`;
 }
 
 /** ALTER TABLE ... DROP COLUMN SQL生成 */

--- a/frontend/src/utils/treeNode.ts
+++ b/frontend/src/utils/treeNode.ts
@@ -41,3 +41,8 @@ export function shouldLoadColumns(
 ): node is DatabaseObject & { type: 'table' | 'view' } {
   return isExpandableType(node.type) && (!node.children || node.children.length === 0);
 }
+
+/** "schema.table" または "table" から裸のテーブル名部分を抽出 */
+export function extractBareTableName(displayName: string): string {
+  return displayName.includes('.') ? displayName.split('.')[1] : displayName;
+}


### PR DESCRIPTION
- buildInsertTemplateSql 追加 (schema.table + プレースホルダ形式)
- qualifyDisplayName 抽出で buildSelectSql と DRY 共通化
- extractBareTableName ヘルパーで tableName 抽出ロジック集約
- 失敗時 Toast 通知 (既存 queryExecuteSlice パターン踏襲)
- view は除外 (ODBCで updatable判定不能のため)

Closes #388