### PR TITLE
fix: 結果コピーをMarkdownテーブル形式に変更 (#374)

### DIFF
--- a/frontend/src/components/grid/hooks/useGridContextMenu.ts
+++ b/frontend/src/components/grid/hooks/useGridContextMenu.ts
@@ -47,6 +47,23 @@ export function buildInsertSql(
   return `INSERT INTO ${target} (${columnNames.join(', ')}) VALUES (${values.join(', ')});`;
 }
 
+const MARKDOWN_SEPARATOR_CELL = '---';
+
+function escapeMarkdownCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+}
+
+/** Markdown テーブル生成 (純粋関数、単体テスト可能) */
+export function buildMarkdownTable(
+  headers: readonly string[],
+  rows: readonly (readonly string[])[]
+): string {
+  const headerLine = `| ${headers.map(escapeMarkdownCell).join(' | ')} |`;
+  const separatorLine = `| ${headers.map(() => MARKDOWN_SEPARATOR_CELL).join(' | ')} |`;
+  const dataLines = rows.map((r) => `| ${r.map(escapeMarkdownCell).join(' | ')} |`);
+  return [headerLine, separatorLine, ...dataLines].join('\n');
+}
+
 type ContextMenuState =
   | { x: number; y: number; type: 'header'; columnId: string }
   | { x: number; y: number; type: 'cell'; columnId: string; rowIndex: number };
@@ -139,7 +156,11 @@ export function useGridContextMenu(
             const v = r.original[contextMenu.columnId];
             return v === null || v === undefined ? 'NULL' : String(v);
           });
-          copyToClipboard([header, ...colData].join('\n'), '列データをコピーしました');
+          const md = buildMarkdownTable(
+            [header],
+            colData.map((v) => [v])
+          );
+          copyToClipboard(md, '列データをコピーしました');
         },
       });
 
@@ -192,10 +213,7 @@ export function useGridContextMenu(
             const v = row?.original[c.name];
             return v === null || v === undefined ? 'NULL' : String(v);
           });
-          copyToClipboard(
-            [headerRow.join('\t'), dataRow.join('\t')].join('\n'),
-            '行をコピーしました'
-          );
+          copyToClipboard(buildMarkdownTable(headerRow, [dataRow]), '行をコピーしました');
         },
       },
       { label: '', action: () => {}, separator: true },

--- a/frontend/src/tests/grid/useGridContextMenu.test.ts
+++ b/frontend/src/tests/grid/useGridContextMenu.test.ts
@@ -13,7 +13,10 @@ import type {
   GridRow,
   GridTable,
 } from '../../components/grid/hooks/useGridContextMenu';
