### PR TITLE
feat: 接続プロファイルをフォルダでグループ化する (#397)

### DIFF
--- a/backend/providers/settings_provider.cpp
+++ b/backend/providers/settings_provider.cpp
@@ -38,6 +38,9 @@ struct SshConfigResponse {
     bool savePassword = false;
 };
 
+// Non-owning view of a ConnectionProfile for JSON serialization.
+// All std::string_view members point into the source ConnectionProfile;
+// that source must outlive this response until JSON serialization completes.
 struct ConnectionProfileResponse {
     std::string_view id;
     std::string_view name;
@@ -51,6 +54,7 @@ struct ConnectionProfileResponse {
     bool isReadOnly = false;
     std::string_view environment;
     std::string_view dbType;
+    std::string_view folderPath;
     SshConfigResponse ssh;
 };
 
@@ -82,6 +86,7 @@ struct SessionStateResponse {
         .isReadOnly = p.isReadOnly,
         .environment = p.environment,
         .dbType = p.dbType,
+        .folderPath = p.folderPath,
         .ssh =
             {
                 .enabled = p.ssh.enabled,
@@ -129,9 +134,9 @@ struct glz::meta<velocitydb::dto::SshConfigResponse> {
 template <>
 struct glz::meta<velocitydb::dto::ConnectionProfileResponse> {
     using T = velocitydb::dto::ConnectionProfileResponse;
-    static constexpr auto value =
-        glz::object("id", &T::id, "name", &T::name, "server", &T::server, "port", &T::port, "database", &T::database, "username", &T::username, "useWindowsAuth", &T::useWindowsAuth, "savePassword",
-                    &T::savePassword, "isProduction", &T::isProduction, "isReadOnly", &T::isReadOnly, "environment", &T::environment, "dbType", &T::dbType, "ssh", &T::ssh);
+    static constexpr auto value = glz::object("id", &T::id, "name", &T::name, "server", &T::server, "port", &T::port, "database", &T::database, "username", &T::username, "useWindowsAuth",
+                                              &T::useWindowsAuth, "savePassword", &T::savePassword, "isProduction", &T::isProduction, "isReadOnly", &T::isReadOnly, "environment", &T::environment,
+                                              "dbType", &T::dbType, "folderPath", &T::folderPath, "ssh", &T::ssh);
 };
 
 template <>
@@ -288,6 +293,8 @@ std::string SettingsProvider::saveConnectionProfile(std::string_view params) {
             profile.environment = std::string(val.value());
         if (auto val = doc["dbType"].get_string(); !val.error())
             profile.dbType = std::string(val.value());
+        if (auto val = doc["folderPath"].get_string(); !val.error())
+            profile.folderPath = std::string(val.value());
 
         if (auto ssh = doc["ssh"]; !ssh.error()) {
             if (auto val = ssh["enabled"].get_bool(); !val.error())

--- a/backend/utils/settings_manager.h
+++ b/backend/utils/settings_manager.h
@@ -40,6 +40,7 @@ struct ConnectionProfile {
     bool isReadOnly = false;                  // Read-only mode - prevents data modifications
     std::string environment = "development";  // development, staging, production
     std::string dbType = "sqlserver";         // sqlserver, postgresql, mysql
+    std::string folderPath;                   // Optional grouping folder. Empty = root. Flat (no nesting) in current UI.
     SshConfig ssh;                            // SSH tunnel configuration
 };
 

--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -655,6 +655,7 @@ class Bridge {
       isReadOnly?: boolean;
       environment?: 'development' | 'staging' | 'production';
       dbType?: 'sqlserver' | 'postgresql' | 'mysql';
+      folderPath?: string;
       ssh?: {
         enabled: boolean;
         host: string;
@@ -683,6 +684,7 @@ class Bridge {
     isReadOnly?: boolean;
     environment?: 'development' | 'staging' | 'production';
     dbType?: 'sqlserver' | 'postgresql' | 'mysql';
+    folderPath?: string;
     ssh?: {
       enabled: boolean;
       host: string;

--- a/frontend/src/components/dialogs/ConnectionDialog.tsx
+++ b/frontend/src/components/dialogs/ConnectionDialog.tsx
@@ -42,6 +42,7 @@ export interface ConnectionConfig {
   isReadOnly: boolean;
   environment: EnvironmentType;
   dbType: DatabaseType;
+  folderPath: string;
   ssh: SshConfig;
 }
 

--- a/frontend/src/components/dialogs/hooks/useConnectionProfile.ts
+++ b/frontend/src/components/dialogs/hooks/useConnectionProfile.ts
@@ -35,6 +35,7 @@ const DEFAULT_CONFIG: ConnectionConfig = {
   isReadOnly: false,
   environment: 'development',
   dbType: 'sqlserver',
+  folderPath: '',
   ssh: { ...DEFAULT_SSH_CONFIG },
 };
 
@@ -110,6 +111,7 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
       isReadOnly: profile.isReadOnly,
       environment: inferEnvironment(profile),
       dbType: profile.dbType ?? 'sqlserver',
+      folderPath: profile.folderPath ?? '',
       ssh: profile.ssh
         ? {
             enabled: profile.ssh.enabled,
@@ -167,6 +169,7 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
               ? 'production'
               : 'development',
           dbType: isDatabaseType(p.dbType ?? '') ? p.dbType : 'sqlserver',
+          folderPath: p.folderPath ?? '',
           ssh: p.ssh
             ? {
                 enabled: p.ssh.enabled ?? false,
@@ -219,6 +222,7 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
               environment:
                 profile.environment ?? (profile.isProduction ? 'production' : 'development'),
               dbType: profile.dbType ?? 'sqlserver',
+              folderPath: profile.folderPath ?? '',
               ssh: profile.ssh
                 ? {
                     enabled: profile.ssh.enabled,
@@ -259,6 +263,7 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
   const handleSaveProfile = useCallback(async () => {
     const isNewProfile = mode === 'new';
     const currentEditingId = editingProfileId;
+    const folderPath = config.folderPath.trim();
 
     try {
       const result = await bridge.saveConnectionProfile({
@@ -275,6 +280,7 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
         isReadOnly: config.isReadOnly,
         environment: config.environment,
         dbType: config.dbType,
+        folderPath,
         ssh: config.ssh.enabled
           ? {
               enabled: true,
@@ -304,6 +310,7 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
         isReadOnly: config.isReadOnly,
         environment: config.environment,
         dbType: config.dbType,
+        folderPath,
         ssh: config.ssh.enabled
           ? {
               enabled: true,

--- a/frontend/src/components/dialogs/sections/ConnectionFormSection.tsx
+++ b/frontend/src/components/dialogs/sections/ConnectionFormSection.tsx
@@ -36,6 +36,16 @@ export function ConnectionFormSection({
         <input type="text" value={config.name} onChange={(e) => onChange('name', e.target.value)} />
       </div>
 
+      <div className={styles.formGroup}>
+        <label>フォルダ (任意)</label>
+        <input
+          type="text"
+          value={config.folderPath}
+          onChange={(e) => onChange('folderPath', e.target.value)}
+          placeholder="例: Work / Personal (空欄でルート)"
+        />
+      </div>
+
       <div className={styles.formRow}>
         <div className={styles.formGroup}>
           <label>サーバー</label>

--- a/frontend/src/components/tree/FolderNode.tsx
+++ b/frontend/src/components/tree/FolderNode.tsx
@@ -1,0 +1,50 @@
+import { type KeyboardEvent, memo, type ReactNode } from 'react';
+import styles from './ObjectTree.module.css';
+
+interface FolderNodeProps {
+  folderPath: string;
+  expanded: boolean;
+  profileCount: number;
+  onToggle: (folderPath: string) => void;
+  children: ReactNode;
+}
+
+function FolderNodeComponent({
+  folderPath,
+  expanded,
+  profileCount,
+  onToggle,
+  children,
+}: FolderNodeProps) {
+  const toggle = () => onToggle(folderPath);
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
+  return (
+    <div data-testid="folder-node" data-folder-path={folderPath}>
+      <div
+        className={styles.folderHeader}
+        onClick={toggle}
+        onKeyDown={onKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-expanded={expanded}
+        title={folderPath}
+      >
+        <span className={`${styles.folderChevron} ${expanded ? styles.folderChevronExpanded : ''}`}>
+          ▶
+        </span>
+        <span className={styles.folderIcon}>📁</span>
+        <span className={styles.folderName}>{folderPath}</span>
+        <span className={styles.folderCount}>({profileCount})</span>
+      </div>
+      {expanded && <div className={styles.folderBody}>{children}</div>}
+    </div>
+  );
+}
+
+export const FolderNode = memo(FolderNodeComponent);

--- a/frontend/src/components/tree/ObjectTree.module.css
+++ b/frontend/src/components/tree/ObjectTree.module.css
@@ -41,6 +41,58 @@
   font-size: 13px;
 }
 
+/* Folder node (groups profiles by folderPath) */
+.folderHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  cursor: pointer;
+  color: var(--text-secondary, #bbbbbb);
+  font-size: 12px;
+  font-weight: 500;
+  background-color: var(--bg-secondary, #2b2b2b);
+  border-bottom: 1px solid var(--border-color, #3c3f41);
+  user-select: none;
+}
+
+.folderHeader:hover {
+  background: var(--bg-hover, #3c3f41);
+}
+
+.folderChevron {
+  font-size: 10px;
+  width: 12px;
+  flex-shrink: 0;
+  text-align: center;
+  transition: transform 0.15s ease;
+}
+
+.folderChevronExpanded {
+  transform: rotate(90deg);
+}
+
+.folderIcon {
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.folderName {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.folderCount {
+  font-size: 10px;
+  color: var(--text-disabled, #5a5d63);
+}
+
+.folderBody {
+  padding-left: 16px;
+}
+
 /* Profile items (disconnected) */
 .profileItem {
   display: flex;

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { bridge } from '../../api/bridge';
 import { applyConnectionMigration } from '../../store/connectionMigration';
@@ -9,7 +9,10 @@ import {
   isSshAuthType,
   type SavedConnectionProfile,
 } from '../../types';
+import { groupProfilesByFolder, type ProfileGroup } from '../../utils/groupProfilesByFolder';
+import { pruneCollapsedFolders } from '../../utils/pruneCollapsedFolders';
 import type { ExpandableType } from '../../utils/treeNode';
+import { FolderNode } from './FolderNode';
 import styles from './ObjectTree.module.css';
 import { ProfileNode } from './ProfileNode';
 
@@ -33,6 +36,7 @@ function normalizeProfile(p: RawProfile): SavedConnectionProfile {
         ? 'production'
         : 'development',
     dbType: isDatabaseType(p.dbType ?? '') ? p.dbType : 'sqlserver',
+    folderPath: p.folderPath ?? '',
     ssh: p.ssh
       ? {
           enabled: p.ssh.enabled ?? false,
@@ -63,6 +67,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
   const [profiles, setProfiles] = useState<SavedConnectionProfile[]>([]);
   const [confirmingProfile, setConfirmingProfile] = useState<SavedConnectionProfile | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
+  const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(() => new Set());
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: profileVersion is an intentional re-fetch trigger
   useEffect(() => {
@@ -87,9 +92,62 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
     return map;
   }, [connections]);
 
+  const profileGroups = useMemo(() => groupProfilesByFolder(profiles), [profiles]);
+
+  // Drop collapsed state for folders that no longer exist, so a recreated
+  // folder of the same name doesn't inherit a stale "closed" flag.
+  useEffect(() => {
+    const existing = new Set(profileGroups.map((g) => g.folderPath));
+    setCollapsedFolders((prev) => pruneCollapsedFolders(prev, existing) ?? prev);
+  }, [profileGroups]);
+
+  const toggleFolder = useCallback((folderPath: string) => {
+    setCollapsedFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(folderPath)) {
+        next.delete(folderPath);
+      } else {
+        next.add(folderPath);
+      }
+      return next;
+    });
+  }, []);
+
   const handleProfileClick = useCallback((profile: SavedConnectionProfile) => {
     setConfirmingProfile(profile);
   }, []);
+
+  const renderGroup = useCallback(
+    (group: ProfileGroup) => {
+      const profileNodes = group.profiles.map((profile) => (
+        <ProfileNode
+          key={profile.id}
+          profile={profile}
+          connection={connectionByName.get(profile.name)}
+          filter={filter}
+          onTableOpen={onTableOpen}
+          onProfileClick={handleProfileClick}
+        />
+      ));
+
+      if (group.folderPath === '') {
+        return <Fragment key="root">{profileNodes}</Fragment>;
+      }
+
+      return (
+        <FolderNode
+          key={group.folderPath}
+          folderPath={group.folderPath}
+          expanded={!collapsedFolders.has(group.folderPath)}
+          profileCount={group.profiles.length}
+          onToggle={toggleFolder}
+        >
+          {profileNodes}
+        </FolderNode>
+      );
+    },
+    [connectionByName, filter, onTableOpen, handleProfileClick, collapsedFolders, toggleFolder]
+  );
 
   const handleConfirm = useCallback(async () => {
     if (!confirmingProfile) return;
@@ -161,16 +219,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
 
   return (
     <div className={styles.container}>
-      {profiles.map((profile) => (
-        <ProfileNode
-          key={profile.id}
-          profile={profile}
-          connection={connectionByName.get(profile.name)}
-          filter={filter}
-          onTableOpen={onTableOpen}
-          onProfileClick={handleProfileClick}
-        />
-      ))}
+      {profileGroups.map(renderGroup)}
 
       {profiles.length === 0 && <div className={styles.noConnection}>接続なし</div>}
 

--- a/frontend/src/tests/components/tree/ObjectTree.folder.test.tsx
+++ b/frontend/src/tests/components/tree/ObjectTree.folder.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addConnectionMock = vi.fn().mockResolvedValue({});
+const cancelConnectionMock = vi.fn();
+
+type MockConnection = { id: string; name: string; isActive: boolean };
+
+const mockState: { connections: MockConnection[] } = { connections: [] };
+
+vi.mock('../../../store/connectionStore', () => {
+  const useConnectionStore = (
+    selector?: (s: { connections: MockConnection[]; profileVersion: number }) => unknown
+  ) => (selector ? selector({ connections: mockState.connections, profileVersion: 0 }) : null);
+  (useConnectionStore as unknown as { getState: () => unknown }).getState = () => ({
+    connections: mockState.connections,
+    activeConnectionId: null,
+    setTableListLoadTime: vi.fn(),
+    setTableOpenTime: vi.fn(),
+  });
+  return {
+    useConnectionStore,
+    useConnectionActions: () => ({
+      addConnection: addConnectionMock,
+      cancelConnection: cancelConnectionMock,
+    }),
+  };
+});
+
+vi.mock('../../../store/connectionMigration', () => ({
+  applyConnectionMigration: vi.fn(),
+}));
+
+vi.mock('../../../api/bridge', () => ({
+  bridge: {
+    getConnectionProfiles: vi.fn(),
+    getProfilePassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshPassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshKeyPassphrase: vi.fn().mockResolvedValue({ passphrase: '' }),
+    getTables: vi.fn().mockResolvedValue({ tables: [], loadTimeMs: 0 }),
+    getColumns: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import { bridge } from '../../../api/bridge';
+import { ObjectTree } from '../../../components/tree/ObjectTree';
+
+type ProfileFixture = Awaited<ReturnType<typeof bridge.getConnectionProfiles>>['profiles'][number];
+
+const buildProfile = (id: string, name: string, folderPath?: string): ProfileFixture => ({
+  id,
+  name,
+  server: '127.0.0.1',
+  port: 1433,
+  database: 'db',
+  username: 'sa',
+  useWindowsAuth: false,
+  savePassword: false,
+  isProduction: false,
+  isReadOnly: false,
+  environment: 'development',
+  dbType: 'sqlserver',
+  ...(folderPath === undefined ? {} : { folderPath }),
+});
+
+const setProfiles = (profiles: ProfileFixture[]) => {
+  vi.mocked(bridge.getConnectionProfiles).mockResolvedValue({ profiles });
+};
+
+const getFolderPaths = () =>
+  screen.queryAllByTestId('folder-node').map((el) => el.dataset.folderPath ?? '');
+
+describe('ObjectTree folder grouping', () => {
+  beforeEach(() => {
+    mockState.connections = [];
+    addConnectionMock.mockClear();
+    cancelConnectionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders folder nodes for each distinct folderPath preserving first-appearance order', async () => {
+    setProfiles([
+      buildProfile('p1', 'Alpha'),
+      buildProfile('p2', 'WorkA', 'Work'),
+      buildProfile('p3', 'Beta'),
+      buildProfile('p4', 'WorkB', 'Work'),
+      buildProfile('p5', 'Home1', 'Personal'),
+    ]);
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(5);
+    });
+
+    expect(getFolderPaths()).toEqual(['Work', 'Personal']);
+  });
+
+  it('does not render a folder node when all profiles are at root', async () => {
+    setProfiles([buildProfile('p1', 'Alpha'), buildProfile('p2', 'Beta')]);
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(2);
+    });
+
+    expect(getFolderPaths()).toEqual([]);
+  });
+
+  it('hides inner profiles when folder is collapsed via click', async () => {
+    setProfiles([buildProfile('p1', 'WorkA', 'Work'), buildProfile('p2', 'WorkB', 'Work')]);
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(2);
+    });
+
+    const folder = screen.getByTestId('folder-node');
+    const header = folder.querySelector('[title="Work"]');
+    expect(header).not.toBeNull();
+    if (header) fireEvent.click(header);
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('profile-node')).toHaveLength(0);
+    });
+  });
+
+  it('preserves profile order within a folder', async () => {
+    setProfiles([
+      buildProfile('p1', 'Third', 'Work'),
+      buildProfile('p2', 'First', 'Work'),
+      buildProfile('p3', 'Second', 'Work'),
+    ]);
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(3);
+    });
+
+    const names = screen.getAllByTestId('profile-node').map((el) => el.dataset.profileName ?? '');
+    expect(names).toEqual(['Third', 'First', 'Second']);
+  });
+});

--- a/frontend/src/tests/utils/groupProfilesByFolder.test.ts
+++ b/frontend/src/tests/utils/groupProfilesByFolder.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import type { SavedConnectionProfile } from '../../types';
+import { groupProfilesByFolder } from '../../utils/groupProfilesByFolder';
+
+function makeProfile(id: string, folderPath?: string): SavedConnectionProfile {
+  return {
+    id,
+    name: id,
+    server: 'localhost',
+    port: 1433,
+    database: 'db',
+    username: 'u',
+    useWindowsAuth: true,
+    savePassword: false,
+    isProduction: false,
+    isReadOnly: false,
+    ...(folderPath === undefined ? {} : { folderPath }),
+  };
+}
+
+describe('groupProfilesByFolder', () => {
+  it('returns empty array when no profiles', () => {
+    expect(groupProfilesByFolder([])).toEqual([]);
+  });
+
+  it('groups all profiles under root when none have folderPath', () => {
+    const profiles = [makeProfile('a'), makeProfile('b')];
+
+    const result = groupProfilesByFolder(profiles);
+
+    expect(result).toEqual([{ folderPath: '', profiles: [profiles[0], profiles[1]] }]);
+  });
+
+  it('treats undefined and empty string folderPath as root', () => {
+    const profiles = [makeProfile('a'), makeProfile('b', ''), makeProfile('c', undefined)];
+
+    const result = groupProfilesByFolder(profiles);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].folderPath).toBe('');
+    expect(result[0].profiles.map((p) => p.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('groups profiles by folderPath preserving first-appearance order', () => {
+    const profiles = [
+      makeProfile('root1'),
+      makeProfile('work1', 'Work'),
+      makeProfile('root2'),
+      makeProfile('work2', 'Work'),
+      makeProfile('personal1', 'Personal'),
+    ];
+
+    const result = groupProfilesByFolder(profiles);
+
+    expect(result.map((g) => g.folderPath)).toEqual(['', 'Work', 'Personal']);
+    expect(result[0].profiles.map((p) => p.id)).toEqual(['root1', 'root2']);
+    expect(result[1].profiles.map((p) => p.id)).toEqual(['work1', 'work2']);
+    expect(result[2].profiles.map((p) => p.id)).toEqual(['personal1']);
+  });
+
+  it('preserves within-group profile order as given', () => {
+    const profiles = [
+      makeProfile('w3', 'Work'),
+      makeProfile('w1', 'Work'),
+      makeProfile('w2', 'Work'),
+    ];
+
+    const result = groupProfilesByFolder(profiles);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].profiles.map((p) => p.id)).toEqual(['w3', 'w1', 'w2']);
+  });
+
+  it('does not create a root group if all profiles are foldered', () => {
+    const profiles = [makeProfile('a', 'A'), makeProfile('b', 'B')];
+
+    const result = groupProfilesByFolder(profiles);
+
+    expect(result.map((g) => g.folderPath)).toEqual(['A', 'B']);
+  });
+});

--- a/frontend/src/tests/utils/pruneCollapsedFolders.test.ts
+++ b/frontend/src/tests/utils/pruneCollapsedFolders.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { pruneCollapsedFolders } from '../../utils/pruneCollapsedFolders';
+
+describe('pruneCollapsedFolders', () => {
+  it('returns null when collapsed set is empty', () => {
+    expect(pruneCollapsedFolders(new Set(), new Set(['Work']))).toBeNull();
+  });
+
+  it('returns null when every collapsed folder still exists', () => {
+    expect(
+      pruneCollapsedFolders(new Set(['Work', 'Personal']), new Set(['Work', 'Personal']))
+    ).toBeNull();
+  });
+
+  it('drops folders that no longer exist', () => {
+    const result = pruneCollapsedFolders(new Set(['Work', 'Personal']), new Set(['Work']));
+    expect(result).not.toBeNull();
+    expect([...(result ?? [])]).toEqual(['Work']);
+  });
+
+  it('returns empty set when no collapsed folder remains', () => {
+    const result = pruneCollapsedFolders(new Set(['Work']), new Set(['Personal']));
+    expect(result).not.toBeNull();
+    expect(result?.size).toBe(0);
+  });
+
+  it('preserves insertion order of surviving folders', () => {
+    const result = pruneCollapsedFolders(new Set(['A', 'B', 'C', 'D']), new Set(['A', 'C', 'D']));
+    expect([...(result ?? [])]).toEqual(['A', 'C', 'D']);
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -56,6 +56,7 @@ export interface SavedConnectionProfile {
   isReadOnly: boolean;
   environment?: EnvironmentType;
   dbType?: DatabaseType;
+  folderPath?: string;
   ssh?: SavedSshConfig;
 }
 

--- a/frontend/src/utils/groupProfilesByFolder.ts
+++ b/frontend/src/utils/groupProfilesByFolder.ts
@@ -1,0 +1,24 @@
+import type { SavedConnectionProfile } from '../types';
+
+export interface ProfileGroup {
+  folderPath: string;
+  profiles: SavedConnectionProfile[];
+}
+
+export function groupProfilesByFolder(profiles: SavedConnectionProfile[]): ProfileGroup[] {
+  const groupIndex = new Map<string, number>();
+  const groups: ProfileGroup[] = [];
+
+  for (const profile of profiles) {
+    const folderPath = profile.folderPath ?? '';
+    const existing = groupIndex.get(folderPath);
+    if (existing === undefined) {
+      groupIndex.set(folderPath, groups.length);
+      groups.push({ folderPath, profiles: [profile] });
+    } else {
+      groups[existing].profiles.push(profile);
+    }
+  }
+
+  return groups;
+}

--- a/frontend/src/utils/pruneCollapsedFolders.ts
+++ b/frontend/src/utils/pruneCollapsedFolders.ts
@@ -1,0 +1,13 @@
+export function pruneCollapsedFolders(
+  collapsed: ReadonlySet<string>,
+  existing: ReadonlySet<string>
+): Set<string> | null {
+  if (collapsed.size === 0) return null;
+  let changed = false;
+  const next = new Set<string>();
+  for (const path of collapsed) {
+    if (existing.has(path)) next.add(path);
+    else changed = true;
+  }
+  return changed ? next : null;
+}


### PR DESCRIPTION
派生フォルダ方式 (profile.folderPath を真実の源) で左ペインにフォルダ UI を追加。
同じ folderPath を持つ profile を FolderNode 配下にまとめ、空欄はルート直下として既存レイアウトと完全互換。

- backend: ConnectionProfile.folderPath を Glaze シリアライズに中継
- frontend: groupProfilesByFolder で出現順グループ化 (PR-1 順序原則を継承)
- frontend: collapsedFolders Set で折りたたみ状態を管理 (デフォルト展開)
- frontend: 削除済みフォルダの collapsed 状態を useEffect で自動 cleanup
- frontend: ConnectionFormSection に「フォルダ (任意)」入力欄を追加
- frontend: FolderNode は role/tabIndex/onKeyDown でキーボード対応

Close #397