### PR TITLE
refactor(frontend): SVG アイコンを SvgIcons.tsx に共通化 (#403)

### DIFF
--- a/frontend/src/components/editor/EditorTabs.tsx
+++ b/frontend/src/components/editor/EditorTabs.tsx
@@ -4,55 +4,16 @@ import { useQueries, useQueryActions, useQueryStore } from '../../store/querySto
 import type { Query } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
 import { stripBrackets } from '../../utils/stringUtils';
+import { TabIcons } from '../icons/SvgIcons';
 import { resolveNewQueryConnectionId } from '../layout/newQueryConnection';
 import styles from './EditorTabs.module.css';
 
-// SQL file icon
-const SqlIcon = (
-  <svg
-    className={styles.tabIcon}
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.2"
-    aria-hidden="true"
-  >
-    <path d="M9 1H4a1 1 0 00-1 1v12a1 1 0 001 1h8a1 1 0 001-1V5L9 1z" />
-    <path d="M9 1v4h4" />
-  </svg>
-);
-
-// ER diagram icon
-const ERDiagramIcon = (
-  <svg
-    className={styles.tabIcon}
-    viewBox="0 0 16 16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="1.2"
-    aria-hidden="true"
-  >
-    <rect x="1" y="1" width="5" height="4" rx="0.5" />
-    <rect x="10" y="1" width="5" height="4" rx="0.5" />
-    <rect x="5.5" y="11" width="5" height="4" rx="0.5" />
-    <path d="M3.5 5v3.5h4.5V11" />
-    <path d="M12.5 5v3.5h-4.5V11" />
-  </svg>
-);
-
-// Plus icon for add button
-const PlusIcon = (
-  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-    <path d="M8 3v10M3 8h10" />
-  </svg>
-);
-
-// Close icon
-const CloseIcon = (
-  <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-    <path d="M4 4l8 8M12 4l-8 8" />
-  </svg>
-);
+const TabFileIcon = ({ isERDiagram }: { isERDiagram: boolean }) =>
+  isERDiagram ? (
+    <TabIcons.ERDiagram className={styles.tabIcon} />
+  ) : (
+    <TabIcons.Sql className={styles.tabIcon} />
+  );
 
 type ConnectionColorMap = Record<string, { color: string; label: string }>;
 
@@ -256,7 +217,7 @@ export function EditorTabs() {
               onDrop={(e) => handleDrop(e, index)}
               onDragEnd={handleDragEnd}
             >
-              {query.isERDiagram ? ERDiagramIcon : SqlIcon}
+              <TabFileIcon isERDiagram={query.isERDiagram ?? false} />
               <span className={styles.tabName}>
                 {query.isDirty && <span className={styles.dirty}>●</span>}
                 {stripBrackets(query.name)}
@@ -270,7 +231,7 @@ export function EditorTabs() {
                 }}
                 title="タブを閉じる"
               >
-                {CloseIcon}
+                <TabIcons.Close />
               </button>
             </div>
           );
@@ -298,7 +259,7 @@ export function EditorTabs() {
                     setMenuOpen(false);
                   }}
                 >
-                  {query.isERDiagram ? ERDiagramIcon : SqlIcon}
+                  <TabFileIcon isERDiagram={query.isERDiagram ?? false} />
                   <span className={styles.overflowMenuItemName}>{stripBrackets(query.name)}</span>
                 </button>
               ))}
