### PR TITLE
fix: フォルダ機能の永続化と同名 profile の接続先混線を修正 (#413, #414)

### DIFF
--- a/backend/utils/glaze_meta.h
+++ b/backend/utils/glaze_meta.h
@@ -27,7 +27,7 @@ struct glz::meta<velocitydb::ConnectionProfile> {
     using T = velocitydb::ConnectionProfile;
     static constexpr auto value = object("id", &T::id, "name", &T::name, "server", &T::server, "port", &T::port, "database", &T::database, "username", &T::username, "useWindowsAuth",
                                          &T::useWindowsAuth, "savePassword", &T::savePassword, "encryptedPassword", &T::encryptedPassword, "isProduction", &T::isProduction, "isReadOnly",
-                                         &T::isReadOnly, "environment", &T::environment, "dbType", &T::dbType, "ssh", &T::ssh);
+                                         &T::isReadOnly, "environment", &T::environment, "dbType", &T::dbType, "folderPath", &T::folderPath, "ssh", &T::ssh);
 };
 
 template <>

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -82,12 +82,13 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
     fetchProfiles();
   }, [profileVersion]);
 
-  // Lookup map: profile.name → active Connection. Profile order is the source of truth;
-  // connection state only changes how each row is rendered, never its position.
-  const connectionByName = useMemo(() => {
+  // Lookup map: profile.id → active Connection. Profile-derived connections carry profileId
+  // (set in handleConfirm below); ad-hoc connections lack it and are not shown on profile rows.
+  // Required to avoid same-name collision across folders (#414).
+  const connectionByProfileId = useMemo(() => {
     const map = new Map<string, (typeof connections)[number]>();
     for (const c of connections) {
-      if (c.isActive) map.set(c.name, c);
+      if (c.isActive && c.profileId) map.set(c.profileId, c);
     }
     return map;
   }, [connections]);
@@ -123,7 +124,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
         <ProfileNode
           key={profile.id}
           profile={profile}
-          connection={connectionByName.get(profile.name)}
+          connection={connectionByProfileId.get(profile.id)}
           filter={filter}
           onTableOpen={onTableOpen}
           onProfileClick={handleProfileClick}
@@ -146,7 +147,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
         </FolderNode>
       );
     },
