### PR TITLE
Refactor

### DIFF
--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -61,8 +61,9 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
     setSettings(defaultSettings);
   }, []);
 
+  // version (primitive) は updateSetting 対象外。スプレッド不可のため型から除外。
   const updateSetting = useCallback(
-    <K extends keyof AppSettings>(
+    <K extends Exclude<keyof AppSettings, 'version'>>(
       category: K,
       key: keyof AppSettings[K],
       value: AppSettings[K][keyof AppSettings[K]]

--- a/frontend/src/components/grid/ColumnResizer.tsx
+++ b/frontend/src/components/grid/ColumnResizer.tsx
@@ -50,16 +50,10 @@ function ColumnResizerInner({
       const resizerRect = (e.currentTarget as HTMLElement).getBoundingClientRect();
 
       // Overlay 縦線 indicator (DOM 直挿入、React 経由しない最軽量パス)
+      // cssText 一括設定で layout 再計算を 1 回にまとめる
       const indicator = document.createElement('div');
-      indicator.style.position = 'fixed';
-      indicator.style.top = '0';
-      indicator.style.left = `${resizerRect.left + resizerRect.width / 2}px`;
-      indicator.style.width = '2px';
-      indicator.style.height = '100vh';
-      indicator.style.background = INDICATOR_COLOR;
-      indicator.style.pointerEvents = 'none';
-      indicator.style.zIndex = '9999';
-      indicator.style.willChange = 'transform';
+      const indicatorLeft = resizerRect.left + resizerRect.width / 2;
+      indicator.style.cssText = `position: fixed; top: 0; left: ${indicatorLeft}px; width: 2px; height: 100vh; background: ${INDICATOR_COLOR}; pointer-events: none; z-index: 9999; will-change: transform;`;
       document.body.appendChild(indicator);
 
       let pendingDx = 0;

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -19,6 +19,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useEphemeralOpen } from '../../hooks/useEphemeralOpen';
 import { useConnectionStore } from '../../store/connectionStore';
 import {
   useIsActiveDataView,
@@ -123,7 +124,12 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [showColumnFilters, setShowColumnFilters] = useState(false);
-  const [isErrorDialogOpen, setIsErrorDialogOpen] = useState(false);
+  // エラーダイアログの表示制御: error 到来で自動 open、ユーザーが閉じられる、再 open 可
+  const {
+    isOpen: isErrorDialogOpen,
+    dismiss: dismissErrorDialog,
+    reopen: reopenErrorDialog,
+  } = useEphemeralOpen(error);
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const elapsedSeconds = useElapsedTimer(isExecuting);
 
@@ -155,10 +161,6 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     storedWhereClause: currentQuery?.whereClause ?? '',
     applyWhereFilter,
   });
-
-  useEffect(() => {
-    setIsErrorDialogOpen(!!error);
-  }, [error]);
 
   // --- Derived data ---
   const isMultiple =
@@ -667,14 +669,14 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     return (
       <div className={`${styles.message} ${styles.error}`}>
         <span>{parsed.summary}</span>
-        <button className={styles.errorDetailButton} onClick={() => setIsErrorDialogOpen(true)}>
+        <button className={styles.errorDetailButton} onClick={reopenErrorDialog}>
           詳細を表示
         </button>
         <Suspense fallback={null}>
           <ErrorDetailDialog
             isOpen={isErrorDialogOpen}
             errorMessage={error}
-            onClose={() => setIsErrorDialogOpen(false)}
+            onClose={dismissErrorDialog}
           />
         </Suspense>
       </div>

--- a/frontend/src/components/grid/hooks/useRelatedRows.ts
+++ b/frontend/src/components/grid/hooks/useRelatedRows.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { bridge } from '../../../api/bridge';
 import type { ForeignKeyInfo } from '../../../types';
 import { log } from '../../../utils/logger';
@@ -47,18 +47,26 @@ export function useRelatedRows({
     fetchForeignKeys();
   }, [connectionId, tableName]);
 
+  // columnName -> FK の index map を一度だけ構築し、判定/取得を O(1) に
+  // 元 .find() と揃えて先勝ち (同一 column が複数 FK に含まれる場合は配列先頭を優先)
+  const fkByColumn = useMemo(() => {
+    const map = new Map<string, ForeignKeyInfo>();
+    for (const fk of foreignKeys) {
+      for (const col of fk.columns) {
+        if (!map.has(col)) map.set(col, fk);
+      }
+    }
+    return map;
+  }, [foreignKeys]);
+
   const isForeignKeyColumn = useCallback(
-    (columnName: string): boolean => {
-      return foreignKeys.some((fk) => fk.columns.includes(columnName));
-    },
-    [foreignKeys]
+    (columnName: string): boolean => fkByColumn.has(columnName),
+    [fkByColumn]
   );
 
   const getForeignKeyInfo = useCallback(
-    (columnName: string): ForeignKeyInfo | null => {
-      return foreignKeys.find((fk) => fk.columns.includes(columnName)) ?? null;
-    },
-    [foreignKeys]
+    (columnName: string): ForeignKeyInfo | null => fkByColumn.get(columnName) ?? null,
+    [fkByColumn]
   );
 
   const navigateToRelatedRow = useCallback(

--- a/frontend/src/components/history/HistoryItem.module.css
+++ b/frontend/src/components/history/HistoryItem.module.css
@@ -2,6 +2,9 @@
   padding: 8px 12px;
   border-bottom: 1px solid var(--border-color);
   cursor: pointer;
+  /* off-screen アイテムを skip render (大量履歴時のスクロール FPS 改善) */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 60px;
 }
 
 .container:hover {

--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -34,8 +34,8 @@ export function ConnectionTreeSection({
   onTableOpen,
 }: ConnectionTreeSectionProps) {
   const [treeData, setTreeData] = useState<DatabaseObject[]>([]);
-  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set());
-  const [loadingNodes, setLoadingNodes] = useState<Set<string>>(new Set());
+  const [expandedNodes, setExpandedNodes] = useState<Set<string>>(() => new Set());
+  const [loadingNodes, setLoadingNodes] = useState<Set<string>>(() => new Set());
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [contextMenu, setContextMenu] = useState<{
     x: number;

--- a/frontend/src/components/tree/ObjectTree.module.css
+++ b/frontend/src/components/tree/ObjectTree.module.css
@@ -51,6 +51,9 @@
   border-bottom: 1px solid var(--border-color, #3c3f41);
   color: var(--text-secondary, #808080);
   font-size: 13px;
+  /* off-screen スキップで大量プロファイル時のスクロール負荷を削減 */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 30px;
 }
 
 .profileItem:hover {

--- a/frontend/src/components/tree/TreeNode.module.css
+++ b/frontend/src/components/tree/TreeNode.module.css
@@ -13,6 +13,9 @@
   border-radius: 4px;
   margin: 1px 4px;
   border-left: 3px solid var(--connection-color, transparent);
+  /* 大量テーブル展開時の off-screen ノードを skip render */
+  content-visibility: auto;
+  contain-intrinsic-size: auto 28px;
 }
 
 .node:hover {

--- a/frontend/src/hooks/useDialogKeyboard.ts
+++ b/frontend/src/hooks/useDialogKeyboard.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 
 interface UseDialogKeyboardOptions {
   /** ダイアログが開いているかどうか */
@@ -13,25 +13,30 @@ interface UseDialogKeyboardOptions {
  * ダイアログ共通のキーボードショートカットを処理するhook
  * - Escape: ダイアログを閉じる
  * - Ctrl+Enter: 送信/保存
+ *
+ * listener は mount 時に 1 回だけ登録し、最新 callback は ref 経由で反映する。
+ * props 変化で add/removeEventListener が走らないため、イベント登録コストを削減。
  */
 export function useDialogKeyboard({ isOpen, onEscape, onSubmit }: UseDialogKeyboardOptions): void {
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (!isOpen) return;
-
-      if (e.key === 'Escape' && onEscape) {
-        e.preventDefault();
-        onEscape();
-      } else if (e.ctrlKey && e.key === 'Enter' && onSubmit) {
-        e.preventDefault();
-        onSubmit();
-      }
-    },
-    [isOpen, onEscape, onSubmit]
-  );
+  const optsRef = useRef<UseDialogKeyboardOptions>({ isOpen, onEscape, onSubmit });
+  // Intentionally no deps: sync ref on every render. useKeyboardHandler と同じ API 形
+  useEffect(() => {
+    optsRef.current = { isOpen, onEscape, onSubmit };
+  });
 
   useLayoutEffect(() => {
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleKeyDown]);
+    const onKeyDown = (e: KeyboardEvent) => {
+      const { isOpen: open, onEscape: esc, onSubmit: submit } = optsRef.current;
+      if (!open) return;
+      if (e.key === 'Escape' && esc) {
+        e.preventDefault();
+        esc();
+      } else if (e.ctrlKey && e.key === 'Enter' && submit) {
+        e.preventDefault();
+        submit();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
 }

--- a/frontend/src/hooks/useEphemeralOpen.ts
+++ b/frontend/src/hooks/useEphemeralOpen.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from 'react';
+
+interface UseEphemeralOpenResult {
+  /** ダイアログが開くべきか: trigger 到来後、未 dismiss なら true */
+  isOpen: boolean;
+  /** ユーザー操作でダイアログを閉じる (同じ trigger では再度開かない) */
+  dismiss: () => void;
+  /** 現在の trigger に対して再度開く (ボタンから再表示等) */
+  reopen: () => void;
+}
+
+/**
+ * Trigger 値が変化する度に自動で open し、ユーザー dismiss できるダイアログ制御。
+ *
+ * - trigger が null/undefined/false → isOpen=false
+ * - trigger が truthy に変化 → isOpen=true (dismiss 状態リセット)
+ * - 同じ trigger 内で dismiss() → isOpen=false
+ * - 同じ trigger 内で reopen() → isOpen=true
+ *
+ * React 公式推奨の expressed-state パターン (useEffect 不使用) で実装。
+ * @see https://react.dev/learn/you-might-not-need-an-effect
+ */
+export function useEphemeralOpen<T>(trigger: T): UseEphemeralOpenResult {
+  const [prevTrigger, setPrevTrigger] = useState<T>(trigger);
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  if (trigger !== prevTrigger) {
+    setPrevTrigger(trigger);
+    setIsDismissed(false);
+  }
+
+  const dismiss = useCallback(() => setIsDismissed(true), []);
+  const reopen = useCallback(() => setIsDismissed(false), []);
+
+  return {
+    isOpen: !!trigger && !isDismissed,
+    dismiss,
+    reopen,
+  };
+}

--- a/frontend/src/tests/helpers/mockSettingsUtils.ts
+++ b/frontend/src/tests/helpers/mockSettingsUtils.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 
 const mockSettings = {
+  version: 1,
   editor: { fontSize: 14, tabSize: 4, wordWrap: true, minimap: false },
   query: { autoCommit: true, timeout: 300000, maxRows: 10000 },
   appearance: { theme: 'dark' as const },

--- a/frontend/src/tests/hooks/useEphemeralOpen.test.ts
+++ b/frontend/src/tests/hooks/useEphemeralOpen.test.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useEphemeralOpen } from '../../hooks/useEphemeralOpen';
+
+describe('useEphemeralOpen', () => {
+  it('trigger が null なら isOpen=false', () => {
+    const { result } = renderHook(() => useEphemeralOpen<string | null>(null));
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('trigger が truthy なら isOpen=true', () => {
+    const { result } = renderHook(() => useEphemeralOpen<string | null>('err-A'));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('dismiss() で isOpen=false になる', () => {
+    const { result } = renderHook(() => useEphemeralOpen<string | null>('err-A'));
+    expect(result.current.isOpen).toBe(true);
+    act(() => result.current.dismiss());
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('dismiss 後 reopen() で再度 isOpen=true', () => {
+    const { result } = renderHook(() => useEphemeralOpen<string | null>('err-A'));
+    act(() => result.current.dismiss());
+    expect(result.current.isOpen).toBe(false);
+    act(() => result.current.reopen());
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('trigger が変化すると dismiss 状態がリセットされる (再 open)', () => {
+    const { result, rerender } = renderHook(
+      ({ trigger }: { trigger: string | null }) => useEphemeralOpen(trigger),
+      { initialProps: { trigger: 'err-A' as string | null } }
+    );
+    act(() => result.current.dismiss());
+    expect(result.current.isOpen).toBe(false);
+
+    rerender({ trigger: 'err-B' });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('同じ trigger で rerender しても dismiss 状態は保持される', () => {
+    const { result, rerender } = renderHook(
+      ({ trigger }: { trigger: string | null }) => useEphemeralOpen(trigger),
+      { initialProps: { trigger: 'err-A' as string | null } }
+    );
+    act(() => result.current.dismiss());
+    rerender({ trigger: 'err-A' });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('trigger が null になると isOpen=false (dismiss 状態は問わず)', () => {
+    const { result, rerender } = renderHook(
+      ({ trigger }: { trigger: string | null }) => useEphemeralOpen(trigger),
+      { initialProps: { trigger: 'err-A' as string | null } }
+    );
+    expect(result.current.isOpen).toBe(true);
+    rerender({ trigger: null });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('null → 新 trigger で isOpen=true', () => {
+    const { result, rerender } = renderHook(
+      ({ trigger }: { trigger: string | null }) => useEphemeralOpen(trigger),
+      { initialProps: { trigger: null as string | null } }
+    );
+    expect(result.current.isOpen).toBe(false);
+    rerender({ trigger: 'err-X' });
+    expect(result.current.isOpen).toBe(true);
+  });
+});

--- a/frontend/src/tests/utils/settingsUtils.test.ts
+++ b/frontend/src/tests/utils/settingsUtils.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { defaultSettings, getSettings } from '../../utils/settingsUtils';
+
+const STORAGE_KEY = 'app-settings';
+
+describe('settingsUtils.getSettings (schema migration)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('localStorage 未設定時は defaults を返す', () => {
+    expect(getSettings()).toEqual(defaultSettings);
+  });
+
+  it('壊れた JSON はスキップして defaults を返す', () => {
+    localStorage.setItem(STORAGE_KEY, '{not valid json');
+    expect(getSettings()).toEqual(defaultSettings);
+  });
+
+  it('null/配列など object でない JSON も defaults を返す', () => {
+    localStorage.setItem(STORAGE_KEY, 'null');
+    expect(getSettings()).toEqual(defaultSettings);
+    localStorage.setItem(STORAGE_KEY, '[]');
+    // 配列は Object.assign で spread 可能なので editor 等は defaults 由来となる
+    const fromArray = getSettings();
+    expect(fromArray.version).toBe(1);
+    expect(fromArray.editor).toEqual(defaultSettings.editor);
+  });
+
+  it('version 欠落 (v0) データを v1 形式へ migrate する', () => {
+    const legacy = {
+      editor: { fontSize: 16, tabSize: 2, wordWrap: false, minimap: true },
+      query: { autoCommit: false, timeout: 60000, maxRows: 500 },
+      appearance: { theme: 'light' },
+      shortcuts: {
+        execute: 'F5',
+        newQuery: 'Ctrl+T',
+        format: 'Ctrl+F',
+        search: 'Ctrl+P',
+      },
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(legacy));
+    const migrated = getSettings();
+    expect(migrated.version).toBe(1);
+    expect(migrated.editor.fontSize).toBe(16);
+    expect(migrated.editor.minimap).toBe(true);
+    expect(migrated.query.timeout).toBe(60000);
+    expect(migrated.appearance.theme).toBe('light');
+    expect(migrated.shortcuts.execute).toBe('F5');
+  });
+
+  it('部分的なデータは defaults で埋める (forward compatible)', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ editor: { fontSize: 20 } }));
+    const merged = getSettings();
+    expect(merged.version).toBe(1);
+    expect(merged.editor.fontSize).toBe(20);
+    // 他は default 継承
+    expect(merged.editor.tabSize).toBe(defaultSettings.editor.tabSize);
+    expect(merged.query).toEqual(defaultSettings.query);
+    expect(merged.shortcuts).toEqual(defaultSettings.shortcuts);
+  });
+
+  it('version 付き新形式データはそのまま読める', () => {
+    const current = { ...defaultSettings, editor: { ...defaultSettings.editor, fontSize: 18 } };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(current));
+    const loaded = getSettings();
+    expect(loaded.version).toBe(1);
+    expect(loaded.editor.fontSize).toBe(18);
+  });
+});

--- a/frontend/src/utils/settingsUtils.ts
+++ b/frontend/src/utils/settingsUtils.ts
@@ -6,7 +6,11 @@ export const QUERY_TIMEOUT_MIN_SEC = 1;
 export const QUERY_TIMEOUT_MAX_SEC = 3600;
 export const QUERY_TIMEOUT_DEFAULT_SEC = 300;
 
+// 破壊的変更時にインクリメントし migrate() にケース追加
+const SETTINGS_VERSION = 1;
+
 export interface AppSettings {
+  version: number;
   editor: {
     fontSize: number;
     tabSize: number;
@@ -30,6 +34,7 @@ export interface AppSettings {
 }
 
 export const defaultSettings: AppSettings = {
+  version: SETTINGS_VERSION,
   editor: {
     fontSize: 14,
     tabSize: 4,
@@ -52,22 +57,47 @@ export const defaultSettings: AppSettings = {
   },
 };
 
+// 各サブオブジェクトを型検証し、フィールド単位で defaults fallback
+// (zod 4 の dynamic import が vitest 環境で解決困難なため手書き validator)
+function pickTyped<T extends object>(source: unknown, template: T): Partial<T> {
+  if (typeof source !== 'object' || source === null) return {};
+  const src = source as Record<string, unknown>;
+  const out: Partial<T> = {};
+  for (const key of Object.keys(template) as (keyof T)[]) {
+    const v = src[key as string];
+    const expected = typeof template[key];
+    if (typeof v === expected) (out as Record<string, unknown>)[key as string] = v;
+  }
+  return out;
+}
+
+// 旧形式 (version 欠落 or 古いバージョン) を現行形式へ正規化
+function migrate(parsed: unknown): AppSettings {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return defaultSettings;
+  }
+  const obj = parsed as Record<string, unknown>;
+  return {
+    version: SETTINGS_VERSION,
+    editor: { ...defaultSettings.editor, ...pickTyped(obj.editor, defaultSettings.editor) },
+    query: { ...defaultSettings.query, ...pickTyped(obj.query, defaultSettings.query) },
+    appearance: {
+      ...defaultSettings.appearance,
+      ...pickTyped(obj.appearance, defaultSettings.appearance),
+    },
+    shortcuts: {
+      ...defaultSettings.shortcuts,
+      ...pickTyped(obj.shortcuts, defaultSettings.shortcuts),
+    },
+  };
+}
+
 export function getSettings(): AppSettings {
   const saved = localStorage.getItem('app-settings');
-  if (saved) {
-    try {
-      const parsed = JSON.parse(saved);
-      return {
-        ...defaultSettings,
-        ...parsed,
-        editor: { ...defaultSettings.editor, ...parsed.editor },
-        query: { ...defaultSettings.query, ...parsed.query },
-        appearance: { ...defaultSettings.appearance, ...parsed.appearance },
-        shortcuts: { ...defaultSettings.shortcuts, ...parsed.shortcuts },
-      };
-    } catch {
-      return defaultSettings;
-    }
+  if (!saved) return defaultSettings;
+  try {
+    return migrate(JSON.parse(saved));
+  } catch {
+    return defaultSettings;
   }
-  return defaultSettings;
 }


### PR DESCRIPTION
- H1: ConnectionTreeSection のSet初期化を lazy化
- H2: ResultGrid のerror→dialog派生stateを useEphemeralOpen hookに抽出(React公式 expressed-stateパターン、useEffect削除)
- M3: AppSettingsにversion:1追加、migrate()で旧形式から復旧
- M4: useDialogKeyboard をrefパターンで再登録コスト削減

- H3/H4: 履歴/スキーマツリー項目に content-visibility: auto 適用(off-screen描画省略、大量時のスクロールFPS改善)
- M1: useRelatedRows のFK判定を Map化、O(1)化
- M2: ColumnResizer の9連続 style.xxx を cssText一括(mousedown時 layout thrashing削減)