### PR TITLE
fix(frontend): virtualizer broken-state フォールバックでグリッド空表示を解消 (#417)

### DIFF
--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -1,6 +1,6 @@
 import { flexRender, type Row, type Table } from '@tanstack/react-table';
 import type { VirtualItem } from '@tanstack/react-virtual';
-import { type MouseEvent, memo, type RefObject, type UIEvent, useCallback } from 'react';
+import { type MouseEvent, memo, type RefObject, type UIEvent, useCallback, useMemo } from 'react';
 import { type ColumnMeta, isSystemColumn, type RowData } from '../../types/grid';
 import type { ValidationError } from '../../utils/validation';
 import { ContextMenu } from '../common/ContextMenu';
@@ -71,6 +71,45 @@ interface GridTableProps {
   onAutoSizeColumns?: () => void;
 }
 
+// Issue #417: TanStack Virtual が `outerSize=0` (= 容器の offsetHeight=0) で
+// `virtualRows=[]` を返した状態 (= "broken state") から復旧不能になる事象への
+// フォールバック上限。WebView2 想定 (1080p / 行高 32px) で可視 ~33 行、
+// overscan 10 を含めた約 1.5 倍を確保し、初回描画コストとのバランスを取った値。
+// virtualizer が ResizeObserver 経由で復旧し次第、通常経路に戻る (本フォールバックは無効化)。
+const FALLBACK_RENDER_LIMIT = 50;
+// 仮想行 fallback で使う既定行高 (= ResultGrid の estimateSize と一致させる)。
+const FALLBACK_ROW_HEIGHT = 32;
+
+/** broken-state 用に合成 VirtualItem 配列を生成する (純粋関数) */
+function createFallbackVirtualItems(rowCount: number): VirtualItem[] {
+  const limit = Math.min(rowCount, FALLBACK_RENDER_LIMIT);
+  const items: VirtualItem[] = new Array(limit);
+  for (let i = 0; i < limit; i++) {
+    items[i] = {
+      key: i,
+      index: i,
+      start: i * FALLBACK_ROW_HEIGHT,
+      end: (i + 1) * FALLBACK_ROW_HEIGHT,
+      size: FALLBACK_ROW_HEIGHT,
+      lane: 0,
+    };
+  }
+  return items;
+}
+
+/** virtualRows 配列から paddingTop / paddingBottom を計算する (純粋関数) */
+function computeRowPaddings(
+  items: VirtualItem[],
+  totalSize: number
+): { paddingTop: number; paddingBottom: number } {
+  if (items.length === 0) return { paddingTop: 0, paddingBottom: 0 };
+  const paddingTop = items[0]?.start ?? 0;
+  const lastEnd = items[items.length - 1]?.end ?? 0;
+  // broken-state では totalSize も 0 になり得るため (totalSize - lastEnd) が負にならないようガード。
+  const paddingBottom = Math.max(0, totalSize - lastEnd);
+  return { paddingTop, paddingBottom };
+}
+
 /** Extract row/cell info from a bubbled event via data attributes */
 function findCellFromEvent(e: MouseEvent) {
   const td = (e.target as HTMLElement).closest('td[data-field]') as HTMLElement | null;
@@ -103,9 +142,17 @@ function GridTableInner({
   // memo の浅い比較で列幅変化を検出するために受け取るだけ。値自体は table.getState() 経由で参照される。
   columnSizing: _columnSizing,
 }: GridTableProps) {
-  const paddingTop = virtualRows.length > 0 ? (virtualRows[0]?.start ?? 0) : 0;
-  const paddingBottom =
-    virtualRows.length > 0 ? totalSize - (virtualRows[virtualRows.length - 1]?.end ?? 0) : 0;
+  // Issue #417: virtualizer broken-state (rows>0 だが virtualRows=[]) を検出して
+  // 先頭 N 行を非仮想で描画する。これにより WebView2 layout race で空表示になる
+  // 事象を回避する。virtualizer が復旧した瞬間 (virtualRows が満たされた瞬間)
+  // 通常経路に切り替わるため、復旧後の二重描画は起こらない。
+  const isVirtualizerBroken = virtualRows.length === 0 && rows.length > 0;
+  const renderItems = useMemo<VirtualItem[]>(
+    () => (isVirtualizerBroken ? createFallbackVirtualItems(rows.length) : virtualRows),
+    [isVirtualizerBroken, virtualRows, rows.length]
+  );
+
+  const { paddingTop, paddingBottom } = computeRowPaddings(renderItems, totalSize);
 
   const { contextMenu, openHeaderMenu, openCellMenu, closeMenu, getMenuItems } = useGridContextMenu(
     columnsMeta,
@@ -264,8 +311,9 @@ function GridTableInner({
               <td style={{ height: `${paddingTop}px` }} />
             </tr>
           )}
-          {virtualRows.map((virtualRow) => {
+          {renderItems.map((virtualRow) => {
             const row = rows[virtualRow.index];
+            if (!row) return null;
             const rowIndex = virtualRow.index;
             const originalIndex = Number(row.original.__originalIndex);
             const isSelected = selection.selectedRows.has(rowIndex);

--- a/frontend/src/tests/grid/GridTable.virtualizerFallback.test.tsx
+++ b/frontend/src/tests/grid/GridTable.virtualizerFallback.test.tsx
@@ -1,0 +1,217 @@
+// Issue #417 回帰防止: TanStack Virtual が outerSize=0 で virtualRows=[] を返す
+// "broken state" でも、行が **必ず描画される** ことを検証する。
+//
+// 既存の単体テスト (sqlIdentifier / GridStatusBar / ResultGrid integration) では
+// GridTable 本体は () => null で mock されており、本番の virtualization 経路は
+// jsdom + offsetHeight=0 + ResizeObserver no-op で **常に空表示** になっていた。
+// このテストは GridTable 本体を実 mount し、virtualRows=[] を強制した時に
+// 行が空にならない (フォールバック描画) ことで Issue #417 の再発を捕まえる。
+//
+// 一次ソース根拠:
+//   - @tanstack/virtual-core/dist/esm/index.js:497-516 (calculateRange)
+//     measurements.length > 0 && outerSize > 0 ? calculateRange(...) : null
+//   - 同 file:341-348 (getSize)  scrollRect.height を返す
+//   - 同 file:1-5 (getRect)      element.offsetWidth / offsetHeight を読む
+//   - 同 file:802-806 (measure)  itemSizeCache のみクリア (scrollRect は更新しない)
+// → WebView2 の flex layout race で offsetHeight=0 の瞬間に観測されると
+//   scrollRect={0,0} に固定、rowVirtualizer.measure() でも復旧不能になる。
+
+import {
+  type ColumnDef,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  type Row,
+  useReactTable,
+} from '@tanstack/react-table';
+import type { VirtualItem } from '@tanstack/react-virtual';
+import { cleanup, render, within } from '@testing-library/react';
+import { useRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type GridEditContext,
+  type GridSelectionState,
+  GridTable,
+} from '../../components/grid/GridTable';
+import type { RowData } from '../../types/grid';
+
+afterEach(cleanup);
+
+const ROW_HEIGHT = 32;
+
+function makeRowData(count: number): RowData[] {
+  return Array.from({ length: count }, (_, i) => ({
+    __rowIndex: String(i + 1),
+    __originalIndex: String(i),
+    name: `name-${i}`,
+    age: String(20 + i),
+  }));
+}
+
+const COLUMNS: ColumnDef<RowData>[] = [
+  { id: '__rowIndex', header: '#', accessorKey: '__rowIndex', size: 40 },
+  { id: 'name', header: 'name', accessorKey: 'name', size: 120 },
+  { id: 'age', header: 'age', accessorKey: 'age', size: 60 },
+];
+
+const NOOP_EDIT: GridEditContext = {
+  isEditMode: false,
+  editingCell: null,
+  editValue: '',
+  isRowDeleted: () => false,
+  isRowInserted: () => false,
+  getCellChange: () => null,
+  getValidationError: () => null,
+  isForeignKeyColumn: () => false,
+};
+
+const NOOP_SELECTION: GridSelectionState = {
+  selectedRows: new Set<number>(),
+  selectedColumns: new Set<string>(),
+};
+
+const NOOP_CALLBACKS = {
+  onSetEditValue: vi.fn(),
+  onStartEdit: vi.fn(),
+  onCommitEdit: vi.fn(),
+  onRowToggle: vi.fn(),
+  onRowRangeSelect: vi.fn(),
+  onCellClick: vi.fn(),
+  onCellRangeSelect: vi.fn(),
+  onColumnSelect: vi.fn(),
+  onColumnRangeSelect: vi.fn(),
+  onUpdateCell: vi.fn(),
+};
+
+interface HarnessProps {
+  data: RowData[];
+  /** virtualRows を強制する。空配列なら "broken state" を再現 */
+  virtualRows: VirtualItem[];
+  totalSize: number;
+}
+
+/** 実 useReactTable で table を構築し、virtualRows / totalSize は外部制御する */
+function Harness({ data, virtualRows, totalSize }: HarnessProps) {
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const table = useReactTable<RowData>({
+    data,
+    columns: COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+  const rows: Row<RowData>[] = table.getRowModel().rows;
+  return (
+    <GridTable
+      table={table}
+      tableContainerRef={tableContainerRef}
+      rows={rows}
+      virtualRows={virtualRows}
+      totalSize={totalSize}
+      showColumnFilters={false}
+      showLogicalNamesInGrid={false}
+      columnsMeta={[]}
+      edit={NOOP_EDIT}
+      selection={NOOP_SELECTION}
+      callbacks={NOOP_CALLBACKS}
+      columnSizing={{}}
+    />
+  );
+}
+
+function dataRows(container: HTMLElement): HTMLTableRowElement[] {
+  // tbody 配下の行のみ拾う (thead は除外)。padding 用 spacer 行は data-row-index を持たないため除外。
+  return Array.from(
+    container.querySelectorAll('tbody tr[data-row-index]')
+  ) as HTMLTableRowElement[];
+}
+
+describe('GridTable virtualizer broken-state フォールバック (Issue #417)', () => {
+  it('virtualRows=[] / rows が存在する時、行が空にならない (フォールバック描画)', () => {
+    // Bug 再現条件: outerSize=0 で TanStack Virtual が空配列を返した状態。
+    // 修正前: tbody が空、ユーザーは何も見えない (Issue #417 主因)。
+    // 修正後: フォールバック経路で先頭 N 行が描画される。
+    const data = makeRowData(10);
+    const { container } = render(
+      <Harness data={data} virtualRows={[]} totalSize={data.length * ROW_HEIGHT} />
+    );
+
+    const rows = dataRows(container);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('virtualRows=[] / rows=10 件: 全 10 行がフォールバックで描画される', () => {
+    const data = makeRowData(10);
+    const { container } = render(
+      <Harness data={data} virtualRows={[]} totalSize={data.length * ROW_HEIGHT} />
+    );
+
+    const rows = dataRows(container);
+    expect(rows).toHaveLength(10);
+    // 描画行のセル内容が data と一致する (順序不変)
+    rows.forEach((tr, i) => {
+      expect(within(tr).getByText(`name-${i}`)).toBeInTheDocument();
+      expect(within(tr).getByText(String(20 + i))).toBeInTheDocument();
+    });
+  });
+
+  it('virtualRows=[] / rows=1000 件: フォールバックは上限 (50 行) で打ち切る', () => {
+    // 大規模データで全行を非仮想描画するとメモリ・初期描画コストが膨らむ。
+    // フォールバックは "見える分" を超える固定上限 (= viewport を埋める最低限) で打ち切る。
+    const data = makeRowData(1000);
+    const { container } = render(
+      <Harness data={data} virtualRows={[]} totalSize={data.length * ROW_HEIGHT} />
+    );
+
+    const rows = dataRows(container);
+    // FALLBACK_RENDER_LIMIT (= 50) を超えない。下限は実装定数に依存しすぎないため緩く検査:
+    //   - 上限 50 を超えない
+    //   - 1 行は確実に出ている (空表示でない)
+    expect(rows.length).toBeLessThanOrEqual(50);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('virtualRows が提供される通常ケースでは virtualRows.index の行のみ描画される (フォールバックは発動しない)', () => {
+    // 通常経路の回帰検知: virtualRows が空でなければフォールバックは絶対に作動してはならない。
+    // (フォールバックが優先されると スクロール位置 ≠ 描画位置 になり、padding 計算が破綻する)
+    const data = makeRowData(100);
+    const virtualRows: VirtualItem[] = [
+      { key: 5, index: 5, start: 5 * ROW_HEIGHT, end: 6 * ROW_HEIGHT, size: ROW_HEIGHT, lane: 0 },
+      { key: 6, index: 6, start: 6 * ROW_HEIGHT, end: 7 * ROW_HEIGHT, size: ROW_HEIGHT, lane: 0 },
+      { key: 7, index: 7, start: 7 * ROW_HEIGHT, end: 8 * ROW_HEIGHT, size: ROW_HEIGHT, lane: 0 },
+    ];
+    const { container } = render(
+      <Harness data={data} virtualRows={virtualRows} totalSize={data.length * ROW_HEIGHT} />
+    );
+
+    const rows = dataRows(container);
+    expect(rows).toHaveLength(3);
+    // 描画されたのは index 5, 6, 7 の行のみ
+    expect(within(rows[0]).getByText('name-5')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('name-6')).toBeInTheDocument();
+    expect(within(rows[2]).getByText('name-7')).toBeInTheDocument();
+  });
+
+  it('rows=[] / virtualRows=[] では行を描画しない (空状態でフォールバックを誤発動しない)', () => {
+    // 空 ResultSet で行 0 件は正当な状態。フォールバックで偽の行を出してはならない。
+    const { container } = render(<Harness data={[]} virtualRows={[]} totalSize={0} />);
+
+    const rows = dataRows(container);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('virtualRows={index:0,...} 1 件提供時はその 1 行のみ描画 (フォールバックで上書きしない)', () => {
+    // virtualRows.length === 1 でもフォールバック経路に流れない (`length === 0` のみが broken state)
+    const data = makeRowData(100);
+    const virtualRows: VirtualItem[] = [
+      { key: 0, index: 0, start: 0, end: ROW_HEIGHT, size: ROW_HEIGHT, lane: 0 },
+    ];
+    const { container } = render(
+      <Harness data={data} virtualRows={virtualRows} totalSize={data.length * ROW_HEIGHT} />
+    );
+
+    const rows = dataRows(container);
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getByText('name-0')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
WebView2 software compositing の flex layout race で TanStack Virtual の `observeElementRect` が `offsetHeight=0` を観測した瞬間、
`scrollRect={0,0}` に固定され `ResizeObserver` も `0→0` では発火しないため virtualRows=[] のまま復旧不能になり、一部 (= 全) 行が描画されない事象が発生する。

GridTable に broken-state (virtualRows=[] && rows>0) 検出 + 先頭 N 行(FALLBACK_RENDER_LIMIT=50) を合成 VirtualItem で非仮想描画する経路を追加。
virtualizer が ResizeObserver 経由で復旧した瞬間 (virtualRows.length>0)通常経路へ自動切替するため、復旧後の二重描画は起こらない。
パフォーマンス影響を避けるため createFallbackVirtualItems / computeRowPaddingsは純粋関数として module-level に抽出。

回帰防止: 既存統合テストでは GridTable を `() => null` で mock していたため本番の virtualization 経路の壊れに気付けなかった。本テストは実 GridTable を mount し broken state 入力で空表示を検出する 6 ケースを追加。

Closes #417