### PR TITLE
fix(ci): GitHub context を env: 経由で shell injection を解消 (#433, #430)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,9 +57,11 @@ jobs:
             cmake-bench-${{ runner.os }}-${{ inputs.build_type }}-
 
       - name: Configure CMake
+        env:
+          BUILD_TYPE: ${{ inputs.build_type }}
         run: |
           cmake -B build -G Ninja `
-            -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} `
+            -DCMAKE_BUILD_TYPE=$env:BUILD_TYPE `
             -DBUILD_TESTS=ON `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,9 +97,11 @@ jobs:
           path: dist
 
       - name: Create ZIP
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           cd dist
-          zip -r ../Velocity-DB-${{ github.ref_name }}.zip .
+          zip -r "../Velocity-DB-${REF_NAME}.zip" .
 
       - name: Create Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary

- Semgrep ルール \`yaml.github-actions.security.run-shell-injection\` の指摘 2 件を修正
- \`release.yml\`: \`Create ZIP\` step の \`\${{ github.ref_name }}\` を \`env: REF_NAME\` 経由化
- \`bench.yml\`: \`Configure CMake\` step の \`\${{ inputs.build_type }}\` を \`env: BUILD_TYPE\` 経由化

## Test plan

- [x] actionlint で構文 OK 確認済み
- [x] bash での \`\$REF_NAME\` 展開動作確認済み
- [ ] PR merge 後の Semgrep 再スキャンで再検出されないこと
- [ ] \`gh workflow run bench.yml -f build_type=Release\` で CMake が正常に configure されること

Closes #433
Closes #430