### PR TITLE
refactor(frontend): handleExecute を checkQueryExecutability に抽出 (#404)

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -7,11 +7,7 @@ import { useConnectionStore } from '../../store/connectionStore';
 import { useQueryStore } from '../../store/queryStore';
 import { useSessionStore } from '../../store/sessionStore';
 import { lazyWithRetry } from '../../utils/lazyWithRetry';
-import {
-  checkSqlSafety,
-  getQueryWarnings,
-  type UnsafeQueryWarning,
-} from '../../utils/sqlSafetyCheck';
+import { checkQueryExecutability } from '../../utils/queryExecutionCheck';
 import type { ConnectionConfig } from '../dialogs/ConnectionDialog';
 import { QueryConfirmDialog } from '../dialogs/QueryConfirmDialog';
 import { ToolbarIcons } from '../icons/SvgIcons';
@@ -152,44 +148,27 @@ export function MainLayout() {
   const handleExecute = useCallback(() => {
     if (!activeQueryId || !activeQueryConnectionId || !activeQuery) return;
 
-    const sql = activeQuery.content;
+    const result = checkQueryExecutability(activeQuery.content, { isReadOnly, isProduction });
 
-    // Check for read-only mode violations
-    if (isReadOnly) {
-      const safetyResult = checkSqlSafety(sql);
-      if (!safetyResult.isSafe) {
-        setQueryConfirmDialog({
-          isOpen: true,
-          title: 'Read-Only Mode',
-          message: safetyResult.message || 'This query is blocked in read-only mode.',
-          details: sql.slice(0, 200) + (sql.length > 200 ? '...' : ''),
-          isBlocked: true,
-        });
-        return;
-      }
+    if (result.action === 'execute') {
+      doExecuteQuery();
+      return;
     }
 
-    // Check for production mode warnings
-    if (isProduction && !isReadOnly) {
-      const warnings = getQueryWarnings(sql, true);
-      if (warnings.length > 0) {
-        pendingExecutionRef.current = {
-          queryId: activeQueryId,
-          connectionId: activeQueryConnectionId,
-        };
-        setQueryConfirmDialog({
-          isOpen: true,
-          title: 'Production Warning',
-          message: warnings.map((w: UnsafeQueryWarning) => w.message).join('\n'),
-          details: sql.slice(0, 200) + (sql.length > 200 ? '...' : ''),
-          isBlocked: false,
-        });
-        return;
-      }
+    if (result.action === 'warn') {
+      pendingExecutionRef.current = {
+        queryId: activeQueryId,
+        connectionId: activeQueryConnectionId,
+      };
     }
 
-    // Safe to execute
-    doExecuteQuery();
+    setQueryConfirmDialog({
+      isOpen: true,
+      title: result.title,
+      message: result.message,
+      details: result.details,
+      isBlocked: result.action === 'block',
+    });
   }, [
     activeQueryId,
     activeQueryConnectionId,

--- a/frontend/src/tests/utils/queryExecutionCheck.test.ts
+++ b/frontend/src/tests/utils/queryExecutionCheck.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkQueryExecutability,
+  previewSql,
+  SQL_PREVIEW_MAX_LENGTH,
+} from '../../utils/queryExecutionCheck';
+
+describe('previewSql', () => {
+  it('should return original string when length <= 200', () => {
+    const sql = 'SELECT * FROM users';
+    expect(previewSql(sql)).toBe(sql);
+  });
+
+  it('should return exact boundary (200 chars) without truncation', () => {
+    const sql = 'a'.repeat(SQL_PREVIEW_MAX_LENGTH);
+    expect(previewSql(sql)).toBe(sql);
+    expect(previewSql(sql).endsWith('...')).toBe(false);
+  });
+
+  it('should truncate and append "..." when length > 200', () => {
+    const sql = 'a'.repeat(250);
+    const result = previewSql(sql);
+    expect(result).toBe(`${'a'.repeat(200)}...`);
+    expect(result.length).toBe(203);
+  });
+
+  it('should return empty string for empty input', () => {
+    expect(previewSql('')).toBe('');
+  });
+});
+
+describe('checkQueryExecutability', () => {
+  describe('execute action', () => {
+    it('should allow SELECT in read-only + production', () => {
+      const result = checkQueryExecutability('SELECT * FROM users', {
+        isReadOnly: true,
+        isProduction: true,
+      });
+      expect(result).toEqual({ action: 'execute' });
+    });
+
+    it('should allow any SQL when not read-only and not production', () => {
+      const result = checkQueryExecutability('DELETE FROM users', {
+        isReadOnly: false,
+        isProduction: false,
+      });
+      expect(result).toEqual({ action: 'execute' });
+    });
+  });
+
+  describe('block action (read-only)', () => {
+    it('should block DML in read-only mode', () => {
+      const result = checkQueryExecutability('DELETE FROM users', {
+        isReadOnly: true,
+        isProduction: false,
+      });
+      expect(result.action).toBe('block');
+      if (result.action === 'block') {
+        expect(result.title).toBe('Read-Only Mode');
+        expect(result.message).toContain('DELETE');
+        expect(result.details).toBe('DELETE FROM users');
+      }
+    });
+
+    it('should include truncated preview for long blocked SQL', () => {
+      const longSql = `UPDATE users SET name = '${'x'.repeat(300)}' WHERE id = 1`;
+      const result = checkQueryExecutability(longSql, {
+        isReadOnly: true,
+        isProduction: false,
+      });
+      expect(result.action).toBe('block');
+      if (result.action === 'block') {
+        expect(result.details.endsWith('...')).toBe(true);
+        expect(result.details.length).toBe(203);
+      }
+    });
+  });
+
+  describe('warn action (production)', () => {
+    it('should warn on DML in production when not read-only', () => {
+      const result = checkQueryExecutability('DELETE FROM users WHERE id = 1', {
+        isReadOnly: false,
+        isProduction: true,
+      });
+      expect(result.action).toBe('warn');
+      if (result.action === 'warn') {
+        expect(result.title).toBe('Production Warning');
+        expect(result.message).toContain('DELETE');
+        expect(result.details).toBe('DELETE FROM users WHERE id = 1');
+      }
+    });
+
+    it('should warn with multiple messages for UPDATE without WHERE in production', () => {
+      const result = checkQueryExecutability('UPDATE users SET status = 1', {
+        isReadOnly: false,
+        isProduction: true,
+      });
+      expect(result.action).toBe('warn');
+      if (result.action === 'warn') {
+        expect(result.message).toContain('production');
+        expect(result.message).toContain('WHERE');
+      }
+    });
+
+    it('should allow SELECT in production without warning', () => {
+      const result = checkQueryExecutability('SELECT * FROM users', {
+        isReadOnly: false,
+        isProduction: true,
+      });
+      expect(result).toEqual({ action: 'execute' });
+    });
+  });
+
+  describe('priority: read-only takes precedence over production', () => {
+    it('should block (not warn) when both flags true and SQL is DML', () => {
+      const result = checkQueryExecutability('DELETE FROM users', {
+        isReadOnly: true,
+        isProduction: true,
+      });
+      expect(result.action).toBe('block');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should allow empty SQL in read-only mode', () => {
+      const result = checkQueryExecutability('', {
+        isReadOnly: true,
+        isProduction: true,
+      });
+      expect(result).toEqual({ action: 'execute' });
+    });
+
+    it('should allow commented-out DML in read-only mode (not executed as DML)', () => {
+      const result = checkQueryExecutability('-- DELETE FROM users\nSELECT 1', {
+        isReadOnly: true,
+        isProduction: false,
+      });
+      expect(result).toEqual({ action: 'execute' });
+    });
+
+    it('should include both dml_in_production and no_where warnings joined by newline', () => {
+      const result = checkQueryExecutability('UPDATE users SET status = 1', {
+        isReadOnly: false,
+        isProduction: true,
+      });
+      expect(result.action).toBe('warn');
+      if (result.action === 'warn') {
+        const lines = result.message.split('\n');
+        expect(lines).toHaveLength(2);
+        expect(lines[0]).toContain('production');
+        expect(lines[1]).toContain('WHERE');
+      }
+    });
+
+    it('should emit single warning for UPDATE with WHERE in production', () => {
+      const result = checkQueryExecutability('UPDATE users SET status = 1 WHERE id = 1', {
+        isReadOnly: false,
+        isProduction: true,
+      });
+      expect(result.action).toBe('warn');
+      if (result.action === 'warn') {
+        expect(result.message.split('\n')).toHaveLength(1);
+        expect(result.message).toContain('production');
+      }
+    });
+  });
+});

--- a/frontend/src/utils/queryExecutionCheck.ts
+++ b/frontend/src/utils/queryExecutionCheck.ts
@@ -1,0 +1,51 @@
+import { checkSqlSafety, getQueryWarnings, type UnsafeQueryWarning } from './sqlSafetyCheck';
+
+export const SQL_PREVIEW_MAX_LENGTH = 200;
+
+export function previewSql(sql: string): string {
+  if (sql.length <= SQL_PREVIEW_MAX_LENGTH) return sql;
+  return `${sql.slice(0, SQL_PREVIEW_MAX_LENGTH)}...`;
+}
+
+export type ExecutionCheckResult =
+  | { action: 'execute' }
+  | { action: 'block'; title: string; message: string; details: string }
+  | { action: 'warn'; title: string; message: string; details: string };
+
+interface ExecutabilityOptions {
+  isReadOnly: boolean;
+  isProduction: boolean;
+}
+
+// Read-Only/Production 判定を handleExecute から分離。
+// UI 依存なしに単体テスト可能、挙動は元のインライン実装と等価。
+export function checkQueryExecutability(
+  sql: string,
+  opts: ExecutabilityOptions
+): ExecutionCheckResult {
+  if (opts.isReadOnly) {
+    const safety = checkSqlSafety(sql);
+    if (!safety.isSafe) {
+      return {
+        action: 'block',
+        title: 'Read-Only Mode',
+        message: safety.message ?? 'This query is blocked in read-only mode.',
+        details: previewSql(sql),
+      };
+    }
+  }
+
+  if (opts.isProduction && !opts.isReadOnly) {
+    const warnings = getQueryWarnings(sql, true);
+    if (warnings.length > 0) {
+      return {
+        action: 'warn',
+        title: 'Production Warning',
+        message: warnings.map((w: UnsafeQueryWarning) => w.message).join('\n'),
+        details: previewSql(sql),
+      };
+    }
+  }
+
+  return { action: 'execute' };
+}


### PR DESCRIPTION
## Summary

- 純粋関数 `checkQueryExecutability` + `previewSql` を抽出
- MainLayout.handleExecute 49→25 行、discriminated union で分岐整理
- 単体テスト 16 件追加

## Test plan

- [x] Biome / tsc / Vitest 764+ tests pass
- [ ] 実機: Read-Only DML → block ダイアログ
- [ ] 実機: Production DELETE/UPDATE → warn ダイアログ

Close #404