### PR TITLE
feat(frontend): プロファイル順序を接続後も維持する unified rendering (#397)

### DIFF
--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { bridge } from '../../api/bridge';
 import { applyConnectionMigration } from '../../store/connectionMigration';
@@ -10,8 +10,8 @@ import {
   type SavedConnectionProfile,
 } from '../../types';
 import type { ExpandableType } from '../../utils/treeNode';
-import { ConnectionTreeSection } from './ConnectionTreeSection';
 import styles from './ObjectTree.module.css';
+import { ProfileNode } from './ProfileNode';
 
 type RawProfile = Awaited<ReturnType<typeof bridge.getConnectionProfiles>>['profiles'][number];
 
@@ -77,13 +77,15 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
     fetchProfiles();
   }, [profileVersion]);
 
-  // Get active connections
-  const activeConnections = connections.filter((c) => c.isActive);
-
-  // Get disconnected profiles (not currently connected)
-  const disconnectedProfiles = profiles.filter(
-    (profile) => !connections.some((c) => c.name === profile.name)
-  );
+  // Lookup map: profile.name → active Connection. Profile order is the source of truth;
+  // connection state only changes how each row is rendered, never its position.
+  const connectionByName = useMemo(() => {
+    const map = new Map<string, (typeof connections)[number]>();
+    for (const c of connections) {
+      if (c.isActive) map.set(c.name, c);
+    }
+    return map;
+  }, [connections]);
 
   const handleProfileClick = useCallback((profile: SavedConnectionProfile) => {
     setConfirmingProfile(profile);
@@ -159,34 +161,18 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
 
   return (
     <div className={styles.container}>
-      {/* Connected databases */}
-      {activeConnections.map((connection) => (
-        <ConnectionTreeSection
-          key={connection.id}
-          connection={connection}
+      {profiles.map((profile) => (
+        <ProfileNode
+          key={profile.id}
+          profile={profile}
+          connection={connectionByName.get(profile.name)}
           filter={filter}
           onTableOpen={onTableOpen}
+          onProfileClick={handleProfileClick}
         />
       ))}
 
-      {/* Disconnected profiles */}
-      {disconnectedProfiles.map((profile) => (
-        <div
-          key={profile.id}
-          className={`${styles.profileItem} ${profile.isProduction ? styles.production : ''}`}
-          onClick={() => handleProfileClick(profile)}
-          title={`Click to connect to ${profile.name}`}
-        >
-          <span className={styles.profileIcon}>🗄</span>
-          <span className={styles.profileName}>{profile.name}</span>
-          <span className={styles.profileStatus}>未接続</span>
-        </div>
-      ))}
-
-      {/* No connections message */}
-      {activeConnections.length === 0 && disconnectedProfiles.length === 0 && (
-        <div className={styles.noConnection}>接続なし</div>
-      )}
+      {profiles.length === 0 && <div className={styles.noConnection}>接続なし</div>}
 
       {/* Connection confirmation dialog */}
       {confirmingProfile && (

--- a/frontend/src/components/tree/ProfileNode.tsx
+++ b/frontend/src/components/tree/ProfileNode.tsx
@@ -1,0 +1,45 @@
+import { memo } from 'react';
+import type { Connection, SavedConnectionProfile } from '../../types';
+import type { ExpandableType } from '../../utils/treeNode';
+import { ConnectionTreeSection } from './ConnectionTreeSection';
+import styles from './ObjectTree.module.css';
+
+interface ProfileNodeProps {
+  profile: SavedConnectionProfile;
+  connection: Connection | undefined;
+  filter: string;
+  onTableOpen?: (tableName: string, tableType: ExpandableType, connectionId?: string) => void;
+  onProfileClick: (profile: SavedConnectionProfile) => void;
+}
+
+function ProfileNodeComponent({
+  profile,
+  connection,
+  filter,
+  onTableOpen,
+  onProfileClick,
+}: ProfileNodeProps) {
+  if (connection) {
+    return (
+      <div data-testid="profile-node" data-profile-name={profile.name}>
+        <ConnectionTreeSection connection={connection} filter={filter} onTableOpen={onTableOpen} />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="profile-node"
+      data-profile-name={profile.name}
+      className={`${styles.profileItem} ${profile.isProduction ? styles.production : ''}`}
+      onClick={() => onProfileClick(profile)}
+      title={`Click to connect to ${profile.name}`}
+    >
+      <span className={styles.profileIcon}>🗄</span>
+      <span className={styles.profileName}>{profile.name}</span>
+      <span className={styles.profileStatus}>未接続</span>
+    </div>
+  );
+}
+
+export const ProfileNode = memo(ProfileNodeComponent);

--- a/frontend/src/tests/components/tree/ObjectTree.order.test.tsx
+++ b/frontend/src/tests/components/tree/ObjectTree.order.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addConnectionMock = vi.fn().mockResolvedValue({});
+const cancelConnectionMock = vi.fn();
+
+type MockConnection = { id: string; name: string; isActive: boolean };
+
+// Wrap mutable state in an object so vi.mock factory references the holder, not the binding.
+// Reassigning a top-level `let` from beforeEach can desynchronize from the hoisted factory closure.
+const mockState: { connections: MockConnection[] } = { connections: [] };
+
+vi.mock('../../../store/connectionStore', () => {
+  const useConnectionStore = (
+    selector?: (s: { connections: MockConnection[]; profileVersion: number }) => unknown
+  ) => (selector ? selector({ connections: mockState.connections, profileVersion: 0 }) : null);
+  (useConnectionStore as unknown as { getState: () => unknown }).getState = () => ({
+    connections: mockState.connections,
+    activeConnectionId: null,
+    setTableListLoadTime: vi.fn(),
+    setTableOpenTime: vi.fn(),
+  });
+  return {
+    useConnectionStore,
+    useConnectionActions: () => ({
+      addConnection: addConnectionMock,
+      cancelConnection: cancelConnectionMock,
+    }),
+  };
+});
+
+vi.mock('../../../store/connectionMigration', () => ({
+  applyConnectionMigration: vi.fn(),
+}));
+
+vi.mock('../../../api/bridge', () => ({
+  bridge: {
+    getConnectionProfiles: vi.fn(),
+    getProfilePassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshPassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshKeyPassphrase: vi.fn().mockResolvedValue({ passphrase: '' }),
+    getTables: vi.fn().mockResolvedValue({ tables: [], loadTimeMs: 0 }),
+    getColumns: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import { bridge } from '../../../api/bridge';
+import { ObjectTree } from '../../../components/tree/ObjectTree';
+
+// Single source of truth: bridge schema. Schema drift surfaces as a compile error here.
+type ProfileFixture = Awaited<ReturnType<typeof bridge.getConnectionProfiles>>['profiles'][number];
+
+const buildProfile = (id: string, name: string): ProfileFixture => ({
+  id,
+  name,
+  server: '127.0.0.1',
+  port: 1433,
+  database: 'db',
+  username: 'sa',
+  useWindowsAuth: false,
+  savePassword: false,
+  isProduction: false,
+  isReadOnly: false,
+  environment: 'development',
+  dbType: 'sqlserver',
+});
+
+const setProfiles = (profiles: ProfileFixture[]) => {
+  vi.mocked(bridge.getConnectionProfiles).mockResolvedValue({
+    profiles,
+  });
+};
+
+const getRenderedProfileNames = () =>
+  screen.getAllByTestId('profile-node').map((el) => el.dataset.profileName ?? '');
+
+describe('ObjectTree unified rendering — profile order preservation', () => {
+  beforeEach(() => {
+    mockState.connections = [];
+    addConnectionMock.mockClear();
+    cancelConnectionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should_preserve_profile_order_when_one_profile_is_connected', async () => {
+    setProfiles([
+      buildProfile('p_a', 'Alpha'),
+      buildProfile('p_b', 'Bravo'),
+      buildProfile('p_c', 'Charlie'),
+      buildProfile('p_d', 'Delta'),
+    ]);
+    mockState.connections = [{ id: 'conn_b', name: 'Bravo', isActive: true }];
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(4);
+    });
+
+    expect(getRenderedProfileNames()).toEqual(['Alpha', 'Bravo', 'Charlie', 'Delta']);
+  });
+
+  it('should_preserve_profile_order_when_middle_profile_is_connected', async () => {
+    setProfiles([
+      buildProfile('p_x', 'Xenon'),
+      buildProfile('p_y', 'Yttrium'),
+      buildProfile('p_z', 'Zinc'),
+    ]);
+    mockState.connections = [{ id: 'conn_y', name: 'Yttrium', isActive: true }];
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(3);
+    });
+
+    expect(getRenderedProfileNames()).toEqual(['Xenon', 'Yttrium', 'Zinc']);
+  });
+
+  it('should_render_no_connection_message_when_profiles_empty', async () => {
+    setProfiles([]);
+    mockState.connections = [];
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('接続なし')).toBeInTheDocument();
+    });
+    expect(screen.queryAllByTestId('profile-node')).toHaveLength(0);
+  });
+
+  it('should_render_all_profiles_when_all_connected', async () => {
+    setProfiles([
+      buildProfile('p_1', 'One'),
+      buildProfile('p_2', 'Two'),
+      buildProfile('p_3', 'Three'),
+    ]);
+    mockState.connections = [
+      { id: 'conn_1', name: 'One', isActive: true },
+      { id: 'conn_2', name: 'Two', isActive: true },
+      { id: 'conn_3', name: 'Three', isActive: true },
+    ];
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(3);
+    });
+    expect(getRenderedProfileNames()).toEqual(['One', 'Two', 'Three']);
+  });
+
+  it('should_render_all_profiles_when_all_disconnected', async () => {
+    setProfiles([
+      buildProfile('p_1', 'One'),
+      buildProfile('p_2', 'Two'),
+      buildProfile('p_3', 'Three'),
+    ]);
+    mockState.connections = [];
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(3);
+    });
+    expect(getRenderedProfileNames()).toEqual(['One', 'Two', 'Three']);
+  });
+});


### PR DESCRIPTION
ref #397