### PR TITLE
fix(backend): sqruff の parse error (code:null + "Unparsable section") を検出

### DIFF
--- a/backend/parsers/sql_linter.cpp
+++ b/backend/parsers/sql_linter.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <format>
 #include <memory>
+#include <optional>
 
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -69,6 +70,41 @@ using UniqueHandle = std::unique_ptr<void, HandleCloser>;
     return std::filesystem::path(buf).parent_path();
 }
 
+/// Convert one sqruff JSON diagnostic entry into LintDiagnostic, filtering to parse errors only.
+/// Returns std::nullopt for non-parse-error diagnostics (lint warnings).
+[[nodiscard]] std::optional<LintDiagnostic> parseDiagnosticEntry(simdjson::dom::element entry) {
+    constexpr std::string_view UNPARSABLE_MESSAGE = "Unparsable section";
+
+    auto codeRes = entry["code"].get_string();
+    std::string code = codeRes.error() ? std::string{} : std::string(codeRes.value());
+
+    const bool isPrsCode = code.starts_with("PRS");
+    // 採用候補は (a) PRS prefix code または (b) 空 code (Unparsable 候補)。
+    // 非 PRS の通常 lint code (LT02/CP01 等) はここで早期破棄し message 取得を省く。
+    if (!isPrsCode && !code.empty())
+        return std::nullopt;
+
+    std::string message;
+    if (auto msg = entry["message"].get_string(); !msg.error())
+        message.assign(msg.value().data(), msg.value().size());
+
+    const bool isUnparsable = code.empty() && message == UNPARSABLE_MESSAGE;
+    if (!isPrsCode && !isUnparsable)
+        return std::nullopt;
+
+    LintDiagnostic d;
+    d.code = std::move(code);
+    d.message = std::move(message);
+
+    auto rangeObj = entry["range"]["start"];
+    if (auto ln = rangeObj["line"].get_int64(); !ln.error())
+        d.line = std::max<int>(1, static_cast<int>(ln.value()));
+    if (auto col = rangeObj["character"].get_int64(); !col.error())
+        d.column = std::max<int>(1, static_cast<int>(col.value()));
+
+    return d;
+}
+
 }  // namespace
 
 std::string mapDialectToSqruff(std::string_view dbType) {
@@ -111,30 +147,15 @@ std::expected<std::vector<LintDiagnostic>, std::string> parseSqruffJson(std::str
     if (obj.error())
         return std::unexpected("sqruff JSON top-level is not an object");
 
+    // sqruff 0.38 では parse error に rule code を付けず "Unparsable section" message + code:null で出力する。
+    // 一方で sqlfluff 互換の PRS* code が将来採用される可能性に備え両形式を受理する (parseDiagnosticEntry 参照)。
     for (auto [_, value] : obj.value()) {
         auto arr = value.get_array();
         if (arr.error())
             continue;
         for (auto entry : arr.value()) {
-            auto codeRes = entry["code"].get_string();
-            std::string code = codeRes.error() ? std::string{} : std::string(codeRes.value());
-            // Filter: only parse-error rule codes (PRS*) are actionable blockers.
-            if (code.size() < 3 || code.substr(0, 3) != "PRS")
-                continue;
-
-            LintDiagnostic d;
-            d.code = std::move(code);
-
-            if (auto msg = entry["message"].get_string(); !msg.error())
-                d.message.assign(msg.value().data(), msg.value().size());
-
-            auto rangeObj = entry["range"]["start"];
-            if (auto ln = rangeObj["line"].get_int64(); !ln.error())
-                d.line = std::max<int>(1, static_cast<int>(ln.value()));
-            if (auto col = rangeObj["character"].get_int64(); !col.error())
-                d.column = std::max<int>(1, static_cast<int>(col.value()));
-
-            diagnostics.push_back(std::move(d));
+            if (auto d = parseDiagnosticEntry(entry))
+                diagnostics.push_back(std::move(*d));
         }
     }
     return diagnostics;

--- a/backend/parsers/sql_linter.h
+++ b/backend/parsers/sql_linter.h
@@ -40,8 +40,10 @@ struct SqlLinterConfig {
 /// Returns empty string for unsupported dbType.
 [[nodiscard]] std::string mapDialectToSqruff(std::string_view dbType);
 
-/// Parse sqruff JSON output ({"<path>":[Diagnostic,...]}) and filter to PRS-prefixed rule codes.
-/// The rest of diagnostics (non-parse-errors) are discarded even if sqruff emits them.
+/// Parse sqruff JSON output ({"<path>":[Diagnostic,...]}) and filter to parse errors only.
+/// Accepted entries: (a) code starts with "PRS" (sqlfluff-compat), or
+///                   (b) code is null/missing AND message == "Unparsable section" (sqruff 0.38 native).
+/// All other diagnostics (non-parse-errors) are discarded even if sqruff emits them.
 [[nodiscard]] std::expected<std::vector<LintDiagnostic>, std::string> parseSqruffJson(std::string_view json);
 
 /// Spawn sqruff.exe with the given SQL passed on stdin and return raw stdout JSON.
@@ -54,7 +56,7 @@ struct SqlLinterConfig {
 /// Default config path: <module dir>/config/sqruff/.sqruff
 [[nodiscard]] std::filesystem::path defaultSqruffConfig();
 
-/// High-level convenience: invoke sqruff, parse JSON, filter to PRS.
+/// High-level convenience: invoke sqruff, parse JSON, filter to parse errors (PRS or Unparsable section).
 /// Returns empty vector when SQL has no parse errors.
 [[nodiscard]] std::expected<std::vector<LintDiagnostic>, LintError> lintSqlForParseErrors(const SqlLinterConfig& cfg, std::string_view sql, std::string_view dialect);
 

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -107,10 +107,13 @@ export function createExecuteSlice(
         log.warning(`[queryExecuteSlice] lint unavailable: ${result.reason ?? 'unknown'}`);
         return null;
       }
-      // backend側で既にPRSのみに絞り込み済み。diagnostics破損時の保険として再確認
-      const prs = result.diagnostics.filter((d) => d.code.startsWith('PRS'));
-      if (prs.length === 0) return null;
-      const markers: SqlMarkerInput[] = prs.map((d) => ({
+      // backend 側で parse error のみに絞り込み済み (PRS prefix or "Unparsable section")。
+      // diagnostics 破損時の保険として、採用条件 (PRS prefix or 空 code) を frontend でも再確認。
+      const parseErrors = result.diagnostics.filter(
+        (d) => d.code.startsWith('PRS') || d.code === ''
+      );
+      if (parseErrors.length === 0) return null;
+      const markers: SqlMarkerInput[] = parseErrors.map((d) => ({
         line: d.line,
         column: d.column,
         code: d.code,

--- a/tests/parsers/test_sql_linter.cpp
+++ b/tests/parsers/test_sql_linter.cpp
@@ -93,13 +93,60 @@ TEST(ParseSqruffJsonTest, MultipleFilesFlattened) {
     EXPECT_EQ(msgs, (std::set<std::string>{"m1", "m2"}));
 }
 
-TEST(ParseSqruffJsonTest, MissingCodeFieldIsDiscarded) {
-    // A diagnostic without "code" cannot be classified as PRS, so the filter discards it.
-    // Regression guard: if sqruff ever emits code-less entries we keep fail-closed on them.
-    std::string json = R"({"stdin":[{"message":"m","range":{"start":{"line":1,"character":1}}}]})";
+TEST(ParseSqruffJsonTest, MissingCodeWithUnparsableMessageIsAccepted) {
+    // sqruff (Rust移植版) は parse error に rule code を付けず "Unparsable section" message で出力する。
+    // code フィールド欠損でも message が一致すれば parse error として採用する。
+    std::string json = R"({"stdin":[{"message":"Unparsable section","range":{"start":{"line":1,"character":1}}}]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ((*result)[0].message, "Unparsable section");
+}
+
+TEST(ParseSqruffJsonTest, MissingCodeWithOtherMessageIsDiscarded) {
+    // code 欠損でも message が "Unparsable section" 以外なら lint warning として扱い捨てる。
+    std::string json = R"({"stdin":[{"message":"some style warning","range":{"start":{"line":1,"character":1}}}]})";
     auto result = parseSqruffJson(json);
     ASSERT_TRUE(result.has_value());
     EXPECT_TRUE(result->empty());
+}
+
+TEST(ParseSqruffJsonTest, NullCodeWithUnparsableMessageIsAccepted) {
+    // sqruff 0.38 の現実出力: code:null + message:"Unparsable section" を採用する。
+    std::string json = R"({"<string>":[{"range":{"start":{"line":1,"character":1},"end":{"line":1,"character":1}},"message":"Unparsable section","severity":"Warning","source":"sqruff","code":null}]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ((*result)[0].message, "Unparsable section");
+    EXPECT_EQ((*result)[0].line, 1);
+    EXPECT_EQ((*result)[0].column, 1);
+}
+
+TEST(ParseSqruffJsonTest, NullCodeNonUnparsableIsDiscarded) {
+    // code:null だが message が Unparsable section でないものは parse error 判定しない (誤検出防止)。
+    std::string json = R"({"stdin":[{"range":{"start":{"line":1,"character":1}},"message":"random warning","severity":"Warning","code":null}]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->empty());
+}
+
+TEST(ParseSqruffJsonTest, RealSqruff038OutputMixedLintAndParseError) {
+    // sqruff 0.38.0 実機出力 (printf 'SELECT *\nFROM users\nWHRE id = 1\n' | sqruff lint - --dialect postgres --format json --parsing-errors)
+    // lint warning (LT02/AL05/CP02) は捨て、line:3,character:6 の parse error 1 件のみ採用。
+    std::string json = R"({"<string>":[
+        {"range":{"start":{"line":2,"character":5},"end":{"line":2,"character":5}},"message":"Expected line break and indent of 4 spaces before \"users\".","severity":"Warning","source":"sqruff","code":"LT02"},
+        {"range":{"start":{"line":3,"character":1},"end":{"line":3,"character":1}},"message":"Alias 'WHRE' is never used in SELECT statement.","severity":"Warning","source":"sqruff","code":"AL05"},
+        {"range":{"start":{"line":3,"character":1},"end":{"line":3,"character":1}},"message":"Unquoted identifiers must be consistently lower case.","severity":"Warning","source":"sqruff","code":"CP02"},
+        {"range":{"start":{"line":3,"character":1},"end":{"line":3,"character":1}},"message":"Expected indent of 4 spaces","severity":"Warning","source":"sqruff","code":"LT02"},
+        {"range":{"start":{"line":3,"character":5},"end":{"line":3,"character":5}},"message":"Expected line break and no indent before \"id\".","severity":"Warning","source":"sqruff","code":"LT02"},
+        {"range":{"start":{"line":3,"character":6},"end":{"line":3,"character":6}},"message":"Unparsable section","severity":"Warning","source":"sqruff","code":null}
+    ]})";
+    auto result = parseSqruffJson(json);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ((*result)[0].line, 3);
+    EXPECT_EQ((*result)[0].column, 6);
+    EXPECT_EQ((*result)[0].message, "Unparsable section");
 }
 
 TEST(ParseSqruffJsonTest, MalformedJsonReturnsError) {


### PR DESCRIPTION
sqruff 0.38 (Rust 移植版) は parse error に rule code を付けず `code:null` + `message:"Unparsable section"` で出力するため、
既存の `code.startsWith("PRS")` フィルタでは parse error をすべて捨てており、SQL 構文エラー検出機能 (#362) が現行 sqruff バイナリで機能していなかった。

- parseSqruffJson: 空 code + "Unparsable section" message を採用条件に追加(sqlfluff 互換 PRS* code もそのまま受理)
- parseDiagnosticEntry: anonymous namespace に entry 解析を関数抽出 (ネスト軽減)
- starts_with("PRS") への置換 (C++20 イディオム)
- frontend: `PRS prefix or 空 code` で defense-in-depth フィルタを維持
- tests: 5 件追加 (Missing/Null code パターン + sqruff 0.38 実機出力)
- header コメントを実装 (両形式受理) と整合

Closes #431