@@ -313,7 +274,7 @@ export function EditorTabs() {
           onClick={() => setAddMenuOpen((prev) => !prev)}
           title="新規タブ (Ctrl+N)"
         >
-          {PlusIcon}
+          <TabIcons.Plus />
         </button>
         {addMenuOpen && (
           <div className={styles.overflowMenu}>
@@ -326,11 +287,11 @@ export function EditorTabs() {
                 setAddMenuOpen(false);
               }}
             >
-              {SqlIcon}
+              <TabIcons.Sql className={styles.tabIcon} />
               <span>新規クエリ</span>
             </button>
             <button type="button" className={styles.overflowMenuItem} onClick={createERDiagram}>
-              {ERDiagramIcon}
+              <TabIcons.ERDiagram className={styles.tabIcon} />
               <span>新規ER図</span>
             </button>
           </div>

--- a/frontend/src/components/icons/SvgIcons.tsx
+++ b/frontend/src/components/icons/SvgIcons.tsx
@@ -1,0 +1,253 @@
+import type { SVGProps } from 'react';
+
+type IconProps = SVGProps<SVGSVGElement>;
+
+// ====================================================================
+// ToolbarIcons — MainLayout 上部ツールバー用 (16x16, 視覚的に太め)
+// ====================================================================
+export const ToolbarIcons = {
+  Database: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <ellipse cx="8" cy="4" rx="6" ry="2.5" />
+      <path d="M2 4v8c0 1.38 2.69 2.5 6 2.5s6-1.12 6-2.5V4" />
+      <path d="M2 8c0 1.38 2.69 2.5 6 2.5s6-1.12 6-2.5" />
+    </svg>
+  ),
+  Play: (props: IconProps) => (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M4 2v12l10-6-10-6z" />
+    </svg>
+  ),
+  Stop: (props: IconProps) => (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" {...props}>
+      <rect x="3" y="3" width="10" height="10" rx="1" />
+    </svg>
+  ),
+  Format: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M2 3h12M2 6h8M2 9h12M2 12h8" />
+    </svg>
+  ),
+  Sidebar: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="2" y="2" width="12" height="12" rx="1" />
+      <path d="M6 2v12" />
+    </svg>
+  ),
+  Terminal: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="2" y="2" width="12" height="12" rx="1" />
+      <path d="M2 10h12" />
+    </svg>
+  ),
+  Search: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="7" cy="7" r="4" />
+      <path d="M10 10l3.5 3.5" />
+    </svg>
+  ),
+  Settings: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <circle cx="8" cy="8" r="2" />
+      <path d="M8 1v2M8 13v2M1 8h2M13 8h2M2.93 2.93l1.41 1.41M11.66 11.66l1.41 1.41M2.93 13.07l1.41-1.41M11.66 4.34l1.41-1.41" />
+    </svg>
+  ),
+};
+
+// ====================================================================
+// TreeIcons — TreeNode 用 (16x16、細め。Toolbar と同名でも形状は別)
+// ====================================================================
+export const TreeIcons = {
+  Database: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <ellipse cx="8" cy="4" rx="5" ry="2" />
+      <path d="M3 4v8c0 1.1 2.24 2 5 2s5-.9 5-2V4" />
+      <path d="M3 8c0 1.1 2.24 2 5 2s5-.9 5-2" />
+    </svg>
+  ),
+  Folder: (props: IconProps) => (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M2 3.5A1.5 1.5 0 013.5 2h2.879a1.5 1.5 0 011.06.44l1.122 1.12A1.5 1.5 0 009.622 4H12.5A1.5 1.5 0 0114 5.5v7a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 12.5v-9z" />
+    </svg>
+  ),
+  FolderOpen: (props: IconProps) => (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M1.5 13.25V3.5A1.5 1.5 0 013 2h3.379a1.5 1.5 0 011.06.44l.94.94a.5.5 0 00.354.147H13.5A1.5 1.5 0 0115 5v.5H2V3.5a.5.5 0 01.5-.5h3.379a.5.5 0 01.354.146l.94.94A1.5 1.5 0 008.233 4.5H13.5a.5.5 0 01.5.5v.5H2v7.75a.75.75 0 00.75.75h10.5a.75.75 0 00.75-.75V6h1v7.25a1.75 1.75 0 01-1.75 1.75H2.75a1.75 1.75 0 01-1.25-2z" />
+    </svg>
+  ),
+  Table: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="2" y="2" width="12" height="12" rx="1" />
+      <path d="M2 5h12M2 8h12M2 11h12M6 5v9M10 5v9" />
+    </svg>
+  ),
+  View: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M1 8s2.5-5 7-5 7 5 7 5-2.5 5-7 5-7-5-7-5z" />
+      <circle cx="8" cy="8" r="2.5" />
+    </svg>
+  ),
+  Column: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M4 4v8M8 8h4" />
+    </svg>
+  ),
+  Key: (props: IconProps) => (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M5.5 9a2.5 2.5 0 100-5 2.5 2.5 0 000 5zm0-1a1.5 1.5 0 110-3 1.5 1.5 0 010 3z" />
+      <path d="M7.5 6.5h6v1h-6z" />
+      <path d="M11.5 6.5v3h-1v-3zM13.5 6.5v2h-1v-2z" />
+    </svg>
+  ),
+  Loading: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M8 2v2M8 12v2M2 8h2M12 8h2" />
+    </svg>
+  ),
+  ChevronRight: (props: IconProps) => (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M6 4l4 4-4 4" />
+    </svg>
+  ),
+  ChevronDown: (props: IconProps) => (
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M4 6l4 4 4-4" />
+    </svg>
+  ),
+};
+
+// ====================================================================
+// TabIcons — EditorTabs 用 (16x16、細め)
+// ====================================================================
+export const TabIcons = {
+  Sql: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M9 1H4a1 1 0 00-1 1v12a1 1 0 001 1h8a1 1 0 001-1V5L9 1z" />
+      <path d="M9 1v4h4" />
+    </svg>
+  ),
+  ERDiagram: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.2"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="1" y="1" width="5" height="4" rx="0.5" />
+      <rect x="10" y="1" width="5" height="4" rx="0.5" />
+      <rect x="5.5" y="11" width="5" height="4" rx="0.5" />
+      <path d="M3.5 5v3.5h4.5V11" />
+      <path d="M12.5 5v3.5h-4.5V11" />
+    </svg>
+  ),
+  Plus: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M8 3v10M3 8h10" />
+    </svg>
+  ),
+  Close: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M4 4l8 8M12 4l-8 8" />
+    </svg>
+  ),
+};

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../utils/sqlSafetyCheck';
 import type { ConnectionConfig } from '../dialogs/ConnectionDialog';
 import { QueryConfirmDialog } from '../dialogs/QueryConfirmDialog';