-    [connectionByName, filter, onTableOpen, handleProfileClick, collapsedFolders, toggleFolder]
+    [connectionByProfileId, filter, onTableOpen, handleProfileClick, collapsedFolders, toggleFolder]
   );
 
   const handleConfirm = useCallback(async () => {
@@ -174,6 +175,7 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
       }
 
       const result = await addConnection({
+        profileId: confirmingProfile.id,
         name: confirmingProfile.name,
         server: confirmingProfile.server,
         port: confirmingProfile.port,

--- a/frontend/src/components/tree/ProfileNode.tsx
+++ b/frontend/src/components/tree/ProfileNode.tsx
@@ -19,9 +19,15 @@ function ProfileNodeComponent({
   onTableOpen,
   onProfileClick,
 }: ProfileNodeProps) {
+  const identityProps = {
+    'data-testid': 'profile-node',
+    'data-profile-name': profile.name,
+    'data-profile-id': profile.id,
+  };
+
   if (connection) {
     return (
-      <div data-testid="profile-node" data-profile-name={profile.name}>
+      <div {...identityProps}>
         <ConnectionTreeSection connection={connection} filter={filter} onTableOpen={onTableOpen} />
       </div>
     );
@@ -29,8 +35,7 @@ function ProfileNodeComponent({
 
   return (
     <div
-      data-testid="profile-node"
-      data-profile-name={profile.name}
+      {...identityProps}
       className={`${styles.profileItem} ${profile.isProduction ? styles.production : ''}`}
       onClick={() => onProfileClick(profile)}
       title={`Click to connect to ${profile.name}`}

--- a/frontend/src/store/connectionStore.ts
+++ b/frontend/src/store/connectionStore.ts
@@ -87,17 +87,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         dbType: connection.dbType ?? 'sqlserver',
       };
 
-      const existing = get().connections.find((c) => c.name === connection.name);
+      // Profile 由来接続は profileId で同定 (#414): 同名でもフォルダ違いなら共存。
+      // 手動接続 (profileId なし) は従来どおり同名で置換し、profile 由来とは衝突させない。
+      const matchesExisting = (c: Connection) =>
+        connection.profileId
+          ? c.profileId === connection.profileId
+          : c.name === connection.name && !c.profileId;
+
+      const existing = get().connections.find(matchesExisting);
       const oldId = existing?.id;
       if (existing) {
         await bridge.disconnect(existing.id).catch(() => {});
       }
 
       set((state) => ({
-        connections: [
-          ...state.connections.filter((c) => c.name !== connection.name),
-          newConnection,
-        ],
+        connections: [...state.connections.filter((c) => !matchesExisting(c)), newConnection],
         activeConnectionId: result.connectionId,
         isConnecting: false,
         connectRequestId: null,

--- a/frontend/src/tests/components/tree/ObjectTree.profileId.test.tsx
+++ b/frontend/src/tests/components/tree/ObjectTree.profileId.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const addConnectionMock = vi.fn().mockResolvedValue({});
+const cancelConnectionMock = vi.fn();
+
+type MockConnection = {
+  id: string;
+  name: string;
+  isActive: boolean;
+  profileId?: string;
+};
+
+const mockState: { connections: MockConnection[] } = { connections: [] };
+
+vi.mock('../../../store/connectionStore', () => {
+  const useConnectionStore = (
+    selector?: (s: { connections: MockConnection[]; profileVersion: number }) => unknown
+  ) => (selector ? selector({ connections: mockState.connections, profileVersion: 0 }) : null);
+  (useConnectionStore as unknown as { getState: () => unknown }).getState = () => ({
+    connections: mockState.connections,
+    activeConnectionId: null,
+    setTableListLoadTime: vi.fn(),
+    setTableOpenTime: vi.fn(),
+  });
+  return {
+    useConnectionStore,
+    useConnectionActions: () => ({
+      addConnection: addConnectionMock,
+      cancelConnection: cancelConnectionMock,
+    }),
+  };
+});
+
+vi.mock('../../../store/connectionMigration', () => ({
+  applyConnectionMigration: vi.fn(),
+}));
+
+vi.mock('../../../api/bridge', () => ({
+  bridge: {
+    getConnectionProfiles: vi.fn(),
+    getProfilePassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshPassword: vi.fn().mockResolvedValue({ password: '' }),
+    getSshKeyPassphrase: vi.fn().mockResolvedValue({ passphrase: '' }),
+    getTables: vi.fn().mockResolvedValue({ tables: [], loadTimeMs: 0 }),
+    getColumns: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+import { bridge } from '../../../api/bridge';
+import { ObjectTree } from '../../../components/tree/ObjectTree';
+
+type ProfileFixture = Awaited<ReturnType<typeof bridge.getConnectionProfiles>>['profiles'][number];
+
+const buildProfile = (id: string, name: string, folderPath: string): ProfileFixture => ({
+  id,
+  name,
+  server: 's',
+  port: 1433,
+  database: 'd',
+  username: 'u',
+  useWindowsAuth: false,
+  savePassword: false,
+  isProduction: false,
+  isReadOnly: false,
+  environment: 'development',
+  dbType: 'sqlserver',
+  folderPath,
+});
+
+const setProfiles = (profiles: ProfileFixture[]) => {
+  vi.mocked(bridge.getConnectionProfiles).mockResolvedValue({ profiles });
+};
+
+describe('ObjectTree profileId-based active state (#414)', () => {
+  beforeEach(() => {
+    mockState.connections = [];
+    addConnectionMock.mockClear();
+    cancelConnectionMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 接続中 profile は ConnectionTreeSection を表示し「未接続」テキストを出さない。
+  // 未接続 profile は ProfileNode 内で「未接続」テキストを出す (ProfileNode L40)。
+  // 振る舞い (UI 表示) ベースで active/inactive を判定する。
+  const isUnconnected = (node: HTMLElement) => node.textContent?.includes('未接続') ?? false;
+
+  it('同名異フォルダの 2 profile で profileId 一致側のみ接続中表示、もう片方は未接続のまま', async () => {
+    setProfiles([
+      buildProfile('p_dev_test', 'Test', 'Develop'),
+      buildProfile('p_stg_test', 'Test', 'Staging'),
+    ]);
+    mockState.connections = [
+      {
+        id: 'db_dev',
+        name: 'Test',
+        isActive: true,
+        profileId: 'p_dev_test',
+      },
+    ];
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(2);
+    });
+
+    const nodes = screen.getAllByTestId('profile-node');
+    const byProfileId = Object.fromEntries(nodes.map((n) => [n.dataset.profileId, n]));
+
+    expect(isUnconnected(byProfileId.p_dev_test)).toBe(false);
+    expect(isUnconnected(byProfileId.p_stg_test)).toBe(true);
+  });
+
+  it('profileId 無しの connection は profile に紐づかない (profile 行は未接続のまま)', async () => {
+    setProfiles([buildProfile('p_only', 'Test', 'Develop')]);
+    mockState.connections = [
+      {
+        id: 'db_manual',
+        name: 'Test',
+        isActive: true,
+        // profileId 無し = 手動接続
+      },
+    ];
+
+    render(<ObjectTree filter="" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('profile-node')).toHaveLength(1);
+    });
+
+    const node = screen.getAllByTestId('profile-node')[0];
+    expect(isUnconnected(node)).toBe(true);
+  });
+});

--- a/frontend/src/tests/stores/connectionStore.profileId.test.ts
+++ b/frontend/src/tests/stores/connectionStore.profileId.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnectionStore } from '../../store/connectionStore';
+
+const mockConnectAsync = vi.fn();
+const mockGetConnectResult = vi.fn();
+const mockCancelConnect = vi.fn();
+const mockDisconnect = vi.fn();
+const mockTestConnection = vi.fn();
+
+vi.mock('../../api/bridge', () => ({
+  bridge: {
+    connectAsync: (...args: unknown[]) => mockConnectAsync(...args),
+    getConnectResult: (...args: unknown[]) => mockGetConnectResult(...args),
+    cancelConnect: (...args: unknown[]) => mockCancelConnect(...args),
+    disconnect: (...args: unknown[]) => mockDisconnect(...args),
+    testConnection: (...args: unknown[]) => mockTestConnection(...args),
+  },
+}));
+
+const baseConnection = {
+  name: 'Test',
+  server: 'localhost',
+  port: 1433,
+  database: 'testdb',
+  username: 'sa',
+  password: 'pass',
+  useWindowsAuth: false,
+  dbType: 'sqlserver' as const,
+  isProduction: false,
+  isReadOnly: false,
+};
+
+describe('connectionStore profileId-based identification (#414)', () => {
+  beforeEach(() => {
+    useConnectionStore.setState({
+      connections: [],
+      activeConnectionId: null,
+      isConnecting: false,
+      connectRequestId: null,
+      connectCancelled: false,
+      error: null,
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    useConnectionStore.setState({
+      connections: [],
+      activeConnectionId: null,
+      isConnecting: false,
+      connectRequestId: null,
+      connectCancelled: false,
+      error: null,
+    });
+  });
+
+  it('別 profileId かつ同名なら共存する (Develop/Test と Staging/Test)', async () => {
+    mockConnectAsync.mockResolvedValue({ requestId: 'req_2' });
+    mockGetConnectResult.mockResolvedValue({ status: 'connected', connectionId: 'db_staging' });
+    mockDisconnect.mockResolvedValue(undefined);
+
+    useConnectionStore.setState({
+      connections: [
+        {
+          ...baseConnection,
+          id: 'db_dev',
+          isActive: true,
+          profileId: 'profile_develop_test',
+          server: 'docker-host',
+        },
+      ],
+    });
+
+    await useConnectionStore.getState().addConnection({
+      ...baseConnection,
+      profileId: 'profile_staging_test',
+      server: '123.231.222.1',
+    });
+
+    const state = useConnectionStore.getState();
+    expect(state.connections).toHaveLength(2);
+    expect(mockDisconnect).not.toHaveBeenCalled();
+
+    // #414 真の症状の契約化: 既存 profile 由来接続の DB 接続情報が改変されないこと。
+    // count・disconnect 呼び出し数だけだと「片方が他方の server を上書き」を検出できない。
+    const dev = state.connections.find((c) => c.profileId === 'profile_develop_test');
+    const stg = state.connections.find((c) => c.profileId === 'profile_staging_test');
+    expect(dev?.server).toBe('docker-host');
+    expect(stg?.server).toBe('123.231.222.1');
+    expect(dev?.id).toBe('db_dev');
+    expect(stg?.id).toBe('db_staging');
+  });
+
+  it('同じ profileId で再接続すると既存を置換する', async () => {
+    mockConnectAsync.mockResolvedValue({ requestId: 'req_3' });
+    mockGetConnectResult.mockResolvedValue({ status: 'connected', connectionId: 'db_new' });
+    mockDisconnect.mockResolvedValue(undefined);
+
+    useConnectionStore.setState({
+      connections: [
+        {
+          ...baseConnection,
+          id: 'db_old',
+          isActive: true,
+          profileId: 'profile_dev',
+        },
+      ],
+    });
+
+    const result = await useConnectionStore.getState().addConnection({
+      ...baseConnection,
+      profileId: 'profile_dev',
+    });
+
+    const state = useConnectionStore.getState();
+    expect(state.connections).toHaveLength(1);
+    expect(state.connections[0].id).toBe('db_new');
+    expect(mockDisconnect).toHaveBeenCalledWith('db_old');
+    expect(result.replaced).toEqual({ oldId: 'db_old', newId: 'db_new' });
+  });
+
+  it('profileId 無し (手動接続) は同名で従来どおり置換する (後方互換)', async () => {
+    mockConnectAsync.mockResolvedValue({ requestId: 'req_4' });
+    mockGetConnectResult.mockResolvedValue({ status: 'connected', connectionId: 'db_manual_2' });
+    mockDisconnect.mockResolvedValue(undefined);
+
+    useConnectionStore.setState({
+      connections: [{ ...baseConnection, id: 'db_manual_1', isActive: true }],
+    });
+
+    await useConnectionStore.getState().addConnection(baseConnection);
+
+    const state = useConnectionStore.getState();
+    expect(state.connections).toHaveLength(1);
+    expect(state.connections[0].id).toBe('db_manual_2');
+    expect(mockDisconnect).toHaveBeenCalledWith('db_manual_1');
+  });
+
+  it('profileId あり追加時に profileId 無し同名は影響を受けない', async () => {
+    mockConnectAsync.mockResolvedValue({ requestId: 'req_5' });
+    mockGetConnectResult.mockResolvedValue({
+      status: 'connected',
+      connectionId: 'db_from_profile',
+    });
+    mockDisconnect.mockResolvedValue(undefined);
+
+    useConnectionStore.setState({
+      connections: [{ ...baseConnection, id: 'db_manual', isActive: true }],
+    });
+
+    await useConnectionStore.getState().addConnection({
+      ...baseConnection,
+      profileId: 'profile_x',
+    });
+
+    const state = useConnectionStore.getState();
+    expect(state.connections).toHaveLength(2);
+    expect(mockDisconnect).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -78,6 +78,7 @@ export interface Connection {
   tableListLoadTimeMs?: number; // Time taken to load table list
   tableOpenTimeMs?: number; // Time taken to open a table (click to display)
   ssh?: SshConfig;
+  profileId?: string; // Set when connection originates from a saved profile; absent for ad-hoc connections.
 }
 
 // Query types

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(TEST_SOURCES
     database/test_thread_pool.cpp
     database/test_result_cache.cpp
     utils/test_version_config.cpp
+    utils/test_glaze_meta_roundtrip.cpp
 )
 
 add_executable(VelocityDBTests ${TEST_SOURCES})

--- a/tests/utils/test_glaze_meta_roundtrip.cpp
+++ b/tests/utils/test_glaze_meta_roundtrip.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include "utils/glaze_meta.h"
+#include "utils/settings_manager.h"
+
+#include <glaze/glaze.hpp>
+
+#include <string>
+
+namespace velocitydb {
+namespace {
+
+TEST(GlazeMetaConnectionProfile, PreservesFolderPathAcrossRoundTrip) {
+    ConnectionProfile original;
+    original.id = "id-1";
+    original.name = "Test";
+    original.server = "localhost";
+    original.database = "db";
+    original.folderPath = "Develop";
+
+    std::string json;
+    auto write_err = glz::write_json(original, json);
+    ASSERT_FALSE(static_cast<bool>(write_err)) << "serialize should succeed";
+
+    EXPECT_NE(json.find(R"("folderPath":"Develop")"), std::string::npos)
+        << "folderPath should be present in serialized JSON: " << json;
+
+    ConnectionProfile decoded;
+    auto read_err = glz::read_json(decoded, json);
+    ASSERT_FALSE(static_cast<bool>(read_err)) << "deserialize should succeed";
+
+    EXPECT_EQ(decoded.folderPath, "Develop");
+    EXPECT_EQ(decoded.name, original.name);
+    EXPECT_EQ(decoded.id, original.id);
+}
+
+TEST(GlazeMetaConnectionProfile, PreservesFolderPathThroughAppSettingsRoundTrip) {
+    // 本番フロー (SettingsManager::serializeSettings/deserializeSettings) と同じ
+    // AppSettings → connectionProfiles 経由で folderPath が保持されることを確認する。
+    AppSettings original;
+    ConnectionProfile a;
+    a.id = "id-a";
+    a.name = "Test";
+    a.folderPath = "Develop";
+    ConnectionProfile b;
+    b.id = "id-b";
+    b.name = "Test";
+    b.folderPath = "Staging";
+    original.connectionProfiles = {a, b};
+
+    std::string json;
+    auto write_err = glz::write_json(original, json);
+    ASSERT_FALSE(static_cast<bool>(write_err));
+
+    AppSettings decoded;
+    auto read_err = glz::read_json(decoded, json);
+    ASSERT_FALSE(static_cast<bool>(read_err));
+
+    ASSERT_EQ(decoded.connectionProfiles.size(), 2u);
+    EXPECT_EQ(decoded.connectionProfiles[0].folderPath, "Develop");
+    EXPECT_EQ(decoded.connectionProfiles[0].id, "id-a");
+    EXPECT_EQ(decoded.connectionProfiles[1].folderPath, "Staging");
+    EXPECT_EQ(decoded.connectionProfiles[1].id, "id-b");
+}
+
+TEST(GlazeMetaConnectionProfile, DefaultsFolderPathToEmptyWhenMissingInJson) {
+    // 既存ユーザーの settings.json には folderPath が無い。
+    // deserialize 時に欠落フィールドを空文字列にして落ちないこと (後方互換)。
+    constexpr auto json = R"({"id":"id-2","name":"Legacy","server":"s","port":1433,
+        "database":"d","username":"u","useWindowsAuth":true,"savePassword":false,
+        "encryptedPassword":"","isProduction":false,"isReadOnly":false,
+        "environment":"development","dbType":"sqlserver",
+        "ssh":{"enabled":false,"host":"","port":22,"username":"",
+            "authType":"password","encryptedPassword":"","privateKeyPath":"",
+            "encryptedKeyPassphrase":""}})";
+
+    ConnectionProfile decoded;
+    auto read_err = glz::read_json(decoded, json);
+    ASSERT_FALSE(static_cast<bool>(read_err)) << "deserialize should succeed without folderPath";
+
+    EXPECT_EQ(decoded.folderPath, "");
+    EXPECT_EQ(decoded.id, "id-2");
+}
+
+}  // namespace
+}  // namespace velocitydb


### PR DESCRIPTION
- **fix(backend): ConnectionProfile glz::meta に folderPath を追加 (#413)**
- **test(backend): ConnectionProfile/AppSettings JSON roundtrip テスト追加 (#413)**
- **fix(frontend): Connection に profileId を導入し profile 由来接続を識別 (#414)**
- **test(frontend): 同名異フォルダ profile 共存・接続先独立テスト追加 (#414)**

Closes #414 #413