### PR TITLE
fix(backend): general.maxQueryHistory と QueryHistory の整合性確保 (#426)

### DIFF
--- a/backend/contexts/system_context.cpp
+++ b/backend/contexts/system_context.cpp
@@ -13,11 +13,16 @@
 #include "../providers/transaction_provider.h"
 #include "../providers/utility_provider.h"
 
+#include <algorithm>
+
 namespace velocitydb {
 
 SystemContext::SystemContext()
     : m_connections(std::make_unique<ConnectionProvider>())
-    , m_queryHistory(std::make_unique<QueryHistory>())
+    , m_settings(std::make_unique<SettingsProvider>(m_connections.get()))
+    // 設定ファイル破損時の防御: maxQueryHistory が 0 や負値だった場合は最低 1 件にクランプして
+    // QueryHistory が常に有効状態で動作するようにする。
+    , m_queryHistory(std::make_unique<QueryHistory>(static_cast<size_t>(std::max(1, m_settings->settingsManager().getSettings().general.maxQueryHistory))))
     , m_queries(std::make_unique<QueryProvider>(*m_connections, *m_queryHistory))
     , m_asyncQueries(std::make_unique<AsyncQueryProvider>(*m_connections, *m_queryHistory))
     , m_schema(std::make_unique<SchemaProvider>(*m_connections))
@@ -25,9 +30,11 @@ SystemContext::SystemContext()
     , m_exports(std::make_unique<ExportProvider>(*m_connections))
     , m_search(std::make_unique<SearchProvider>(*m_connections))
     , m_utility(std::make_unique<UtilityProvider>())
-    , m_settings(std::make_unique<SettingsProvider>(m_connections.get()))
     , m_io(std::make_unique<IOProvider>())
-    , m_lint(std::make_unique<LintProvider>()) {}
+    , m_lint(std::make_unique<LintProvider>()) {
+    // settings 経由の maxQueryHistory 変更をランタイムで反映できるよう wiring。
+    m_settings->setQueryHistory(m_queryHistory.get());
+}
 
 SystemContext::~SystemContext() = default;
 

--- a/backend/contexts/system_context.h
+++ b/backend/contexts/system_context.h
@@ -7,6 +7,7 @@
 namespace velocitydb {
 
 class QueryHistory;
+class SettingsProvider;
 
 /// Concrete implementation of ISystemContext, owning all provider instances.
 class SystemContext : public ISystemContext {
@@ -32,7 +33,10 @@ public:
     [[nodiscard]] ILintProvider& lint() noexcept override;
 
 private:
+    // 宣言順 = 初期化順。m_settings は m_queryHistory の構築値を提供するため先に置く。
+    // m_settings は具象型: setQueryHistory() を SystemContext から呼ぶため (interface には公開しない)。
     std::unique_ptr<IConnectionProvider> m_connections;
+    std::unique_ptr<SettingsProvider> m_settings;
     std::unique_ptr<QueryHistory> m_queryHistory;
     std::unique_ptr<IQueryProvider> m_queries;
     std::unique_ptr<IAsyncQueryProvider> m_asyncQueries;
@@ -41,7 +45,6 @@ private:
     std::unique_ptr<IExportProvider> m_exports;
     std::unique_ptr<ISearchProvider> m_search;
     std::unique_ptr<IUtilityProvider> m_utility;
-    std::unique_ptr<ISettingsProvider> m_settings;
     std::unique_ptr<IIOProvider> m_io;
     std::unique_ptr<ILintProvider> m_lint;
 };

--- a/backend/database/query_history.cpp
+++ b/backend/database/query_history.cpp
@@ -33,6 +33,10 @@ void QueryHistory::add(const HistoryItem& item) {
         ++m_nonFavoriteCount;
     }
 
+    evictOverLimitLocked();
+}
+
+void QueryHistory::evictOverLimitLocked() {
     // eviction: 平均 O(1) (通常は末尾が非 favorite)。
     // 全 favorite 状態は m_nonFavoriteCount で先に判定して O(1) で skip する。
     while (m_history.size() > m_maxItems) {
@@ -52,6 +56,12 @@ void QueryHistory::add(const HistoryItem& item) {
         m_history.erase(victim);
         --m_nonFavoriteCount;
     }
+}
+
+void QueryHistory::setMaxItems(size_t maxItems) {
+    std::lock_guard lock(m_mutex);
+    m_maxItems = maxItems;
+    evictOverLimitLocked();
 }
 
 std::vector<HistoryItem> QueryHistory::getAll() const {

--- a/backend/database/query_history.h
+++ b/backend/database/query_history.h
@@ -49,7 +49,9 @@ struct HistoryItem {
 
 class QueryHistory {
 public:
-    explicit QueryHistory(size_t maxItems = 10000) : m_maxItems(maxItems) {}
+    /// デフォルト値は GeneralSettings::maxQueryHistory (settings_manager.h) と一致させる。
+    /// 不一致は Issue #426 を参照。
+    explicit QueryHistory(size_t maxItems = 1000) : m_maxItems(maxItems) {}
     ~QueryHistory() = default;
 
     QueryHistory(const QueryHistory&) = delete;
@@ -66,10 +68,17 @@ public:
     void remove(std::string_view id);
     void clear();
 
+    /// 上限件数を変更し、超過分の非 favorite を即時 eviction する。
+    /// settings.general.maxQueryHistory のランタイム反映に使う (Issue #426)。
+    void setMaxItems(size_t maxItems);
+
     [[nodiscard]] std::expected<void, std::string> save(std::string_view filepath) const;
     [[nodiscard]] std::expected<void, std::string> load(std::string_view filepath);
 
 private:
+    /// 呼び出し側で m_mutex を取得済みであることを前提とした eviction 共通ロジック。
+    void evictOverLimitLocked();
+
     size_t m_maxItems;
     mutable std::mutex m_mutex;
     // list を選定: erase 以外で iterator が無効化されないため、unordered_map に iterator を保持して

--- a/backend/providers/settings_provider.cpp
+++ b/backend/providers/settings_provider.cpp
@@ -1,5 +1,6 @@
 #include "settings_provider.h"
 
+#include "../database/query_history.h"
 #include "../interfaces/providers/connection_provider.h"
 #include "../utils/glaze_meta.h"
 #include "../utils/json_utils.h"
@@ -170,6 +171,20 @@ void SettingsProvider::applyQueryTimeoutToConnections(int seconds) {
     }
 }
 
+void SettingsProvider::applyMaxQueryHistoryToInstance(int maxItems) {
+    if (m_queryHistory && maxItems > 0) {
+        m_queryHistory->setMaxItems(static_cast<size_t>(maxItems));
+    }
+}
+
+void SettingsProvider::setQueryHistory(QueryHistory* queryHistory) {
+    m_queryHistory = queryHistory;
+    // 初回 wiring 時に load 済み settings を即時反映する。
+    if (m_queryHistory) {
+        applyMaxQueryHistoryToInstance(m_settingsManager->getSettings().general.maxQueryHistory);
+    }
+}
+
 SettingsProvider::~SettingsProvider() = default;
 SettingsProvider::SettingsProvider(SettingsProvider&&) noexcept = default;
 SettingsProvider& SettingsProvider::operator=(SettingsProvider&&) noexcept = default;
@@ -246,6 +261,7 @@ std::string SettingsProvider::updateSettings(std::string_view params) {
         (void)m_settingsManager->save();
 
         applyQueryTimeoutToConnections(settings.query.timeoutSeconds);
+        applyMaxQueryHistoryToInstance(settings.general.maxQueryHistory);
 
         return JsonUtils::successResponse(R"({"saved":true})");
     } catch (const std::exception& e) {

--- a/backend/providers/settings_provider.h
+++ b/backend/providers/settings_provider.h
@@ -53,7 +53,7 @@ private:
 
     std::unique_ptr<SettingsManager> m_settingsManager;
     std::unique_ptr<SessionManager> m_sessionManager;
-    IConnectionProvider* m_connections;     // Non-owning; may be null in tests
+    IConnectionProvider* m_connections;      // Non-owning; may be null in tests
     QueryHistory* m_queryHistory = nullptr;  // Non-owning; wired post-construction by SystemContext
 };
 

--- a/backend/providers/settings_provider.h
+++ b/backend/providers/settings_provider.h
@@ -11,6 +11,7 @@ namespace velocitydb {
 class SettingsManager;
 class SessionManager;
 class IConnectionProvider;
+class QueryHistory;
 
 /// Provider for application settings and session management
 class SettingsProvider : public ISettingsProvider {
@@ -19,6 +20,11 @@ public:
     ///                    May be nullptr for unit tests that don't exercise timeout propagation.
     explicit SettingsProvider(IConnectionProvider* connections = nullptr);
     ~SettingsProvider() override;
+
+    /// Wire the QueryHistory instance whose maxItems is updated when
+    /// general.maxQueryHistory changes via updateSettings().
+    /// May be called once after construction; pass nullptr to detach.
+    void setQueryHistory(QueryHistory* queryHistory);
 
     SettingsProvider(const SettingsProvider&) = delete;
     SettingsProvider& operator=(const SettingsProvider&) = delete;
@@ -43,10 +49,12 @@ public:
 
 private:
     void applyQueryTimeoutToConnections(int seconds);
+    void applyMaxQueryHistoryToInstance(int maxItems);
 
     std::unique_ptr<SettingsManager> m_settingsManager;
     std::unique_ptr<SessionManager> m_sessionManager;
-    IConnectionProvider* m_connections;  // Non-owning; may be null in tests
+    IConnectionProvider* m_connections;     // Non-owning; may be null in tests
+    QueryHistory* m_queryHistory = nullptr;  // Non-owning; wired post-construction by SystemContext
 };
 
 }  // namespace velocitydb

--- a/tests/database/test_query_history.cpp
+++ b/tests/database/test_query_history.cpp
@@ -240,5 +240,45 @@ TEST_F(QueryHistoryTest, AddRemoveScalesLinearly) {
     EXPECT_LT(ratio, 30.0) << "scaling ratio=" << ratio << " (tSmall=" << tSmall << "us, tLarge=" << tLarge << "us) — superlinear scaling detected";
 }
 
+TEST_F(QueryHistoryTest, SetMaxItemsShrinksHistoryEvictingNonFavorites) {
+    QueryHistory h{10};
+    for (int i = 0; i < 10; ++i) {
+        HistoryItem item;
+        item.id = generateHistoryId();
+        item.sql = "SELECT " + std::to_string(i);
+        item.timestamp = std::chrono::system_clock::now();
+        item.success = true;
+        // 偶数 index を favorite (5 件)
+        item.isFavorite = (i % 2 == 0);
+        h.add(item);
+    }
+    ASSERT_EQ(h.getAll().size(), 10);
+
+    // 上限を 5 に縮小: 非 favorite (5 件) が削除されて favorite だけが残る想定
+    h.setMaxItems(5);
+
+    auto remaining = h.getAll();
+    EXPECT_EQ(remaining.size(), 5);
+    for (const auto& item : remaining) {
+        EXPECT_TRUE(item.isFavorite) << "non-favorite survived after shrink: " << item.sql;
+    }
+}
+
+TEST_F(QueryHistoryTest, SetMaxItemsLargerThanCurrentKeepsAll) {
+    QueryHistory h{5};
+    for (int i = 0; i < 5; ++i) {
+        HistoryItem item;
+        item.id = generateHistoryId();
+        item.sql = "SELECT " + std::to_string(i);
+        item.timestamp = std::chrono::system_clock::now();
+        item.success = true;
+        h.add(item);
+    }
+    ASSERT_EQ(h.getAll().size(), 5);
+
+    h.setMaxItems(100);
+    EXPECT_EQ(h.getAll().size(), 5);
+}
+
 }  // namespace test
 }  // namespace velocitydb

--- a/tests/providers/test_settings_provider.cpp
+++ b/tests/providers/test_settings_provider.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
 
+#include "database/query_history.h"
 #include "providers/settings_provider.h"
-#include "utils/settings_manager.h"
 #include "utils/session_manager.h"
+#include "utils/settings_manager.h"
 
 namespace velocitydb {
 namespace {
@@ -50,6 +51,52 @@ TEST_F(SettingsProviderTest, DeleteNonExistentProfile) {
     // Deleting non-existent profile should succeed (idempotent)
     auto result = provider.deleteConnectionProfile(R"({"id":"non_existent_profile_id"})");
     EXPECT_FALSE(result.empty());
+}
+
+TEST_F(SettingsProviderTest, UpdateSettingsAppliesMaxQueryHistoryToInstance) {
+    // Issue #426: settings.maxQueryHistory の変更が wired QueryHistory に伝播することを検証する。
+    QueryHistory queryHistory{10000};
+    for (int i = 0; i < 20; ++i) {
+        HistoryItem item;
+        item.id = generateHistoryId();
+        item.sql = "SELECT " + std::to_string(i);
+        item.timestamp = std::chrono::system_clock::now();
+        item.success = true;
+        // 全て非 favorite (eviction 対象)
+        queryHistory.add(item);
+    }
+    ASSERT_EQ(queryHistory.getAll().size(), 20);
+
+    provider.setQueryHistory(&queryHistory);
+
+    auto result = provider.updateSettings(R"({"general":{"maxQueryHistory":5}})");
+
+    EXPECT_NE(result.find("\"saved\""), std::string::npos);
+    EXPECT_EQ(queryHistory.getAll().size(), 5u);
+}
+
+TEST_F(SettingsProviderTest, SetQueryHistoryAppliesLoadedMaxToInstance) {
+    // wiring 時点の settings.maxQueryHistory が QueryHistory に即時反映されることを検証する。
+    // 1) settings を maxQueryHistory=3 に変更 (この時点では m_queryHistory 未 wire のため伝播は no-op)。
+    auto updateResult = provider.updateSettings(R"({"general":{"maxQueryHistory":3}})");
+    ASSERT_NE(updateResult.find("\"saved\""), std::string::npos);
+
+    // 2) ローカル QueryHistory は上限 1000 で 10 件保持。
+    QueryHistory queryHistory{1000};
+    for (int i = 0; i < 10; ++i) {
+        HistoryItem item;
+        item.id = generateHistoryId();
+        item.sql = "SELECT " + std::to_string(i);
+        item.timestamp = std::chrono::system_clock::now();
+        item.success = true;
+        queryHistory.add(item);
+    }
+    ASSERT_EQ(queryHistory.getAll().size(), 10);
+
+    // 3) wire 時点で setMaxItems(3) が呼ばれて 3 件まで縮小される。
+    provider.setQueryHistory(&queryHistory);
+
+    EXPECT_EQ(queryHistory.getAll().size(), 3u);
 }
 
 }  // namespace


### PR DESCRIPTION
Closes #426