+import { ToolbarIcons } from '../icons/SvgIcons';
 import { CenterPanel } from './CenterPanel';
 import styles from './MainLayout.module.css';
 import { resolveNewQueryConnectionId } from './newQueryConnection';
@@ -39,56 +40,6 @@ const SettingsDialog = lazyWithRetry(() =>
 function LoadingFallback() {
   return <div style={{ display: 'none' }} />;
 }
-
-// SVG Icons (JetBrains-style simple icons)
-const Icons = {
-  database: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <ellipse cx="8" cy="4" rx="6" ry="2.5" />
-      <path d="M2 4v8c0 1.38 2.69 2.5 6 2.5s6-1.12 6-2.5V4" />
-      <path d="M2 8c0 1.38 2.69 2.5 6 2.5s6-1.12 6-2.5" />
-    </svg>
-  ),
-  play: (
-    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M4 2v12l10-6-10-6z" />
-    </svg>
-  ),
-  stop: (
-    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <rect x="3" y="3" width="10" height="10" rx="1" />
-    </svg>
-  ),
-  format: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <path d="M2 3h12M2 6h8M2 9h12M2 12h8" />
-    </svg>
-  ),
-  sidebar: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <rect x="2" y="2" width="12" height="12" rx="1" />
-      <path d="M6 2v12" />
-    </svg>
-  ),
-  terminal: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <rect x="2" y="2" width="12" height="12" rx="1" />
-      <path d="M2 10h12" />
-    </svg>
-  ),
-  search: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <circle cx="7" cy="7" r="4" />
-      <path d="M10 10l3.5 3.5" />
-    </svg>
-  ),
-  settings: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <circle cx="8" cy="8" r="2" />
-      <path d="M8 1v2M8 13v2M1 8h2M13 8h2M2.93 2.93l1.41 1.41M11.66 11.66l1.41 1.41M2.93 13.07l1.41-1.41M11.66 4.34l1.41-1.41" />
-    </svg>
-  ),
-};
 
 export function MainLayout() {
   // Session store for persisted layout state
@@ -414,7 +365,7 @@ export function MainLayout() {
         {/* Connection */}
         <div className={styles.toolbarGroup}>
           <button onClick={() => setIsConnectionDialogOpen(true)} title="新規接続">
-            {Icons.database}
+            <ToolbarIcons.Database />
             <span>接続</span>
           </button>
         </div>
@@ -428,7 +379,7 @@ export function MainLayout() {
             title={isExecuting ? '停止 (Escape)' : '実行 (F9)'}
             className={styles.executeButton}
           >
-            {isExecuting ? Icons.stop : Icons.play}
+            {isExecuting ? <ToolbarIcons.Stop /> : <ToolbarIcons.Play />}
             <span>{isExecuting ? '停止' : '実行'}</span>
           </button>
         </div>
@@ -440,7 +391,7 @@ export function MainLayout() {
             disabled={!activeQuery?.content || isDataView}
             title="SQLフォーマット (Ctrl+Shift+F)"
           >
-            {Icons.format}
+            <ToolbarIcons.Format />
           </button>
         </div>
 
@@ -454,7 +405,7 @@ export function MainLayout() {
             onClick={() => setIsLeftPanelVisible(!isLeftPanelVisible)}
             title="データベースエクスプローラーを切り替え"
           >
-            {Icons.sidebar}
+            <ToolbarIcons.Sidebar />
           </button>
           <button
             className={styles.iconButton}
@@ -462,7 +413,7 @@ export function MainLayout() {
             disabled={isDataView}
             title="結果パネルを切り替え"
           >
-            {Icons.terminal}
+            <ToolbarIcons.Terminal />
           </button>
         </div>
 
@@ -475,10 +426,10 @@ export function MainLayout() {
             onClick={handleOpenSearch}
             title="検索 (Ctrl+Shift+P)"
           >
-            {Icons.search}
+            <ToolbarIcons.Search />
           </button>
           <button className={styles.iconButton} onClick={handleOpenSettings} title="設定 (Ctrl+,)">
-            {Icons.settings}
+            <ToolbarIcons.Settings />
           </button>
         </div>
       </header>

--- a/frontend/src/components/tree/TreeNode.tsx
+++ b/frontend/src/components/tree/TreeNode.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from 'react';
 import type { DatabaseObject, EnvironmentType } from '../../types';
 import { type ExpandableType, isExpandableType } from '../../utils/treeNode';
+import { TreeIcons } from '../icons/SvgIcons';
 import styles from './TreeNode.module.css';
 
 interface TreeNodeProps {
@@ -22,92 +23,25 @@ const ENV_NAME_CLASS: Record<EnvironmentType, string> = {
   production: styles.nameEnvProduction,
 };
 
-// SVG Icons for tree nodes
-const Icons = {
-  database: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <ellipse cx="8" cy="4" rx="5" ry="2" />
-      <path d="M3 4v8c0 1.1 2.24 2 5 2s5-.9 5-2V4" />
-      <path d="M3 8c0 1.1 2.24 2 5 2s5-.9 5-2" />
-    </svg>
-  ),
-  folder: (
-    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M2 3.5A1.5 1.5 0 013.5 2h2.879a1.5 1.5 0 011.06.44l1.122 1.12A1.5 1.5 0 009.622 4H12.5A1.5 1.5 0 0114 5.5v7a1.5 1.5 0 01-1.5 1.5h-9A1.5 1.5 0 012 12.5v-9z" />
-    </svg>
-  ),
-  folderOpen: (
-    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M1.5 13.25V3.5A1.5 1.5 0 013 2h3.379a1.5 1.5 0 011.06.44l.94.94a.5.5 0 00.354.147H13.5A1.5 1.5 0 0115 5v.5H2V3.5a.5.5 0 01.5-.5h3.379a.5.5 0 01.354.146l.94.94A1.5 1.5 0 008.233 4.5H13.5a.5.5 0 01.5.5v.5H2v7.75a.75.75 0 00.75.75h10.5a.75.75 0 00.75-.75V6h1v7.25a1.75 1.75 0 01-1.75 1.75H2.75a1.75 1.75 0 01-1.25-2z" />
-    </svg>
-  ),
-  table: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.2" aria-hidden="true">
-      <rect x="2" y="2" width="12" height="12" rx="1" />
-      <path d="M2 5h12M2 8h12M2 11h12M6 5v9M10 5v9" />
-    </svg>
-  ),
-  view: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <path d="M1 8s2.5-5 7-5 7 5 7 5-2.5 5-7 5-7-5-7-5z" />
-      <circle cx="8" cy="8" r="2.5" />
-    </svg>
-  ),
-  column: (
-    <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
-      <path d="M4 4v8M8 8h4" />
-    </svg>
-  ),
-  key: (
-    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M5.5 9a2.5 2.5 0 100-5 2.5 2.5 0 000 5zm0-1a1.5 1.5 0 110-3 1.5 1.5 0 010 3z" />
-      <path d="M7.5 6.5h6v1h-6z" />
-      <path d="M11.5 6.5v3h-1v-3zM13.5 6.5v2h-1v-2z" />
-    </svg>
-  ),
-  loading: (
-    <svg
-      viewBox="0 0 16 16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      className={styles.loadingSpinner}
-      aria-hidden="true"
-    >
-      <path d="M8 2v2M8 12v2M2 8h2M12 8h2" />
-    </svg>
-  ),
-  chevronRight: (
-    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M6 4l4 4-4 4" />
-    </svg>
-  ),
-  chevronDown: (
-    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M4 6l4 4 4-4" />
-    </svg>
-  ),
-};
-
 const getIcon = (
   type: DatabaseObject['type'] | 'folder',
   isExpanded?: boolean
 ): React.ReactElement => {
   switch (type) {
     case 'database':
-      return Icons.database;
+      return <TreeIcons.Database />;
     case 'folder':
-      return isExpanded ? Icons.folderOpen : Icons.folder;
+      return isExpanded ? <TreeIcons.FolderOpen /> : <TreeIcons.Folder />;
     case 'table':
-      return Icons.table;
+      return <TreeIcons.Table />;
     case 'view':
-      return Icons.view;
+      return <TreeIcons.View />;
     case 'column':
-      return Icons.column;
+      return <TreeIcons.Column />;
     case 'index':
-      return Icons.key;
+      return <TreeIcons.Key />;
     default:
-      return Icons.column;
+      return <TreeIcons.Column />;
   }
 };
 
@@ -197,7 +131,13 @@ export const TreeNode = memo(function TreeNode({
           tabIndex={-1}
           style={canExpand ? EXPANDER_VISIBLE : EXPANDER_HIDDEN}
         >
-          {isLoading ? Icons.loading : isExpanded ? Icons.chevronDown : Icons.chevronRight}
+          {isLoading ? (
+            <TreeIcons.Loading className={styles.loadingSpinner} />
+          ) : isExpanded ? (
+            <TreeIcons.ChevronDown />
+          ) : (
+            <TreeIcons.ChevronRight />
+          )}
         </span>
         <span className={`${styles.icon} ${getIconClass(node.type)}`}>
           {getIcon(node.type, isExpanded)}


### PR DESCRIPTION
## Summary

- SVG アイコン 22 個を `components/icons/SvgIcons.tsx` に集約
- 3 namespace (ToolbarIcons / TreeIcons / TabIcons) で用途別に分離
- 各 icon は `SVGProps<SVGSVGElement>` を受け取る Function Component
- 消費側: MainLayout (8), TreeNode (8), EditorTabs (6) を `<Namespace.Icon />` 形式に置換

## Why namespace 分離

3 コンテキストで「database」等同名アイコンが存在するが、SVG path は**別物** (ツールバー用 vs
ツリー用)。単純な統合ではなく**名前が被る別物**として namespace で区別。

## Test plan

- [x] Biome lint clean
- [x] Vitest 752 tests all pass
- [x] tsc 型エラーなし
- [ ] 実機でツールバー/ツリー/タブのアイコン表示確認
- [ ] Loading spinner animation (TreeNode.loadingSpinner) 動作確認

Close #403