### PR TITLE
perf(backend): QueryHistory を list+hashmap で O(1) 化

### DIFF
--- a/backend/database/query_history.cpp
+++ b/backend/database/query_history.cpp
@@ -3,6 +3,7 @@
 #include "simdjson.h"
 
 #include <algorithm>
+#include <cassert>
 #include <format>
 #include <fstream>
 #include <ranges>
@@ -11,34 +12,60 @@
 namespace velocitydb {
 
 void QueryHistory::add(const HistoryItem& item) {
+    // 事前条件: 呼び出し側 (provider 等) が generateHistoryId() で id を埋める。
+    // 空 id を許すと map キーが衝突して履歴が破損するため、契約として弾く。
+    assert(!item.id.empty() && "QueryHistory::add requires non-empty id; caller must use generateHistoryId()");
+
     std::lock_guard lock(m_mutex);
 
-    m_history.insert(m_history.begin(), item);
+    if (auto existing = m_indexById.find(item.id); existing != m_indexById.end()) {
+        if (!existing->second->isFavorite) {
+            --m_nonFavoriteCount;
+        }
+        m_history.erase(existing->second);
+        m_indexById.erase(existing);
+    }
 
+    m_history.push_front(item);
+    auto inserted = m_history.begin();
+    m_indexById.emplace(inserted->id, inserted);
+    if (!inserted->isFavorite) {
+        ++m_nonFavoriteCount;
+    }
+
+    // eviction: 平均 O(1) (通常は末尾が非 favorite)。
+    // 全 favorite 状態は m_nonFavoriteCount で先に判定して O(1) で skip する。
     while (m_history.size() > m_maxItems) {
-        auto it = std::ranges::find_if(m_history | std::views::reverse, [](const HistoryItem& h) { return !h.isFavorite; });
+        if (m_nonFavoriteCount == 0) {
+            break;  // 全要素 favorite — eviction 対象なし
+        }
 
-        if (it != (m_history | std::views::reverse).end()) {
-            m_history.erase(std::next(it).base());
-        } else {
+        auto rit = std::ranges::find_if(m_history | std::views::reverse, [](const HistoryItem& h) { return !h.isFavorite; });
+        if (rit == (m_history | std::views::reverse).end()) {
+            // counter と list が一致していれば到達不能。防御的 break。
+            assert(false && "m_nonFavoriteCount out of sync with m_history");
             break;
         }
+
+        auto victim = std::next(rit).base();
+        m_indexById.erase(victim->id);
+        m_history.erase(victim);
+        --m_nonFavoriteCount;
     }
 }
 
 std::vector<HistoryItem> QueryHistory::getAll() const {
     std::lock_guard lock(m_mutex);
-    return m_history;
+    return {m_history.begin(), m_history.end()};
 }
 
 std::vector<HistoryItem> QueryHistory::search(std::string_view keyword) const {
     std::lock_guard lock(m_mutex);
 
     if (keyword.empty()) {
-        return m_history;
+        return {m_history.begin(), m_history.end()};
     }
 
-    // Case-insensitive search without creating lowercase copies of entire strings
     auto caseInsensitiveFind = [](std::string_view haystack, std::string_view needle) -> bool {
         if (needle.size() > haystack.size()) {
             return false;
@@ -48,7 +75,7 @@ std::vector<HistoryItem> QueryHistory::search(std::string_view keyword) const {
     };
 
     std::vector<HistoryItem> results;
-    results.reserve(m_history.size() / 4);  // Estimate ~25% match rate
+    results.reserve(m_history.size() / 4);
 
     for (const auto& item : m_history) {
         if (caseInsensitiveFind(item.sql, keyword)) {
@@ -71,8 +98,13 @@ std::vector<HistoryItem> QueryHistory::getByDate(std::chrono::system_clock::time
 void QueryHistory::setFavorite(std::string_view id, bool favorite) {
     std::lock_guard lock(m_mutex);
 
-    if (auto it = std::ranges::find_if(m_history, [id](const HistoryItem& h) { return h.id == id; }); it != m_history.end()) {
-        it->isFavorite = favorite;
+    if (auto it = m_indexById.find(id); it != m_indexById.end()) {
+        if (it->second->isFavorite && !favorite) {
+            ++m_nonFavoriteCount;
+        } else if (!it->second->isFavorite && favorite) {
+            --m_nonFavoriteCount;
+        }
+        it->second->isFavorite = favorite;
     }
 }
 
@@ -88,13 +120,29 @@ std::vector<HistoryItem> QueryHistory::getFavorites() const {
 void QueryHistory::remove(std::string_view id) {
     std::lock_guard lock(m_mutex);
 
-    std::erase_if(m_history, [id](const HistoryItem& h) { return h.id == id; });
+    auto it = m_indexById.find(id);
+    if (it == m_indexById.end()) {
+        return;
+    }
+    if (!it->second->isFavorite) {
+        --m_nonFavoriteCount;
+    }
+    m_history.erase(it->second);
+    m_indexById.erase(it);
 }
 
 void QueryHistory::clear() {
     std::lock_guard lock(m_mutex);
 
-    std::erase_if(m_history, [](const HistoryItem& h) { return !h.isFavorite; });
+    for (auto it = m_history.begin(); it != m_history.end();) {
+        if (it->isFavorite) {
+            ++it;
+        } else {
+            m_indexById.erase(it->id);
+            it = m_history.erase(it);
+        }
+    }
+    m_nonFavoriteCount = 0;
 }
 
 std::expected<void, std::string> QueryHistory::save(std::string_view filepath) const {
@@ -107,9 +155,15 @@ std::expected<void, std::string> QueryHistory::save(std::string_view filepath) c
         return std::unexpected(std::format("Failed to open history file for writing: {}", filepath));
     }
 
-    outFile << "[\n";
-    for (size_t i = 0; i < m_history.size(); ++i) {
-        const auto& item = m_history[i];
+    outFile << "[";
+    bool first = true;
+    for (const auto& item : m_history) {
+        if (!first) {
+            outFile << ",";
+        }
+        outFile << "\n";
+        first = false;
+
         auto time = std::chrono::system_clock::to_time_t(item.timestamp);
 
         auto jsonEntry =
@@ -126,10 +180,8 @@ std::expected<void, std::string> QueryHistory::save(std::string_view filepath) c
   }})",
                         item.id, item.sql, item.connectionId, time, item.executionTimeMs, item.success ? "true" : "false", item.errorMessage, item.affectedRows, item.isFavorite ? "true" : "false");
         outFile << jsonEntry;
-
-        if (i < m_history.size() - 1) {
-            outFile << ",";
-        }
+    }
+    if (!m_history.empty()) {
         outFile << "\n";
     }
     outFile << "]\n";
@@ -154,7 +206,7 @@ std::expected<void, std::string> QueryHistory::load(std::string_view filepath) {
     std::string jsonContent = buffer.str();
 
     if (jsonContent.empty()) {
-        return {};  // Empty file is valid
+        return {};
     }
 
     try {
@@ -166,6 +218,8 @@ std::expected<void, std::string> QueryHistory::load(std::string_view filepath) {
         }
 
         m_history.clear();
+        m_indexById.clear();
+        m_nonFavoriteCount = 0;
 
         for (auto item : doc.get_array()) {
             HistoryItem historyItem;
@@ -198,7 +252,19 @@ std::expected<void, std::string> QueryHistory::load(std::string_view filepath) {
                 historyItem.isFavorite = favorite.value();
             }
 
+            if (historyItem.id.empty()) {
+                // 不正な入力 (id 欠落) はスキップ。読み込み全体を中断する代わりに防御的に無視する。
+                continue;
+            }
+
             m_history.push_back(std::move(historyItem));
+            auto last = std::prev(m_history.end());
+            if (auto [_, inserted] = m_indexById.emplace(last->id, last); !inserted) {
+                // 重複 id を検出。新エントリを破棄して map との整合を維持する。
+                m_history.pop_back();
+            } else if (!last->isFavorite) {
+                ++m_nonFavoriteCount;
+            }
         }
 
         return {};

--- a/backend/database/query_history.h
+++ b/backend/database/query_history.h
@@ -1,13 +1,17 @@
 #pragma once
 
+#include "../utils/transparent_hash.h"
+
 #include <atomic>
 #include <chrono>
 #include <expected>
 #include <format>
+#include <list>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 namespace velocitydb {
@@ -68,7 +72,12 @@ public:
 private:
     size_t m_maxItems;
     mutable std::mutex m_mutex;
-    std::vector<HistoryItem> m_history;
+    // list を選定: erase 以外で iterator が無効化されないため、unordered_map に iterator を保持して
+    // add/remove/setFavorite を平均 O(1) 化できる。vector では中央 erase で iterator が全無効化される。
+    std::list<HistoryItem> m_history;  // Front = newest.
+    std::unordered_map<std::string, std::list<HistoryItem>::iterator, TransparentStringHash, TransparentStringEqual> m_indexById;
+    // 非 favorite の件数。eviction loop が「全 favorite 状態」を O(1) で skip するためのキャッシュ。
+    size_t m_nonFavoriteCount = 0;
 };
 
 }  // namespace velocitydb

--- a/tests/database/test_query_history.cpp
+++ b/tests/database/test_query_history.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include "database/query_history.h"
 
+#include <chrono>
+
 namespace velocitydb {
 namespace test {
 
@@ -15,6 +17,7 @@ TEST_F(QueryHistoryTest, InitiallyEmpty) {
 
 TEST_F(QueryHistoryTest, AddsItems) {
     HistoryItem item;
+    item.id = generateHistoryId();
     item.sql = "SELECT * FROM Users";
     item.connectionId = "conn-1";
     item.timestamp = std::chrono::system_clock::now();
@@ -32,11 +35,13 @@ TEST_F(QueryHistoryTest, AddsItems) {
 
 TEST_F(QueryHistoryTest, SearchesItems) {
     HistoryItem item1;
+    item1.id = generateHistoryId();
     item1.sql = "SELECT * FROM Users";
     item1.timestamp = std::chrono::system_clock::now();
     item1.success = true;
 
     HistoryItem item2;
+    item2.id = generateHistoryId();
     item2.sql = "SELECT * FROM Orders";
     item2.timestamp = std::chrono::system_clock::now();
     item2.success = true;
@@ -51,6 +56,7 @@ TEST_F(QueryHistoryTest, SearchesItems) {
 
 TEST_F(QueryHistoryTest, SearchIsCaseInsensitive) {
     HistoryItem item;
+    item.id = generateHistoryId();
     item.sql = "SELECT * FROM Users";
     item.timestamp = std::chrono::system_clock::now();
     item.success = true;
@@ -63,6 +69,7 @@ TEST_F(QueryHistoryTest, SearchIsCaseInsensitive) {
 
 TEST_F(QueryHistoryTest, SetsFavorite) {
     HistoryItem item;
+    item.id = generateHistoryId();
     item.sql = "SELECT 1";
     item.timestamp = std::chrono::system_clock::now();
     item.success = true;
@@ -81,12 +88,14 @@ TEST_F(QueryHistoryTest, SetsFavorite) {
 
 TEST_F(QueryHistoryTest, ClearKeepsFavorites) {
     HistoryItem item1;
+    item1.id = generateHistoryId();
     item1.sql = "SELECT 1";
     item1.timestamp = std::chrono::system_clock::now();
     item1.success = true;
     item1.isFavorite = true;
 
     HistoryItem item2;
+    item2.id = generateHistoryId();
     item2.sql = "SELECT 2";
     item2.timestamp = std::chrono::system_clock::now();
     item2.success = true;
@@ -109,6 +118,7 @@ TEST_F(QueryHistoryTest, RespectsMaxItems) {
 
     for (int i = 0; i < 10; ++i) {
         HistoryItem item;
+        item.id = generateHistoryId();
         item.sql = "SELECT " + std::to_string(i);
         item.timestamp = std::chrono::system_clock::now();
         item.success = true;
@@ -118,6 +128,116 @@ TEST_F(QueryHistoryTest, RespectsMaxItems) {
 
     auto all = smallHistory.getAll();
     EXPECT_LE(all.size(), 5);
+}
+
+TEST_F(QueryHistoryTest, RemoveByIdRemovesItem) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    item.sql = "SELECT 1";
+    item.timestamp = std::chrono::system_clock::now();
+    item.success = true;
+
+    history.add(item);
+    auto id = history.getAll()[0].id;
+
+    history.remove(id);
+
+    EXPECT_TRUE(history.getAll().empty());
+}
+
+TEST_F(QueryHistoryTest, RemoveNonExistentIdIsNoop) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    item.sql = "SELECT 1";
+    item.timestamp = std::chrono::system_clock::now();
+    item.success = true;
+
+    history.add(item);
+
+    history.remove("nonexistent-id-xxx");
+
+    EXPECT_EQ(history.getAll().size(), 1);
+}
+
+TEST_F(QueryHistoryTest, AddSameIdReplacesEntry) {
+    HistoryItem item;
+    item.id = "fixed-id";
+    item.sql = "SELECT 1";
+    item.timestamp = std::chrono::system_clock::now();
+    item.success = true;
+
+    history.add(item);
+
+    item.sql = "SELECT 2";
+    history.add(item);
+
+    auto all = history.getAll();
+    EXPECT_EQ(all.size(), 1);
+    EXPECT_EQ(all[0].sql, "SELECT 2");
+    EXPECT_EQ(all[0].id, "fixed-id");
+}
+
+TEST_F(QueryHistoryTest, EvictionSkipsFastWhenAllFavorite) {
+    // 全 favorite 状態で maxItems を大幅超過する add が、
+    // eviction の find_if(reverse) で O(n) 走査せず O(1) で skip されることを検証する。
+    QueryHistory smallHistory{5};
+    constexpr int kCount = 50000;  // maxItems の 10000 倍
+
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kCount; ++i) {
+        HistoryItem item;
+        item.id = generateHistoryId();
+        item.sql = "SELECT " + std::to_string(i);
+        item.timestamp = std::chrono::system_clock::now();
+        item.success = true;
+        item.isFavorite = true;
+        smallHistory.add(item);
+    }
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t0).count();
+
+    // favorite は eviction されないので全件残る。
+    EXPECT_EQ(smallHistory.getAll().size(), static_cast<size_t>(kCount));
+
+    // O(n) per eviction だと 50000 件 × O(n) = O(n²) で数秒〜数十秒かかる。
+    // O(1) skip なら 50000 件 add 全体で << 2 秒。
+    EXPECT_LT(elapsed, 2000) << "all-favorite add of " << kCount << " items took " << elapsed << "ms (expected O(1) eviction skip)";
+}
+
+TEST_F(QueryHistoryTest, AddRemoveScalesLinearly) {
+    // O(1) per op を検証: 件数を 10x にしても合計時間は概ね 10x で収まることを確認する。
+    // 絶対閾値は CI runner の負荷で flaky になるため、スケーリング比で判定する。
+    auto measureAddRemove = [](int count) {
+        QueryHistory h{static_cast<size_t>(count) * 2};
+        std::vector<std::string> ids;
+        ids.reserve(count);
+
+        auto t0 = std::chrono::steady_clock::now();
+        for (int i = 0; i < count; ++i) {
+            HistoryItem item;
+            item.id = generateHistoryId();
+            item.sql = "SELECT " + std::to_string(i) + " FROM tbl_" + std::to_string(i);
+            item.timestamp = std::chrono::system_clock::now();
+            item.success = true;
+            h.add(item);
+        }
+        for (const auto& it : h.getAll()) {
+            ids.push_back(it.id);
+        }
+        for (const auto& id : ids) {
+            h.remove(id);
+        }
+        return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
+    };
+
+    constexpr int kSmall = 1000;
+    constexpr int kLarge = 10000;
+    auto tSmall = measureAddRemove(kSmall);
+    auto tLarge = measureAddRemove(kLarge);
+
+    // O(n) per op なら ratio ≒ 100 (10x データに対し 100x 時間)。O(1) per op なら ≒ 10。
+    // 余裕を見て 30 を上限に設定。これを超えたら superlinear scaling を疑う。
+    auto ratio = static_cast<double>(tLarge) / std::max<int64_t>(tSmall, 1);
+    EXPECT_LT(ratio, 30.0) << "scaling ratio=" << ratio << " (tSmall=" << tSmall << "us, tLarge=" << tLarge << "us) — superlinear scaling detected";
 }
 
 }  // namespace test


### PR DESCRIPTION
fix #418