### PR TITLE
perf(backend): QueryHistory.search() を trigram で 1 万件 <100ms 化 (#424)

### DIFF
--- a/backend/database/query_history.cpp
+++ b/backend/database/query_history.cpp
@@ -3,13 +3,86 @@
 #include "simdjson.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
+#include <cctype>
 #include <format>
 #include <fstream>
 #include <ranges>
 #include <sstream>
+#include <unordered_set>
 
 namespace velocitydb {
+
+namespace {
+
+/// ASCII のみ lowercase 折りたたみ。UTF-8 multi-byte (>= 0x80) は std::tolower の定義域外だが
+/// unsigned char 経由で UB を回避し、戻り値を変えないことで non-ASCII の identity を保つ。
+inline char normalizeByte(unsigned char c) noexcept {
+    return static_cast<char>(std::tolower(c));
+}
+
+/// sql の byte 単位 sliding window で trigram を yield する。size<3 なら no-op。
+/// UTF-8 lead byte に開始位置を限定しない: index と検索の trigram 集合の対称性を優先し、
+/// 偽陽性は最終 substring 検証で除外する。
+template <typename F>
+void forEachTrigram(std::string_view sql, F&& fn) {
+    if (sql.size() < 3)
+        return;
+    for (size_t i = 0; i + 3 <= sql.size(); ++i) {
+        std::array<char, 3> t{
+            normalizeByte(static_cast<unsigned char>(sql[i])),
+            normalizeByte(static_cast<unsigned char>(sql[i + 1])),
+            normalizeByte(static_cast<unsigned char>(sql[i + 2])),
+        };
+        fn(t);
+    }
+}
+
+bool caseInsensitiveFind(std::string_view haystack, std::string_view needle) {
+    if (needle.size() > haystack.size()) {
+        return false;
+    }
+    auto it = std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); });
+    return it != haystack.end();
+}
+
+}  // namespace
+
+void QueryHistory::addToTrigramIndex(HistoryIter it) {
+    // 同一 sql 内で出現する重複 trigram を排除して posting を膨らませない。
+    std::vector<Trigram> trigrams;
+    trigrams.reserve(it->sql.size());
+    forEachTrigram(it->sql, [&trigrams](const std::array<char, 3>& t) { trigrams.push_back(t); });
+    std::ranges::sort(trigrams);
+    const auto dup = std::ranges::unique(trigrams);
+    trigrams.erase(dup.begin(), dup.end());
+
+    const HistoryItem* ptr = &*it;
+    for (const auto& t : trigrams) {
+        m_trigramIndex[t].insert(ptr);
+    }
+}
+
+void QueryHistory::removeFromTrigramIndex(HistoryIter it) {
+    std::vector<Trigram> trigrams;
+    trigrams.reserve(it->sql.size());
+    forEachTrigram(it->sql, [&trigrams](const std::array<char, 3>& t) { trigrams.push_back(t); });
+    std::ranges::sort(trigrams);
+    const auto dup = std::ranges::unique(trigrams);
+    trigrams.erase(dup.begin(), dup.end());
+
+    const HistoryItem* ptr = &*it;
+    for (const auto& t : trigrams) {
+        auto mit = m_trigramIndex.find(t);
+        if (mit == m_trigramIndex.end())
+            continue;
+        mit->second.erase(ptr);
+        if (mit->second.empty()) {
+            m_trigramIndex.erase(mit);
+        }
+    }
+}
 
 void QueryHistory::add(const HistoryItem& item) {
     // 事前条件: 呼び出し側 (provider 等) が generateHistoryId() で id を埋める。
@@ -22,6 +95,7 @@ void QueryHistory::add(const HistoryItem& item) {
         if (!existing->second->isFavorite) {
             --m_nonFavoriteCount;
         }
+        removeFromTrigramIndex(existing->second);
         m_history.erase(existing->second);
         m_indexById.erase(existing);
     }
@@ -29,6 +103,7 @@ void QueryHistory::add(const HistoryItem& item) {
     m_history.push_front(item);
     auto inserted = m_history.begin();
     m_indexById.emplace(inserted->id, inserted);
+    addToTrigramIndex(inserted);
     if (!inserted->isFavorite) {
         ++m_nonFavoriteCount;
     }
@@ -53,6 +128,7 @@ void QueryHistory::evictOverLimitLocked() {
 
         auto victim = std::next(rit).base();
         m_indexById.erase(victim->id);
+        removeFromTrigramIndex(victim);
         m_history.erase(victim);
         --m_nonFavoriteCount;
     }
@@ -76,23 +152,58 @@ std::vector<HistoryItem> QueryHistory::search(std::string_view keyword) const {
         return {m_history.begin(), m_history.end()};
     }
 
-    auto caseInsensitiveFind = [](std::string_view haystack, std::string_view needle) -> bool {
-        if (needle.size() > haystack.size()) {
-            return false;
+    // 短語 (< 3 byte) は trigram 化不能 → 既存と同じ線形 substring search にフォールバック。
+    if (keyword.size() < 3) {
+        std::vector<HistoryItem> results;
+        results.reserve(m_history.size() / 4);
+        for (const auto& item : m_history) {
+            if (caseInsensitiveFind(item.sql, keyword)) {
+                results.push_back(item);
+            }
         }
-        auto it = std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), [](unsigned char a, unsigned char b) { return std::tolower(a) == std::tolower(b); });
-        return it != haystack.end();
-    };
+        return results;
+    }
 
+    // 1. keyword の trigram 集合 (重複排除)
+    std::vector<Trigram> queryTrigrams;
+    queryTrigrams.reserve(keyword.size());
+    forEachTrigram(keyword, [&queryTrigrams](const std::array<char, 3>& t) { queryTrigrams.push_back(t); });
+    std::ranges::sort(queryTrigrams);
+    const auto qDup = std::ranges::unique(queryTrigrams);
+    queryTrigrams.erase(qDup.begin(), qDup.end());
+
+    // 2. 各 trigram の posting set を取得。1 個でも欠ければ確定でゼロ件。
+    std::vector<const std::unordered_set<const HistoryItem*>*> postings;
+    postings.reserve(queryTrigrams.size());
+    for (const auto& t : queryTrigrams) {
+        auto mit = m_trigramIndex.find(t);
+        if (mit == m_trigramIndex.end()) {
+            return {};
+        }
+        postings.push_back(&mit->second);
+    }
+
+    // 3. 最短 posting を起点に、各候補が他全 posting に含まれるかチェック (AND 交差)。
+    //    unordered_set::contains は O(1) なので候補 K 個 × posting M 個で O(K*M)。
+    auto shortest = std::ranges::min_element(postings, {}, [](const auto* p) { return p->size(); });
+    std::unordered_set<const HistoryItem*> candidates;
+    for (const auto* cand : **shortest) {
+        const bool inAll = std::ranges::all_of(postings, [cand](const auto* p) { return p->contains(cand); });
+        if (inAll) {
+            candidates.insert(cand);
+        }
+    }
+
+    // 4. m_history を順走査して final substring 検証。LRU 順 (newest first) を保持する。
     std::vector<HistoryItem> results;
-    results.reserve(m_history.size() / 4);
-
+    results.reserve(candidates.size());
     for (const auto& item : m_history) {
+        if (!candidates.contains(&item))
+            continue;
         if (caseInsensitiveFind(item.sql, keyword)) {
             results.push_back(item);
         }
     }
-
     return results;
 }
 