-import { useGridContextMenu } from '../../components/grid/hooks/useGridContextMenu';
+import {
+  buildMarkdownTable,
+  useGridContextMenu,
+} from '../../components/grid/hooks/useGridContextMenu';
 
 const mockColumnsMeta: ColumnMeta[] = [
   { name: 'id', comment: 'ID番号', type: 'int' },
@@ -35,6 +38,32 @@ const mockTable: GridTable = {
 function createMockEvent(): GridMouseEvent {
   return { preventDefault: vi.fn(), stopPropagation: vi.fn(), clientX: 100, clientY: 200 };
 }
+
+describe('buildMarkdownTable', () => {
+  it('単一列・単一行のテーブルを生成', () => {
+    expect(buildMarkdownTable(['a'], [['1']])).toBe('| a |\n| --- |\n| 1 |');
+  });
+
+  it('複数列・複数行のテーブルを生成', () => {
+    expect(
+      buildMarkdownTable(
+        ['a', 'b'],
+        [
+          ['1', '2'],
+          ['3', '4'],
+        ]
+      )
+    ).toBe('| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |');
+  });
+
+  it('ヘッダーのパイプもエスケープする', () => {
+    expect(buildMarkdownTable(['a|b'], [['1']])).toBe('| a\\|b |\n| --- |\n| 1 |');
+  });
+
+  it('CRLF 改行を <br> にエスケープする', () => {
+    expect(buildMarkdownTable(['a'], [['x\r\ny']])).toBe('| a |\n| --- |\n| x<br>y |');
+  });
+});
 
 describe('useGridContextMenu', () => {
   describe('header context menu', () => {
@@ -138,6 +167,23 @@ describe('useGridContextMenu', () => {
       expect(labels).toContain('行をコピー（ヘッダー付き）');
       expect(labels).toContain('SQL INSERTとしてコピー');
       expect(labels).toContain('この値でフィルタ');
+    });
+
+    it('行をコピー（ヘッダー付き）が Markdown 形式でコピー', () => {
+      const { result } = renderHook(() => useGridContextMenu(mockColumnsMeta, mockRows, mockTable));
+
+      act(() => {
+        result.current.openCellMenu(createMockEvent(), 1, 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      const rowItem = items.find((i) => i.label === '行をコピー（ヘッダー付き）');
+      rowItem?.action();
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        "| id | name | email |\n| --- | --- | --- |\n| 2 | Bob's | NULL |",
+        '行をコピーしました'
+      );
     });
 
     it('SQL INSERTコピーが正しいSQL文を生成', () => {
@@ -256,7 +302,7 @@ describe('useGridContextMenu', () => {
       expect(labels).not.toContain('NULLに設定');
     });
 
-    it('列値をコピー（ヘッダー付き）が正しいデータをコピー', () => {
+    it('列値をコピー（ヘッダー付き）が Markdown 形式でコピー', () => {
       const { result } = renderHook(() => useGridContextMenu(mockColumnsMeta, mockRows, mockTable));
 
       act(() => {
@@ -268,7 +314,47 @@ describe('useGridContextMenu', () => {
       copyItem?.action();
 
       expect(mockCopyToClipboard).toHaveBeenCalledWith(
-        "name\nAlice\nBob's",
+        "| name |\n| --- |\n| Alice |\n| Bob's |",
+        '列データをコピーしました'
+      );
+    });
+
+    it('列値をコピー（ヘッダー付き）がパイプ文字をエスケープする', () => {
+      const piped: GridRow[] = [
+        { original: { __rowIndex: '1', __originalIndex: '0', name: 'a|b' } },
+      ];
+      const pipedCols: ColumnMeta[] = [{ name: 'name', comment: '', type: 'varchar' }];
+      const { result } = renderHook(() => useGridContextMenu(pipedCols, piped, mockTable));
+
+      act(() => {
+        result.current.openHeaderMenu(createMockEvent(), 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      items.find((i) => i.label === '列値をコピー（ヘッダー付き）')?.action();
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        '| name |\n| --- |\n| a\\|b |',
+        '列データをコピーしました'
+      );
+    });
+
+    it('列値をコピー（ヘッダー付き）が改行を <br> にエスケープする', () => {
+      const rowsWithNewline: GridRow[] = [
+        { original: { __rowIndex: '1', __originalIndex: '0', name: 'a\nb' } },
+      ];
+      const cols: ColumnMeta[] = [{ name: 'name', comment: '', type: 'varchar' }];
+      const { result } = renderHook(() => useGridContextMenu(cols, rowsWithNewline, mockTable));
+
+      act(() => {
+        result.current.openHeaderMenu(createMockEvent(), 'name');
+      });
+
+      const items = result.current.getMenuItems();
+      items.find((i) => i.label === '列値をコピー（ヘッダー付き）')?.action();
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        '| name |\n| --- |\n| a<br>b |',
         '列データをコピーしました'
       );
     });


### PR DESCRIPTION
- 列値コピー（ヘッダー付き）と行コピー（ヘッダー付き）を Markdown テーブル形式に変更
- buildMarkdownTable 純粋関数を抽出 (パイプ/改行エスケープ対応)
- 既存テスト更新 + エッジケーステスト追加

Close #374
