### PR TITLE
chore(perf): tests/perf/ ベンチ基盤と pdg bench サブコマンドを追加 (#425)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,72 @@
+name: Benchmarks
+
+# Manual trigger only — performance benchmarks consume Windows runner minutes
+# and need a clean machine for stable measurements. Run via:
+#   gh workflow run bench.yml [-f build_type=Release]
+on:
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: 'CMake build type'
+        required: false
+        default: 'Release'
+        type: choice
+        options:
+          - Release
+          - Debug
+
+permissions:
+  contents: read
+
+jobs:
+  backend-bench:
+    name: Backend Benchmarks
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install Ninja and ccache
+        run: choco install ninja ccache -y
+
+      - name: Setup ccache
+        run: |
+          echo "CC=cl.exe" >> $env:GITHUB_ENV
+          echo "CXX=cl.exe" >> $env:GITHUB_ENV
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> $env:GITHUB_ENV
+          echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $env:GITHUB_ENV
+
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ~\.ccache
+          key: ccache-bench-${{ runner.os }}-${{ inputs.build_type }}-${{ hashFiles('**/*.cpp', '**/*.h') }}
+          restore-keys: |
+            ccache-bench-${{ runner.os }}-${{ inputs.build_type }}-
+
+      - name: Cache CMake build
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/_deps
+            build/third_party
+          key: cmake-bench-${{ runner.os }}-${{ inputs.build_type }}-${{ hashFiles('CMakeLists.txt', 'backend/CMakeLists.txt', 'third_party/CMakeLists.txt') }}
+          restore-keys: |
+            cmake-bench-${{ runner.os }}-${{ inputs.build_type }}-
+
+      - name: Configure CMake
+        run: |
+          cmake -B build -G Ninja `
+            -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} `
+            -DBUILD_TESTS=ON `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache
+
+      - name: Build (parallel)
+        run: cmake --build build --parallel
+
+      - name: Run Backend Benchmarks
+        # -L perf selects only the perf-labeled tests (tests/perf/)
+        run: ctest --test-dir build --output-on-failure -L perf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,8 @@ jobs:
         run: cmake --build build --config Release --parallel
 
       - name: Run Tests (parallel)
-        run: ctest --test-dir build --output-on-failure --parallel
+        # -LE perf excludes performance benchmarks (run via Benchmarks workflow or `pdg bench backend`)
+        run: ctest --test-dir build --output-on-failure --parallel -LE perf
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,8 @@ jobs:
         run: cmake --build build --parallel
 
       - name: Run C++ Tests
-        run: ctest --test-dir build --output-on-failure --parallel
+        # -LE perf excludes performance benchmarks (run via Benchmarks workflow or `pdg bench backend`)
+        run: ctest --test-dir build --output-on-failure --parallel -LE perf
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/docs/PERFORMANCE_VALIDATION.md
+++ b/docs/PERFORMANCE_VALIDATION.md
@@ -178,11 +178,14 @@ uv run scripts/pdg.py test backend
 本検証では「実装の存在確認」までを完了した。継続的な目標達成保証のためには以下が必要:
 
 1. **ベンチマークテスト群の追加** (別 issue / PR)
-   - バックエンド: `tests/perf/` ディレクトリ新設、Google Test での計測アサート
-   - フロントエンド: Vitest での `performance.now()` ベース計測 + Playwright での E2E 計測
-   - `scripts/pdg.py` に `bench` サブコマンド追加
+   - ✅ バックエンド基盤: `tests/perf/` 新設、`VelocityDBPerfTests` 実行ファイル、`perf` ctest ラベル (#425)
+   - ✅ `scripts/pdg.py` に `bench` サブコマンド (`pdg bench backend` で `ctest -L perf`)
+   - 🔍 個別目標 (#3 SELECT / #6 SQL フォーマット / #10 履歴検索 / #11 SIMD) の計測テスト追加は別 PR
+   - 🔍 フロントエンド: Vitest での `performance.now()` ベース計測 + Playwright での E2E 計測 (未着手)
 2. **CI への組み込み**
-   - リグレッション検出のため、PR 毎にベンチマーク値を記録・比較
+   - ✅ 通常テスト workflow (`ci.yml` / `test.yml`) は `ctest -LE perf` で perf を除外
+   - ✅ `bench.yml` を新設 (`workflow_dispatch` で手動実行)
+   - 🔍 PR 毎のリグレッション検出 (値の記録・比較) は未対応
 3. **README の目標表現の明確化**
    - 「高速」(#11) のように定量的でない記述を、具体値もしくは相対値 (例: 「非 SIMD 比 N 倍」) に置き換え
    - 計測条件 (CPU、メモリ、DB ロケーション) の前提を README に併記

--- a/scripts/_lib/test.py
+++ b/scripts/_lib/test.py
@@ -64,8 +64,19 @@ def test_e2e() -> bool:
     return success
 
 
-def test_backend(build_type: str = "Release") -> bool:
-    """Run backend tests."""
+def _run_ctest_preset(
+    build_type: str,
+    label_args: list[str],
+    *,
+    header: str,
+    cmd_label: str,
+    ok_msg: str,
+    fail_msg: str,
+) -> bool:
+    """Run ctest under a CMake preset with the given label filter.
+
+    label_args は ctest にそのまま渡す追加引数 (例: ["--parallel", "-LE", "perf"])。
+    """
     if build_type not in ("Debug", "Release"):
         print(f"ERROR: Invalid build type '{build_type}'")
         return False
@@ -73,25 +84,44 @@ def test_backend(build_type: str = "Release") -> bool:
     project_root = utils.get_project_root()
     build_dir = project_root / "build"
 
-    utils.print_header(f"Running Backend Tests ({build_type})")
+    utils.print_header(f"{header} ({build_type})")
 
     if not build_dir.exists():
         print("\nERROR: Build directory not found")
         print("Run 'uv run scripts/pdg.py build backend' first")
         return False
 
-    # Setup MSVC environment
     env = utils.get_msvc_env()
-
-    # Run CTest with Preset
     preset = build_type.lower()  # "debug" or "release"
-    test_cmd = ["ctest", "--preset", preset, "--output-on-failure", "--parallel"]
+    test_cmd = ["ctest", "--preset", preset, "--output-on-failure", *label_args]
 
-    success, _ = utils.run_command(test_cmd, "CTest", env=env)
+    success, _ = utils.run_command(test_cmd, cmd_label, env=env)
 
-    if success:
-        print("\n[OK] All tests passed!")
-    else:
-        print("\n[FAIL] Tests failed")
-
+    print(f"\n[{'OK' if success else 'FAIL'}] {ok_msg if success else fail_msg}")
     return success
+
+
+def test_backend(build_type: str = "Release") -> bool:
+    """Run backend unit tests (perf-labeled benchmarks excluded)."""
+    # -LE perf excludes performance benchmarks so the default test run stays
+    # fast; use `pdg bench backend` to run them.
+    return _run_ctest_preset(
+        build_type,
+        ["--parallel", "-LE", "perf"],
+        header="Running Backend Tests",
+        cmd_label="CTest",
+        ok_msg="All tests passed!",
+        fail_msg="Tests failed",
+    )
+
+
+def bench_backend(build_type: str = "Release") -> bool:
+    """Run backend performance benchmarks (perf-labeled tests only)."""
+    return _run_ctest_preset(
+        build_type,
+        ["-L", "perf"],
+        header="Running Backend Benchmarks",
+        cmd_label="CTest (perf)",
+        ok_msg="All benchmarks passed!",
+        fail_msg="Benchmarks failed",
+    )

--- a/scripts/pdg.py
+++ b/scripts/pdg.py
@@ -9,6 +9,7 @@ Usage:
     uv run scripts/pdg.py build [backend|frontend|all] [--clean]
     uv run scripts/pdg.py debug [--clean]              # Backend Debug build
     uv run scripts/pdg.py test [backend|frontend|e2e] [--watch]
+    uv run scripts/pdg.py bench [backend]              # Performance benchmarks
     uv run scripts/pdg.py lint [--fix] [--unsafe]
     uv run scripts/pdg.py dev
     uv run scripts/pdg.py package
@@ -21,6 +22,7 @@ Examples:
     uv run scripts/pdg.py build all
     uv run scripts/pdg.py debug                        # Quick debug build
     uv run scripts/pdg.py test frontend --watch
+    uv run scripts/pdg.py bench backend                # Run perf-labeled tests
     uv run scripts/pdg.py lint --fix
     uv run scripts/pdg.py lint --fix --unsafe
     uv run scripts/pdg.py clean logs
@@ -74,6 +76,18 @@ def cmd_test(args: argparse.Namespace) -> bool:
         return test.test_e2e()
     else:
         print(f"ERROR: Unknown test target: {target}")
+        return False
+
+
+def cmd_bench(args: argparse.Namespace) -> bool:
+    """Handle bench command - run performance benchmarks (perf-labeled tests)."""
+    target: str = args.target
+    build_type: str = args.type
+
+    if target == "backend":
+        return test.bench_backend(build_type=build_type)
+    else:
+        print(f"ERROR: Unknown bench target: {target}")
         return False
 
 
@@ -414,6 +428,23 @@ def main() -> None:
         help="Build type for backend tests (default: Release)",
     )
 
+    # Bench command (perf-labeled tests only; excluded from `test` by default)
+    bench_parser = subparsers.add_parser("bench", help="Run performance benchmarks")
+    bench_parser.add_argument(
+        "target",
+        choices=["backend"],
+        default="backend",
+        nargs="?",
+        help="Bench target (default: backend)",
+    )
+    bench_parser.add_argument(
+        "--type",
+        "-t",
+        choices=["Debug", "Release"],
+        default="Release",
+        help="Build type for benchmarks (default: Release)",
+    )
+
     # Lint command
     lint_parser = subparsers.add_parser("lint", aliases=["l"], help="Lint code")
     lint_parser.add_argument("--fix", "-f", action="store_true", help="Auto-fix issues")
@@ -478,6 +509,7 @@ def main() -> None:
         "debug": cmd_debug,
         "test": cmd_test,
         "t": cmd_test,
+        "bench": cmd_bench,
         "lint": cmd_lint,
         "l": cmd_lint,
         "dev": cmd_dev,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,3 +65,7 @@ target_set_output_directories(VelocityDBTests)
 
 include(GoogleTest)
 gtest_discover_tests(VelocityDBTests)
+
+# Performance benchmark tests are built as a separate executable and labeled
+# "perf" so unit-test runs can skip them via `ctest -LE perf`.
+add_subdirectory(perf)

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Performance benchmark tests
+#
+# Built as a separate executable (VelocityDBPerfTests) so that bench cases can be
+# run/skipped independently of unit tests via the "perf" ctest label.
+#
+# Run only perf:        ctest --preset release -L perf
+# Skip perf in normal:  ctest --preset release -LE perf
+
+set(PERF_TEST_SOURCES
+    test_main.cpp
+    test_smoke_bench.cpp
+)
+
+add_executable(VelocityDBPerfTests ${PERF_TEST_SOURCES})
+
+target_include_directories(VelocityDBPerfTests PRIVATE
+    ${CMAKE_SOURCE_DIR}/backend
+    ${CMAKE_SOURCE_DIR}/third_party
+)
+
+target_link_libraries(VelocityDBPerfTests PRIVATE
+    VelocityDBCore
+    gtest
+    gtest_main
+    gmock
+)
+
+target_set_msvc_options(VelocityDBPerfTests)
+target_set_output_directories(VelocityDBPerfTests)
+
+include(GoogleTest)
+gtest_discover_tests(VelocityDBPerfTests
+    PROPERTIES LABELS "perf"
+)

--- a/tests/perf/test_main.cpp
+++ b/tests/perf/test_main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/perf/test_smoke_bench.cpp
+++ b/tests/perf/test_smoke_bench.cpp
@@ -1,0 +1,35 @@
+// Smoke benchmark validating the perf-test infrastructure end to end:
+// std::chrono measurement, EXPECT_LT against a target, and the "perf" ctest label.
+//
+// Concrete benchmarks for README performance goals (#3 SELECT, #6 SQL format,
+// #10 history search, #11 SIMD) are tracked separately — see
+// docs/PERFORMANCE_VALIDATION.md.
+
+#include "parsers/sql_formatter.h"
+
+#include <chrono>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace velocitydb {
+namespace {
+
+// README #6: SQL formatting target. The smoke case uses a short query so the
+// measurement is dominated by formatter overhead, not input size.
+constexpr auto SQL_FORMAT_TARGET = std::chrono::milliseconds(50);
+
+TEST(PerfSmokeBench, SqlFormatterShortQueryUnderTarget) {
+    const std::string sql = "select id, name, email from users where id = 1";
+    SQLFormatter formatter;
+
+    const auto start = std::chrono::steady_clock::now();
+    const auto formatted = formatter.format(sql);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_FALSE(formatted.empty());
+    EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed), SQL_FORMAT_TARGET);
+}
+
+}  // namespace
+}  // namespace velocitydb


### PR DESCRIPTION
- tests/perf/ 新設: VelocityDBPerfTests を別実行ファイル化、gtest_discover_tests に LABELS perf を付与
- ctest のラベルで通常テスト (-LE perf) と bench (-L perf) を分離
- scripts/pdg.py に bench サブコマンドと _run_ctest_preset helper を追加
- CI: ci.yml / test.yml の ctest に -LE perf、bench.yml を新設 (workflow_dispatch + ccache)
- docs/PERFORMANCE_VALIDATION.md の「今後のアクション」#1/#2 に進捗マーク

PerfSmokeBench.SqlFormatterShortQueryUnderTarget を 1 件追加して計測アサート (std::chrono + EXPECT_LT) の枠組みを実証。個別目標 (#3 SELECT / #6 SQL format / #10 履歴検索 / #11 SIMD) の計測テストは別 PR (#424 等) で追加。


Closes #425