@@ -137,6 +248,7 @@ void QueryHistory::remove(std::string_view id) {
     if (!it->second->isFavorite) {
         --m_nonFavoriteCount;
     }
+    removeFromTrigramIndex(it->second);
     m_history.erase(it->second);
     m_indexById.erase(it);
 }
@@ -149,6 +261,7 @@ void QueryHistory::clear() {
             ++it;
         } else {
             m_indexById.erase(it->id);
+            removeFromTrigramIndex(it);
             it = m_history.erase(it);
         }
     }
@@ -229,6 +342,7 @@ std::expected<void, std::string> QueryHistory::load(std::string_view filepath) {
 
         m_history.clear();
         m_indexById.clear();
+        m_trigramIndex.clear();
         m_nonFavoriteCount = 0;
 
         for (auto item : doc.get_array()) {
@@ -272,8 +386,11 @@ std::expected<void, std::string> QueryHistory::load(std::string_view filepath) {
             if (auto [_, inserted] = m_indexById.emplace(last->id, last); !inserted) {
                 // 重複 id を検出。新エントリを破棄して map との整合を維持する。
                 m_history.pop_back();
-            } else if (!last->isFavorite) {
-                ++m_nonFavoriteCount;
+            } else {
+                addToTrigramIndex(last);
+                if (!last->isFavorite) {
+                    ++m_nonFavoriteCount;
+                }
             }
         }
 

--- a/backend/database/query_history.cpp
+++ b/backend/database/query_history.cpp
@@ -49,31 +49,31 @@ bool caseInsensitiveFind(std::string_view haystack, std::string_view needle) {
 
 }  // namespace
 
-void QueryHistory::addToTrigramIndex(HistoryIter it) {
-    // 同一 sql 内で出現する重複 trigram を排除して posting を膨らませない。
-    std::vector<Trigram> trigrams;
-    trigrams.reserve(it->sql.size());
-    forEachTrigram(it->sql, [&trigrams](const std::array<char, 3>& t) { trigrams.push_back(t); });
-    std::ranges::sort(trigrams);
-    const auto dup = std::ranges::unique(trigrams);
-    trigrams.erase(dup.begin(), dup.end());
+std::vector<QueryHistory::Trigram> QueryHistory::buildUniqueTrigrams(std::string_view sql) {
+    // unordered_set で per-trigram O(1) 重複検出。全体 O(L) (L = sql.size())。
+    // 戻り値の順序は非保証だが、呼び出し側は重複なし集合として扱うのみで順序非依存。
+    std::unordered_set<Trigram, TrigramHash> seen;
+    seen.reserve(sql.size());
+    std::vector<Trigram> result;
+    result.reserve(sql.size());
+    forEachTrigram(sql, [&seen, &result](const Trigram& t) {
+        if (seen.insert(t).second) {
+            result.push_back(t);
+        }
+    });
+    return result;
+}
 
+void QueryHistory::addToTrigramIndex(HistoryIter it) {
     const HistoryItem* ptr = &*it;
-    for (const auto& t : trigrams) {
+    for (const auto& t : buildUniqueTrigrams(it->sql)) {
         m_trigramIndex[t].insert(ptr);
     }
 }
 
 void QueryHistory::removeFromTrigramIndex(HistoryIter it) {
-    std::vector<Trigram> trigrams;
-    trigrams.reserve(it->sql.size());
-    forEachTrigram(it->sql, [&trigrams](const std::array<char, 3>& t) { trigrams.push_back(t); });
-    std::ranges::sort(trigrams);
-    const auto dup = std::ranges::unique(trigrams);
-    trigrams.erase(dup.begin(), dup.end());
-
     const HistoryItem* ptr = &*it;
-    for (const auto& t : trigrams) {
+    for (const auto& t : buildUniqueTrigrams(it->sql)) {
         auto mit = m_trigramIndex.find(t);
         if (mit == m_trigramIndex.end())
             continue;
@@ -145,34 +145,9 @@ std::vector<HistoryItem> QueryHistory::getAll() const {
     return {m_history.begin(), m_history.end()};
 }
 
-std::vector<HistoryItem> QueryHistory::search(std::string_view keyword) const {
-    std::lock_guard lock(m_mutex);
+std::unordered_set<const HistoryItem*> QueryHistory::findSearchCandidatesLocked(std::string_view keyword) const {
+    const auto queryTrigrams = buildUniqueTrigrams(keyword);
 
-    if (keyword.empty()) {
-        return {m_history.begin(), m_history.end()};
-    }
-
-    // 短語 (< 3 byte) は trigram 化不能 → 既存と同じ線形 substring search にフォールバック。
-    if (keyword.size() < 3) {
-        std::vector<HistoryItem> results;
-        results.reserve(m_history.size() / 4);
-        for (const auto& item : m_history) {
-            if (caseInsensitiveFind(item.sql, keyword)) {
-                results.push_back(item);
-            }
-        }
-        return results;
-    }
-
-    // 1. keyword の trigram 集合 (重複排除)
-    std::vector<Trigram> queryTrigrams;
-    queryTrigrams.reserve(keyword.size());
-    forEachTrigram(keyword, [&queryTrigrams](const std::array<char, 3>& t) { queryTrigrams.push_back(t); });
-    std::ranges::sort(queryTrigrams);
-    const auto qDup = std::ranges::unique(queryTrigrams);
-    queryTrigrams.erase(qDup.begin(), qDup.end());
-
-    // 2. 各 trigram の posting set を取得。1 個でも欠ければ確定でゼロ件。
     std::vector<const std::unordered_set<const HistoryItem*>*> postings;
     postings.reserve(queryTrigrams.size());
     for (const auto& t : queryTrigrams) {
@@ -183,8 +158,8 @@ std::vector<HistoryItem> QueryHistory::search(std::string_view keyword) const {
         postings.push_back(&mit->second);
     }
 
-    // 3. 最短 posting を起点に、各候補が他全 posting に含まれるかチェック (AND 交差)。
-    //    unordered_set::contains は O(1) なので候補 K 個 × posting M 個で O(K*M)。
+    // 最短 posting を起点に、各候補が他全 posting に含まれるかチェック (AND 交差)。
+    // unordered_set::contains は O(1) なので候補 K 個 × posting M 個で O(K*M)。
     auto shortest = std::ranges::min_element(postings, {}, [](const auto* p) { return p->size(); });
     std::unordered_set<const HistoryItem*> candidates;
     for (const auto* cand : **shortest) {
@@ -193,8 +168,30 @@ std::vector<HistoryItem> QueryHistory::search(std::string_view keyword) const {
             candidates.insert(cand);
         }
     }
+    return candidates;
+}
 
-    // 4. m_history を順走査して final substring 検証。LRU 順 (newest first) を保持する。
+std::vector<HistoryItem> QueryHistory::search(std::string_view keyword) const {
+    std::lock_guard lock(m_mutex);
+
+    if (keyword.empty()) {
+        return {m_history.begin(), m_history.end()};
+    }
+
+    // 短語 (< 3 byte) は trigram 化不能 → 既存と同じ線形 substring search にフォールバック。
+    if (keyword.size() < 3) {
+        std::vector<HistoryItem> results;
+        for (const auto& item : m_history) {
+            if (caseInsensitiveFind(item.sql, keyword)) {
+                results.push_back(item);
+            }
+        }
+        return results;
+    }
+
+    const auto candidates = findSearchCandidatesLocked(keyword);
+
+    // m_history を順走査して final substring 検証。LRU 順 (newest first) を保持する。
     std::vector<HistoryItem> results;
     results.reserve(candidates.size());
     for (const auto& item : m_history) {

--- a/backend/database/query_history.h
+++ b/backend/database/query_history.h
@@ -106,6 +106,13 @@ private:
     void addToTrigramIndex(HistoryIter it);
     /// sql の全 trigram を index から削除する (posting が空なら entry も erase)。
     void removeFromTrigramIndex(HistoryIter it);
+    /// search() の posting 交差処理。keyword の trigram 集合から AND 交差で候補集合を返す。
+    /// 1 個でも posting が欠けていれば空集合を返す (ゼロ件確定)。要 m_mutex 保有。
+    [[nodiscard]] std::unordered_set<const HistoryItem*> findSearchCandidatesLocked(std::string_view keyword) const;
+    /// sql の全 trigram を抽出し重複排除した vector を返す。
+    /// `unordered_set` で重複検出するため per-trigram O(1)、全体 O(L) (L = sql.size())。
+    /// member 化している理由: `TrigramHash` が private nested 型のため anonymous namespace から不可視。
+    [[nodiscard]] static std::vector<Trigram> buildUniqueTrigrams(std::string_view sql);
 
     size_t m_maxItems;
     mutable std::mutex m_mutex;

--- a/backend/database/query_history.h
+++ b/backend/database/query_history.h
@@ -2,8 +2,10 @@
 
 #include "../utils/transparent_hash.h"
 
+#include <array>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <expected>
 #include <format>
 #include <list>
@@ -12,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace velocitydb {
@@ -79,14 +82,41 @@ private:
     /// 呼び出し側で m_mutex を取得済みであることを前提とした eviction 共通ロジック。
     void evictOverLimitLocked();
 
+    using HistoryIter = std::list<HistoryItem>::iterator;
+
+    /// trigram (n=3) inverted index で search() を高速化する (Issue #424)。
+    /// キーは sizeof 3 byte の `std::array<char,3>`、posting には HistoryItem の生ポインタを保持。
+    /// std::list は erase 以外で iterator/要素アドレスが不変なので、ポインタは erase 時のみ同期すればよい。
+    /// posting を unordered_set にすることで insert/erase/lookup を O(1) に保ち、
+    /// add/remove のスケーリングを per-op O(1) に維持する (vector だと erase が posting size N に依存)。
+    using Trigram = std::array<char, 3>;
+    struct TrigramHash {
+        size_t operator()(const Trigram& t) const noexcept {
+            uint32_t v = (static_cast<uint32_t>(static_cast<uint8_t>(t[0])) << 16) | (static_cast<uint32_t>(static_cast<uint8_t>(t[1])) << 8) | static_cast<uint32_t>(static_cast<uint8_t>(t[2]));
+            v ^= v >> 16;
+            v *= 0x7feb352dU;
+            v ^= v >> 15;
+            v *= 0x846ca68bU;
+            v ^= v >> 16;
+            return v;
+        }
+    };
+
+    /// sql の全 trigram を index に登録する (重複は除去)。
+    void addToTrigramIndex(HistoryIter it);
+    /// sql の全 trigram を index から削除する (posting が空なら entry も erase)。
+    void removeFromTrigramIndex(HistoryIter it);
+
     size_t m_maxItems;
     mutable std::mutex m_mutex;
     // list を選定: erase 以外で iterator が無効化されないため、unordered_map に iterator を保持して
     // add/remove/setFavorite を平均 O(1) 化できる。vector では中央 erase で iterator が全無効化される。
     std::list<HistoryItem> m_history;  // Front = newest.
-    std::unordered_map<std::string, std::list<HistoryItem>::iterator, TransparentStringHash, TransparentStringEqual> m_indexById;
+    std::unordered_map<std::string, HistoryIter, TransparentStringHash, TransparentStringEqual> m_indexById;
     // 非 favorite の件数。eviction loop が「全 favorite 状態」を O(1) で skip するためのキャッシュ。
     size_t m_nonFavoriteCount = 0;
+    // trigram → posting (該当 sql を持つ HistoryItem* の集合)。Issue #424。
+    std::unordered_map<Trigram, std::unordered_set<const HistoryItem*>, TrigramHash> m_trigramIndex;
 };
 
 }  // namespace velocitydb

--- a/tests/database/test_query_history.cpp
+++ b/tests/database/test_query_history.cpp
@@ -423,7 +423,17 @@ TEST_F(QueryHistoryTest, SearchAfterSetMaxItemsShrinkSyncsIndex) {
 }
 
 TEST_F(QueryHistoryTest, SearchAfterLoadRebuildsIndex) {
-    auto path = std::filesystem::temp_directory_path() / "qh_load_test.json";
+    // gtest 提供のテスト一時ディレクトリ + テスト名で他テストと隔離する。
+    // RAII guard で ASSERT 失敗時もファイル削除を保証する。
+    const auto path = std::filesystem::path(testing::TempDir()) / "qh_load_SearchAfterLoadRebuildsIndex.json";
+    struct PathGuard {
+        std::filesystem::path p;
+        ~PathGuard() {
+            std::error_code ec;
+            std::filesystem::remove(p, ec);
+        }
+    } guard{path};
+
     {
         QueryHistory writer{100};
         HistoryItem item;
@@ -439,8 +449,6 @@ TEST_F(QueryHistoryTest, SearchAfterLoadRebuildsIndex) {
 
     auto results = reader.search("loaded_token");
     EXPECT_EQ(results.size(), 1);
-
-    std::filesystem::remove(path);
 }
 
 TEST_F(QueryHistoryTest, SearchUpdatesIndexOnReAdd) {

--- a/tests/database/test_query_history.cpp
+++ b/tests/database/test_query_history.cpp
@@ -2,6 +2,8 @@
 #include "database/query_history.h"
 
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 
 namespace velocitydb {
 namespace test {
@@ -278,6 +280,203 @@ TEST_F(QueryHistoryTest, SetMaxItemsLargerThanCurrentKeepsAll) {
 
     h.setMaxItems(100);
     EXPECT_EQ(h.getAll().size(), 5);
+}
+
+TEST_F(QueryHistoryTest, SearchUtf8JapaneseKeyword) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    item.sql = "SELECT * FROM ユーザー WHERE id = 1";
+    item.success = true;
+    history.add(item);
+
+    auto results = history.search("ユーザー");
+    EXPECT_EQ(results.size(), 1);
+}
+
+TEST_F(QueryHistoryTest, SearchUtf8PartialMultibyte) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    item.sql = "SELECT * FROM ユーザー";
+    item.success = true;
+    history.add(item);
+
+    // "ユー" = 6 byte (3 byte * 2)。trigram 4 個生成される。
+    auto results = history.search("ユー");
+    EXPECT_EQ(results.size(), 1);
+}
+
+TEST_F(QueryHistoryTest, SearchShortKeywordFallbackOneByte) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    item.sql = "SELECT a FROM tbl";
+    item.success = true;
+    history.add(item);
+
+    // 1 byte: trigram 化不可 → 線形 fallback
+    auto results = history.search("a");
+    EXPECT_EQ(results.size(), 1);
+}
+
+TEST_F(QueryHistoryTest, SearchShortKeywordFallbackTwoByte) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    item.sql = "SELECT ab FROM tbl";
+    item.success = true;
+    history.add(item);
+
+    // 2 byte: trigram 化不可 → 線形 fallback
+    auto results = history.search("ab");
+    EXPECT_EQ(results.size(), 1);
+}
+
+TEST_F(QueryHistoryTest, SearchTrigramFalsePositiveExcluded) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    // "abc" "bcd" は両方 sql に含まれるが、"abcdef" は substring として存在しない
+    item.sql = "abcXdef";
+    item.success = true;
+    history.add(item);
+
+    auto results = history.search("abcdef");
+    EXPECT_EQ(results.size(), 0) << "trigram 候補だが substring 不一致 → 0 件であるべき";
+}
+
+TEST_F(QueryHistoryTest, SearchAfterRemoveSyncsIndex) {
+    HistoryItem item1;
+    item1.id = "id-A";
+    item1.sql = "SELECT alpha_unique_token FROM tbl";
+    item1.success = true;
+    HistoryItem item2;
+    item2.id = "id-B";
+    item2.sql = "SELECT beta FROM tbl";
+    item2.success = true;
+    history.add(item1);
+    history.add(item2);
+
+    history.remove("id-A");
+
+    // A 固有の trigram で検索しても 0 件であるべき
+    auto results = history.search("alpha_unique_token");
+    EXPECT_EQ(results.size(), 0);
+    // B はまだ残る
+    EXPECT_EQ(history.search("beta").size(), 1);
+}
+
+TEST_F(QueryHistoryTest, SearchAfterEvictionSyncsIndex) {
+    QueryHistory smallHistory{2};
+    HistoryItem itemA;
+    itemA.id = generateHistoryId();
+    itemA.sql = "alpha_evicted_token";
+    itemA.success = true;
+    smallHistory.add(itemA);
+
+    HistoryItem itemB;
+    itemB.id = generateHistoryId();
+    itemB.sql = "beta_token";
+    itemB.success = true;
+    smallHistory.add(itemB);
+
+    HistoryItem itemC;
+    itemC.id = generateHistoryId();
+    itemC.sql = "gamma_token";
+    itemC.success = true;
+    smallHistory.add(itemC);
+
+    // A は eviction された
+    EXPECT_EQ(smallHistory.getAll().size(), 2);
+    auto results = smallHistory.search("alpha_evicted_token");
+    EXPECT_EQ(results.size(), 0) << "eviction された A の trigram は index から消えているべき";
+}
+
+TEST_F(QueryHistoryTest, SearchAfterClearSyncsIndex) {
+    HistoryItem item;
+    item.id = generateHistoryId();
+    item.sql = "SELECT cleared_token FROM tbl";
+    item.success = true;
+    item.isFavorite = false;
+    history.add(item);
+
+    history.clear();
+
+    auto results = history.search("cleared_token");
+    EXPECT_EQ(results.size(), 0);
+}
+
+TEST_F(QueryHistoryTest, SearchAfterSetMaxItemsShrinkSyncsIndex) {
+    QueryHistory h{5};
+    for (int i = 0; i < 5; ++i) {
+        HistoryItem item;
+        item.id = generateHistoryId();
+        item.sql = "shrink_token_" + std::to_string(i);
+        item.success = true;
+        item.isFavorite = false;
+        h.add(item);
+    }
+    ASSERT_EQ(h.getAll().size(), 5);
+
+    // 最古 (push_front の back 側) から eviction される: token_0, token_1, token_2
+    h.setMaxItems(2);
+    EXPECT_EQ(h.getAll().size(), 2);
+
+    auto results = h.search("shrink_token_0");
+    EXPECT_EQ(results.size(), 0) << "eviction された 0 の trigram が残っていない";
+}
+
+TEST_F(QueryHistoryTest, SearchAfterLoadRebuildsIndex) {
+    auto path = std::filesystem::temp_directory_path() / "qh_load_test.json";
+    {
+        QueryHistory writer{100};
+        HistoryItem item;
+        item.id = "loaded-id";
+        item.sql = "SELECT loaded_token FROM tbl";
+        item.success = true;
+        writer.add(item);
+        ASSERT_TRUE(writer.save(path.string()).has_value());
+    }
+
+    QueryHistory reader{100};
+    ASSERT_TRUE(reader.load(path.string()).has_value());
+
+    auto results = reader.search("loaded_token");
+    EXPECT_EQ(results.size(), 1);
+
+    std::filesystem::remove(path);
+}
+
+TEST_F(QueryHistoryTest, SearchUpdatesIndexOnReAdd) {
+    HistoryItem item;
+    item.id = "fixed";
+    item.sql = "SELECT old_token FROM tbl";
+    item.success = true;
+    history.add(item);
+
+    item.sql = "SELECT new_token FROM tbl";
+    history.add(item);
+
+    // 旧 trigram は消えている
+    EXPECT_EQ(history.search("old_token").size(), 0);
+    // 新 trigram でヒット
+    EXPECT_EQ(history.search("new_token").size(), 1);
+}
+
+TEST_F(QueryHistoryTest, SearchPreservesLruOrder) {
+    HistoryItem item1;
+    item1.id = generateHistoryId();
+    item1.sql = "SELECT order_token FROM a";
+    item1.success = true;
+    history.add(item1);
+
+    HistoryItem item2;
+    item2.id = generateHistoryId();
+    item2.sql = "SELECT order_token FROM b";
+    item2.success = true;
+    history.add(item2);
+
+    // 後に add した item2 が先頭 (newest first)
+    auto results = history.search("order_token");
+    ASSERT_EQ(results.size(), 2);
+    EXPECT_EQ(results[0].sql, "SELECT order_token FROM b");
+    EXPECT_EQ(results[1].sql, "SELECT order_token FROM a");
 }
 
 }  // namespace test

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -9,6 +9,7 @@
 set(PERF_TEST_SOURCES
     test_main.cpp
     test_smoke_bench.cpp
+    test_query_history_search_bench.cpp
 )
 
 add_executable(VelocityDBPerfTests ${PERF_TEST_SOURCES})

--- a/tests/perf/test_query_history_search_bench.cpp
+++ b/tests/perf/test_query_history_search_bench.cpp
@@ -1,0 +1,79 @@
+// README #10: QueryHistory.search() target — 1 万件で 100ms 未満。
+// trigram inverted index が posting list 交差 + 最終 substring 検証で
+// 線形 substring 走査 (O(n*m)) より高速になることを検証する。
+
+#include "database/query_history.h"
+
+#include <chrono>
+#include <format>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace velocitydb {
+namespace {
+
+constexpr size_t kBenchCount = 10000;
+constexpr auto SEARCH_TARGET = std::chrono::milliseconds(100);
+
+class QueryHistorySearchBench : public ::testing::Test {
+protected:
+    QueryHistory history{kBenchCount};
+
+    void SetUp() override {
+        for (size_t i = 0; i < kBenchCount; ++i) {
+            HistoryItem item;
+            item.id = generateHistoryId();
+            item.sql = std::format("SELECT col_{} FROM tbl_{} WHERE id = {}", i, i % 100, i);
+            item.success = true;
+            history.add(item);
+        }
+    }
+
+    static std::chrono::milliseconds measureSearch(QueryHistory& h, std::string_view keyword) {
+        const auto start = std::chrono::steady_clock::now();
+        const auto results = h.search(keyword);
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        // 結果が空でも測定は有効。NoMatch ケース用。
+        (void)results;
+        return std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
+    }
+};
+
+TEST_F(QueryHistorySearchBench, ShortKeywordUnder100ms) {
+    // 5 文字: trigram 3 個。selectivity が高い posting (col_5) を起点に絞られる想定。
+    const auto results = history.search("col_5");
+    EXPECT_FALSE(results.empty());
+
+    const auto elapsed = measureSearch(history, "col_5");
+    EXPECT_LT(elapsed, SEARCH_TARGET) << "search('col_5') took " << elapsed.count() << "ms";
+}
+
+TEST_F(QueryHistorySearchBench, MediumKeywordUnder100ms) {
+    // 10 文字: trigram 8 個。長いほど候補が絞られる。
+    const auto results = history.search("tbl_50 WHE");
+    EXPECT_FALSE(results.empty());
+
+    const auto elapsed = measureSearch(history, "tbl_50 WHE");
+    EXPECT_LT(elapsed, SEARCH_TARGET) << "search('tbl_50 WHE') took " << elapsed.count() << "ms";
+}
+
+TEST_F(QueryHistorySearchBench, LongKeywordUnder100ms) {
+    // 21 文字: trigram 19 個。さらに絞り込まれる。
+    const auto kw = std::string("col_500 FROM tbl_0 WH");
+    const auto results = history.search(kw);
+    EXPECT_FALSE(results.empty());
+
+    const auto elapsed = measureSearch(history, kw);
+    EXPECT_LT(elapsed, SEARCH_TARGET) << "search('" << kw << "') took " << elapsed.count() << "ms";
+}
+
+TEST_F(QueryHistorySearchBench, NoMatchUnder100ms) {
+    // 完全不一致: 1 個でも posting に欠ける trigram があれば早期 return で 0 件。
+    const auto kw = std::string("ZZZZQQQQXXXX");
+    const auto elapsed = measureSearch(history, kw);
+    EXPECT_LT(elapsed, SEARCH_TARGET) << "search('" << kw << "') took " << elapsed.count() << "ms";
+}
+
+}  // namespace
+}  // namespace velocitydb

--- a/tests/providers/test_settings_provider.cpp
+++ b/tests/providers/test_settings_provider.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <format>
+
 #include "database/query_history.h"
 #include "providers/settings_provider.h"
 #include "utils/session_manager.h"
@@ -10,15 +12,22 @@ namespace {
 
 class SettingsProviderTest : public ::testing::Test {
 protected:
-    // settings.json は %LOCALAPPDATA%\Velocity-DB\ に永続化されるため、
-    // 過去のテスト実行で書き込まれた maxQueryHistory が次回テストに残留する。
-    // SetUp で大きいデフォルトに戻し、各テストを永続化状態から独立させる。
+    // settings.json は %LOCALAPPDATA%\Velocity-DB\ に永続化されるため、テスト間および
+    // ユーザー設定との state リークを防ぐ。SetUp で元の maxQueryHistory を退避してから
+    // 1000 にリセット、TearDown で退避値に復元する (ユーザー設定を破壊しない)。
     void SetUp() override {
+        m_savedMaxQueryHistory = provider.settingsManager().getSettings().general.maxQueryHistory;
         auto resetResult = provider.updateSettings(R"({"general":{"maxQueryHistory":1000}})");
         ASSERT_NE(resetResult.find("\"saved\""), std::string::npos);
     }
 
+    void TearDown() override {
+        const auto restoreJson = std::format(R"({{"general":{{"maxQueryHistory":{}}}}})", m_savedMaxQueryHistory);
+        (void)provider.updateSettings(restoreJson);
+    }
+
     SettingsProvider provider;
+    int m_savedMaxQueryHistory = 1000;
 };
 
 TEST_F(SettingsProviderTest, AccessSettingsManager) {

--- a/tests/providers/test_settings_provider.cpp
+++ b/tests/providers/test_settings_provider.cpp
@@ -10,6 +10,14 @@ namespace {
 
 class SettingsProviderTest : public ::testing::Test {
 protected:
+    // settings.json は %LOCALAPPDATA%\Velocity-DB\ に永続化されるため、
+    // 過去のテスト実行で書き込まれた maxQueryHistory が次回テストに残留する。
+    // SetUp で大きいデフォルトに戻し、各テストを永続化状態から独立させる。
+    void SetUp() override {
+        auto resetResult = provider.updateSettings(R"({"general":{"maxQueryHistory":1000}})");
+        ASSERT_NE(resetResult.find("\"saved\""), std::string::npos);
+    }
+
     SettingsProvider provider;
 };
 


### PR DESCRIPTION
README #10 「クエリ履歴検索 (1 万件) < 100ms」達成のため、search() の線形 substring 走査 (O(n*m)) を trigram (n=3) inverted index に置換した。

実装の要点:
- trigram キー: std::array<char,3>、posting: std::unordered_set<const HistoryItem*> → insert/erase/lookup を per-op O(1) に維持
- UTF-8 byte 単位 sliding window (lead byte 限定なし、対称性優先)、偽陽性は最終 substring 検証で除外
- ASCII のみ lowercase 折りたたみ (実装方針: 標準ライブラリ完結)
- 短語 (< 3 byte) は線形 fallback、絶対値で十分高速
- search 結果は m_history 順走査で LRU 順 (newest first) 保持
- buildUniqueTrigrams は unordered_set 重複排除で O(L) per call

検証 (Release):
- backend test: 312/312 PASS
- bench (1 万件 search × 4 ケース): 全 < 100ms PASS
- lint: ALL LINTS PASSED

例外対応 (1 PR=1 機能の例外、ユーザー承認):
- tests/providers/test_settings_provider.cpp の SetUp/TearDown を追加。
  PR #427 で追加された 2 テストが %LOCALAPPDATA%\\Velocity-DB\\settings.json を共有する永続化リーク bug を、
  本 PR で新たに 12 件の Search* テストを追加したことで gtest テスト ID 順序がシフトし顕在化させた。
  CI 通過のため同 PR でカバー。

Closes #424