### PR TITLE
refactor(frontend): useConnectionProfile を useReducer 化 (#406)

### DIFF
--- a/frontend/src/components/dialogs/hooks/useConnectionProfile.reducer.ts
+++ b/frontend/src/components/dialogs/hooks/useConnectionProfile.reducer.ts
@@ -1,0 +1,201 @@
+import type { EnvironmentType, SavedConnectionProfile } from '../../../types';
+import type { ConnectionConfig, SshConfig } from '../ConnectionDialog';
+
+export type ProfileMode = 'new' | 'edit';
+
+export const DEFAULT_SSH_CONFIG: SshConfig = {
+  enabled: false,
+  host: '',
+  port: 22,
+  username: '',
+  authType: 'password',
+  password: '',
+  privateKeyPath: '',
+  keyPassphrase: '',
+};
+
+export const DEFAULT_CONFIG: ConnectionConfig = {
+  name: 'New Connection',
+  server: 'localhost',
+  port: 1433,
+  database: 'master',
+  username: '',
+  password: '',
+  useWindowsAuth: true,
+  isProduction: false,
+  isReadOnly: false,
+  environment: 'development',
+  dbType: 'sqlserver',
+  folderPath: '',
+  ssh: { ...DEFAULT_SSH_CONFIG },
+};
+
+export interface ProfileFormState {
+  profiles: SavedConnectionProfile[];
+  mode: ProfileMode;
+  editingProfileId: string | null;
+  savePassword: boolean;
+  config: ConnectionConfig;
+  testResult: { success: boolean; message: string } | null;
+  deleteConfirmOpen: boolean;
+}
+
+export const initialProfileFormState: ProfileFormState = {
+  profiles: [],
+  mode: 'new',
+  editingProfileId: null,
+  savePassword: false,
+  config: { ...DEFAULT_CONFIG, ssh: { ...DEFAULT_SSH_CONFIG } },
+  testResult: null,
+  deleteConfirmOpen: false,
+};
+
+type SetStateValue<T> = T | ((prev: T) => T);
+
+export type ProfileFormAction =
+  | { type: 'SET_PROFILES'; payload: SavedConnectionProfile[] }
+  | { type: 'REMOVE_PROFILE'; payload: string }
+  | {
+      type: 'PROFILE_SAVED';
+      payload:
+        | { profile: SavedConnectionProfile; isNew: true; message: string }
+        | {
+            profile: SavedConnectionProfile;
+            isNew: false;
+            previousId: string;
+            message: string;
+          };
+    }
+  | { type: 'SELECT_PROFILE'; payload: { profile: SavedConnectionProfile; password: string } }
+  | { type: 'NEW_PROFILE' }
+  | { type: 'COPY_PROFILE' }
+  | { type: 'SET_CONFIG'; payload: SetStateValue<ConnectionConfig> }
+  | { type: 'SET_SAVE_PASSWORD'; payload: SetStateValue<boolean> }
+  | {
+      type: 'SET_TEST_RESULT';
+      payload: SetStateValue<{ success: boolean; message: string } | null>;
+    }
+  | { type: 'OPEN_DELETE_CONFIRM' }
+  | { type: 'CLOSE_DELETE_CONFIRM' };
+
+// SavedConnectionProfile.environment は optional (旧バージョン保存データには存在しない)。
+// 旧データは isProduction から environment を推定して後方互換性を担保する。
+function inferEnvironment(profile: SavedConnectionProfile): EnvironmentType {
+  if (profile.environment) return profile.environment;
+  return profile.isProduction ? 'production' : 'development';
+}
+
+function buildConfigFromProfile(
+  profile: SavedConnectionProfile,
+  password: string
+): ConnectionConfig {
+  return {
+    name: profile.name,
+    server: profile.server,
+    port: profile.port,
+    database: profile.database,
+    username: profile.username,
+    password,
+    useWindowsAuth: profile.useWindowsAuth,
+    isProduction: profile.isProduction,
+    isReadOnly: profile.isReadOnly,
+    environment: inferEnvironment(profile),
+    dbType: profile.dbType ?? 'sqlserver',
+    folderPath: profile.folderPath ?? '',
+    ssh: profile.ssh
+      ? {
+          enabled: profile.ssh.enabled,
+          host: profile.ssh.host,
+          port: profile.ssh.port,
+          username: profile.ssh.username,
+          authType: profile.ssh.authType,
+          password: '',
+          privateKeyPath: profile.ssh.privateKeyPath,
+          keyPassphrase: '',
+        }
+      : { ...DEFAULT_SSH_CONFIG },
+  };
+}
+
+function resolveSetStateValue<T>(payload: SetStateValue<T>, prev: T): T {
+  return typeof payload === 'function' ? (payload as (p: T) => T)(prev) : payload;
+}
+
+export function profileFormReducer(
+  state: ProfileFormState,
+  action: ProfileFormAction
+): ProfileFormState {
+  switch (action.type) {
+    case 'SET_PROFILES':
+      return { ...state, profiles: action.payload };
+
+    case 'REMOVE_PROFILE':
+      return {
+        ...state,
+        profiles: state.profiles.filter((p) => p.id !== action.payload),
+      };
+
+    case 'PROFILE_SAVED': {
+      const payload = action.payload;
+      const profiles = payload.isNew
+        ? [...state.profiles, payload.profile]
+        : state.profiles.map((p) => (p.id === payload.previousId ? payload.profile : p));
+      return {
+        ...state,
+        profiles,
+        mode: 'edit',
+        editingProfileId: payload.profile.id,
+        testResult: { success: true, message: payload.message },
+      };
+    }
+
+    case 'SELECT_PROFILE': {
+      const { profile, password } = action.payload;
+      return {
+        ...state,
+        config: buildConfigFromProfile(profile, password),
+        savePassword: profile.savePassword,
+        testResult: null,
+        mode: 'edit',
+        editingProfileId: profile.id,
+      };
+    }
+
+    case 'NEW_PROFILE':
+      return {
+        ...state,
+        mode: 'new',
+        editingProfileId: null,
+        config: { ...DEFAULT_CONFIG, ssh: { ...DEFAULT_SSH_CONFIG } },
+        savePassword: false,
+        testResult: null,
+      };
+
+    case 'COPY_PROFILE':
+      return {
+        ...state,
+        mode: 'new',
+        editingProfileId: null,
+        config: { ...state.config, name: `${state.config.name} (Copy)` },
+        testResult: null,
+      };
+
+    case 'SET_CONFIG':
+      return { ...state, config: resolveSetStateValue(action.payload, state.config) };
+
+    case 'SET_SAVE_PASSWORD':
+      return {
+        ...state,
+        savePassword: resolveSetStateValue(action.payload, state.savePassword),
+      };
+
+    case 'SET_TEST_RESULT':
+      return { ...state, testResult: resolveSetStateValue(action.payload, state.testResult) };
+
+    case 'OPEN_DELETE_CONFIRM':
+      return { ...state, deleteConfirmOpen: true };
+
+    case 'CLOSE_DELETE_CONFIRM':
+      return { ...state, deleteConfirmOpen: false };
+  }
+}

--- a/frontend/src/components/dialogs/hooks/useConnectionProfile.ts
+++ b/frontend/src/components/dialogs/hooks/useConnectionProfile.ts
@@ -1,43 +1,53 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { bridge } from '../../../api/bridge';
 import { useConnectionStore } from '../../../store/connectionStore';
 import {
-  type EnvironmentType,
   isDatabaseType,
   isEnvironmentType,
   isSshAuthType,
   type SavedConnectionProfile,
 } from '../../../types';
-import type { ConnectionConfig, SshConfig } from '../ConnectionDialog';
+import type { ConnectionConfig } from '../ConnectionDialog';
+import {
+  initialProfileFormState,
+  type ProfileMode,
+  profileFormReducer,
+} from './useConnectionProfile.reducer';
 
-export type ProfileMode = 'new' | 'edit';
+type BridgeProfile = Awaited<ReturnType<typeof bridge.getConnectionProfiles>>['profiles'][number];
 
-const DEFAULT_SSH_CONFIG: SshConfig = {
-  enabled: false,
-  host: '',
-  port: 22,
-  username: '',
-  authType: 'password',
-  password: '',
-  privateKeyPath: '',
-  keyPassphrase: '',
-};
-
-const DEFAULT_CONFIG: ConnectionConfig = {
-  name: 'New Connection',
-  server: 'localhost',
-  port: 1433,
-  database: 'master',
-  username: '',
-  password: '',
-  useWindowsAuth: true,
-  isProduction: false,
-  isReadOnly: false,
-  environment: 'development',
-  dbType: 'sqlserver',
-  folderPath: '',
-  ssh: { ...DEFAULT_SSH_CONFIG },
-};
+function normalizeProfile(p: BridgeProfile): SavedConnectionProfile {
+  return {
+    id: p.id,
+    name: p.name,
+    server: p.server,
+    port: p.port ?? 1433,
+    database: p.database,
+    username: p.username,
+    useWindowsAuth: p.useWindowsAuth,
+    savePassword: p.savePassword ?? false,
+    isProduction: p.isProduction ?? false,
+    isReadOnly: p.isReadOnly ?? false,
+    environment: isEnvironmentType(p.environment ?? '')
+      ? p.environment
+      : p.isProduction
+        ? 'production'
+        : 'development',
+    dbType: isDatabaseType(p.dbType ?? '') ? p.dbType : 'sqlserver',
+    folderPath: p.folderPath ?? '',
+    ssh: p.ssh
+      ? {
+          enabled: p.ssh.enabled ?? false,
+          host: p.ssh.host ?? '',
+          port: p.ssh.port ?? 22,
+          username: p.ssh.username ?? '',
+          authType: isSshAuthType(p.ssh.authType ?? '') ? p.ssh.authType : 'password',
+          privateKeyPath: p.ssh.privateKeyPath ?? '',
+          savePassword: p.ssh.savePassword ?? false,
+        }
+      : undefined,
+  };
+}
 
 interface UseConnectionProfileResult {
   profiles: SavedConnectionProfile[];
@@ -60,13 +70,9 @@ interface UseConnectionProfileResult {
 }
 
 export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResult {
-  const [profiles, setProfiles] = useState<SavedConnectionProfile[]>([]);
-  const [mode, setMode] = useState<ProfileMode>('new');
-  const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
-  const [savePassword, setSavePassword] = useState(false);
-  const [config, setConfig] = useState<ConnectionConfig>({ ...DEFAULT_CONFIG });
-  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [state, dispatch] = useReducer(profileFormReducer, initialProfileFormState);
+  const { profiles, mode, editingProfileId, savePassword, config, testResult, deleteConfirmOpen } =
+    state;
 
   const loadingProfileIdRef = useRef<string | null>(null);
   const operationCounterRef = useRef(0);
@@ -74,6 +80,20 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
   const editingProfileIdRef = useRef(editingProfileId);
   modeRef.current = mode;
   editingProfileIdRef.current = editingProfileId;
+
+  const setConfig = useCallback<React.Dispatch<React.SetStateAction<ConnectionConfig>>>((value) => {
+    dispatch({ type: 'SET_CONFIG', payload: value });
+  }, []);
+
+  const setSavePassword = useCallback<React.Dispatch<React.SetStateAction<boolean>>>((value) => {
+    dispatch({ type: 'SET_SAVE_PASSWORD', payload: value });
+  }, []);
+
+  const setTestResult = useCallback<
+    React.Dispatch<React.SetStateAction<{ success: boolean; message: string } | null>>
+  >((value) => {
+    dispatch({ type: 'SET_TEST_RESULT', payload: value });
+  }, []);
 
   const loadProfile = useCallback(async (profile: SavedConnectionProfile, operationId: number) => {
     loadingProfileIdRef.current = profile.id;
@@ -93,52 +113,13 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
 
     if (operationCounterRef.current !== operationId) return;
 
-    // isProductionからenvironmentを推定（後方互換性）
-    const inferEnvironment = (p: SavedConnectionProfile): EnvironmentType => {
-      if (p.environment) return p.environment;
-      return p.isProduction ? 'production' : 'development';
-    };
-
-    setConfig({
-      name: profile.name,
-      server: profile.server,
-      port: profile.port,
-      database: profile.database,
-      username: profile.username,
-      password,
-      useWindowsAuth: profile.useWindowsAuth,
-      isProduction: profile.isProduction,
-      isReadOnly: profile.isReadOnly,
-      environment: inferEnvironment(profile),
-      dbType: profile.dbType ?? 'sqlserver',
-      folderPath: profile.folderPath ?? '',
-      ssh: profile.ssh
-        ? {
-            enabled: profile.ssh.enabled,
-            host: profile.ssh.host,
-            port: profile.ssh.port,
-            username: profile.ssh.username,
-            authType: profile.ssh.authType,
-            password: '',
-            privateKeyPath: profile.ssh.privateKeyPath,
-            keyPassphrase: '',
-          }
-        : { ...DEFAULT_SSH_CONFIG },
-    });
-    setSavePassword(profile.savePassword);
-    setTestResult(null);
-    setMode('edit');
-    setEditingProfileId(profile.id);
+    dispatch({ type: 'SELECT_PROFILE', payload: { profile, password } });
   }, []);
 
   const handleNewProfile = useCallback(() => {
     operationCounterRef.current += 1;
     loadingProfileIdRef.current = null;
-    setMode('new');
-    setEditingProfileId(null);
-    setConfig({ ...DEFAULT_CONFIG });
-    setSavePassword(false);
-    setTestResult(null);
+    dispatch({ type: 'NEW_PROFILE' });
   }, []);
 
   // Load profiles from backend when dialog opens
@@ -152,37 +133,8 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
       .then((result) => {
         if (operationCounterRef.current !== currentOperationId) return;
 
-        const loaded: SavedConnectionProfile[] = result.profiles.map((p) => ({
-          id: p.id,
-          name: p.name,
-          server: p.server,
-          port: p.port ?? 1433,
-          database: p.database,
-          username: p.username,
-          useWindowsAuth: p.useWindowsAuth,
-          savePassword: p.savePassword ?? false,
-          isProduction: p.isProduction ?? false,
-          isReadOnly: p.isReadOnly ?? false,
-          environment: isEnvironmentType(p.environment ?? '')
-            ? p.environment
-            : p.isProduction
-              ? 'production'
-              : 'development',
-          dbType: isDatabaseType(p.dbType ?? '') ? p.dbType : 'sqlserver',
-          folderPath: p.folderPath ?? '',
-          ssh: p.ssh
-            ? {
-                enabled: p.ssh.enabled ?? false,
-                host: p.ssh.host ?? '',
-                port: p.ssh.port ?? 22,
-                username: p.ssh.username ?? '',
-                authType: isSshAuthType(p.ssh.authType ?? '') ? p.ssh.authType : 'password',
-                privateKeyPath: p.ssh.privateKeyPath ?? '',
-                savePassword: p.ssh.savePassword ?? false,
-              }
-            : undefined,
-        }));
-        setProfiles(loaded);
+        const loaded = result.profiles.map(normalizeProfile);
+        dispatch({ type: 'SET_PROFILES', payload: loaded });
 
         // Auto-select first profile if in new mode
         if (
@@ -191,63 +143,13 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
           editingProfileIdRef.current === null
         ) {
           const newOperationId = ++operationCounterRef.current;
-          const profile = loaded[0];
-          loadingProfileIdRef.current = profile.id;
-
-          const loadPasswordAndSetConfig = async () => {
-            let password = '';
-            if (profile.savePassword) {
-              try {
-                const passwordResult = await bridge.getProfilePassword(profile.id);
-                if (operationCounterRef.current !== newOperationId) return;
-                if (passwordResult.password) {
-                  password = passwordResult.password;
-                }
-              } catch (e) {
-                console.error('Failed to load password:', e);
-              }
-            }
-            if (operationCounterRef.current !== newOperationId) return;
-
-            setConfig({
-              name: profile.name,
-              server: profile.server,
-              port: profile.port,
-              database: profile.database,
-              username: profile.username,
-              password,
-              useWindowsAuth: profile.useWindowsAuth,
-              isProduction: profile.isProduction,
-              isReadOnly: profile.isReadOnly,
-              environment:
-                profile.environment ?? (profile.isProduction ? 'production' : 'development'),
-              dbType: profile.dbType ?? 'sqlserver',
-              folderPath: profile.folderPath ?? '',
-              ssh: profile.ssh
-                ? {
-                    enabled: profile.ssh.enabled,
-                    host: profile.ssh.host,
-                    port: profile.ssh.port,
-                    username: profile.ssh.username,
-                    authType: profile.ssh.authType,
-                    password: '',
-                    privateKeyPath: profile.ssh.privateKeyPath,
-                    keyPassphrase: '',
-                  }
-                : { ...DEFAULT_SSH_CONFIG },
-            });
-            setSavePassword(profile.savePassword);
-            setTestResult(null);
-            setMode('edit');
-            setEditingProfileId(profile.id);
-          };
-          loadPasswordAndSetConfig();
+          loadProfile(loaded[0], newOperationId);
         }
       })
       .catch((e) => {
         console.error('Failed to load profiles:', e);
       });
-  }, [isOpen]);
+  }, [isOpen, loadProfile]);
 
   const handleProfileSelect = useCallback(
     (profileId: string) => {
@@ -324,36 +226,42 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
           : undefined,
       };
 
-      if (isNewProfile) {
-        setProfiles((prev) => [...prev, savedProfile]);
-      } else {
-        setProfiles((prev) => prev.map((p) => (p.id === currentEditingId ? savedProfile : p)));
-      }
-
-      setMode('edit');
-      setEditingProfileId(result.id);
-      setTestResult({ success: true, message: 'Profile saved' });
+      dispatch({
+        type: 'PROFILE_SAVED',
+        payload: isNewProfile
+          ? { profile: savedProfile, isNew: true, message: 'Profile saved' }
+          : {
+              profile: savedProfile,
+              isNew: false,
+              previousId: currentEditingId ?? savedProfile.id,
+              message: 'Profile saved',
+            },
+      });
       useConnectionStore.getState().incrementProfileVersion();
     } catch (e) {
       console.error('Failed to save profile:', e);
-      setTestResult({ success: false, message: 'Failed to save profile' });
+      dispatch({
+        type: 'SET_TEST_RESULT',
+        payload: { success: false, message: 'Failed to save profile' },
+      });
     }
   }, [config, mode, editingProfileId, savePassword]);
 
   const handleDeleteProfile = useCallback(() => {
     if (mode !== 'edit' || !editingProfileId) return;
-    setDeleteConfirmOpen(true);
+    dispatch({ type: 'OPEN_DELETE_CONFIRM' });
   }, [mode, editingProfileId]);
 
   const confirmDeleteProfile = useCallback(async () => {
-    setDeleteConfirmOpen(false);
+    dispatch({ type: 'CLOSE_DELETE_CONFIRM' });
     if (!editingProfileId) return;
 
     try {
       await bridge.deleteConnectionProfile(editingProfileId);
 
-      const updatedProfiles = profiles.filter((p) => p.id !== editingProfileId);
-      setProfiles(updatedProfiles);
+      const targetId = editingProfileId;
+      const updatedProfiles = profiles.filter((p) => p.id !== targetId);
+      dispatch({ type: 'REMOVE_PROFILE', payload: targetId });
       useConnectionStore.getState().incrementProfileVersion();
 
       if (updatedProfiles.length > 0) {
@@ -364,12 +272,15 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
       }
     } catch (e) {
       console.error('Failed to delete profile:', e);
-      setTestResult({ success: false, message: 'Failed to delete profile' });
+      dispatch({
+        type: 'SET_TEST_RESULT',
+        payload: { success: false, message: 'Failed to delete profile' },
+      });
     }
   }, [editingProfileId, profiles, handleNewProfile, loadProfile]);
 
   const cancelDeleteProfile = useCallback(() => {
-    setDeleteConfirmOpen(false);
+    dispatch({ type: 'CLOSE_DELETE_CONFIRM' });
   }, []);
 
   const handleCopyProfile = useCallback(() => {
@@ -377,10 +288,7 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
 
     operationCounterRef.current += 1;
     loadingProfileIdRef.current = null;
-    setMode('new');
-    setEditingProfileId(null);
-    setConfig((prev) => ({ ...prev, name: `${prev.name} (Copy)` }));
-    setTestResult(null);
+    dispatch({ type: 'COPY_PROFILE' });
   }, [mode, editingProfileId]);
 
   return {

--- a/frontend/src/tests/hooks/useConnectionProfile.reducer.test.ts
+++ b/frontend/src/tests/hooks/useConnectionProfile.reducer.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'vitest';
+import type { ConnectionConfig } from '../../components/dialogs/ConnectionDialog';
+import {
+  initialProfileFormState,
+  type ProfileFormState,
+  profileFormReducer,
+} from '../../components/dialogs/hooks/useConnectionProfile.reducer';
+import type { SavedConnectionProfile } from '../../types';
+
+function makeProfile(overrides: Partial<SavedConnectionProfile> = {}): SavedConnectionProfile {
+  return {
+    id: 'p1',
+    name: 'Profile 1',
+    server: 'host.example.com',
+    port: 1433,
+    database: 'TestDb',
+    username: 'user1',
+    useWindowsAuth: false,
+    savePassword: false,
+    isProduction: false,
+    isReadOnly: false,
+    environment: 'development',
+    dbType: 'sqlserver',
+    folderPath: '',
+    ssh: undefined,
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<ConnectionConfig> = {}): ConnectionConfig {
+  return {
+    name: 'C',
+    server: 's',
+    port: 1433,
+    database: 'd',
+    username: 'u',
+    password: 'p',
+    useWindowsAuth: false,
+    isProduction: false,
+    isReadOnly: false,
+    environment: 'development',
+    dbType: 'sqlserver',
+    folderPath: '',
+    ssh: {
+      enabled: false,
+      host: '',
+      port: 22,
+      username: '',
+      authType: 'password',
+      password: '',
+      privateKeyPath: '',
+      keyPassphrase: '',
+    },
+    ...overrides,
+  };
+}
+
+function stateWith(overrides: Partial<ProfileFormState> = {}): ProfileFormState {
+  return { ...initialProfileFormState, ...overrides };
+}
+
+describe('profileFormReducer', () => {
+  describe('initialProfileFormState', () => {
+    it('初期値は空配列・new モード・editingProfileId null', () => {
+      expect(initialProfileFormState.profiles).toEqual([]);
+      expect(initialProfileFormState.mode).toBe('new');
+      expect(initialProfileFormState.editingProfileId).toBeNull();
+      expect(initialProfileFormState.savePassword).toBe(false);
+      expect(initialProfileFormState.testResult).toBeNull();
+      expect(initialProfileFormState.deleteConfirmOpen).toBe(false);
+      expect(initialProfileFormState.config.name).toBe('New Connection');
+      expect(initialProfileFormState.config.dbType).toBe('sqlserver');
+      expect(initialProfileFormState.config.ssh.enabled).toBe(false);
+    });
+  });
+
+  describe('SET_PROFILES', () => {
+    it('profiles を payload で完全置換し、他フィールドは不変', () => {
+      const prev = stateWith({ mode: 'edit', editingProfileId: 'old' });
+      const profiles = [makeProfile({ id: 'a' }), makeProfile({ id: 'b' })];
+      const next = profileFormReducer(prev, { type: 'SET_PROFILES', payload: profiles });
+      expect(next.profiles).toEqual(profiles);
+      expect(next.mode).toBe('edit');
+      expect(next.editingProfileId).toBe('old');
+    });
+  });
+
+  describe('REMOVE_PROFILE', () => {
+    it('id 一致の要素のみ削除', () => {
+      const prev = stateWith({
+        profiles: [makeProfile({ id: 'a' }), makeProfile({ id: 'b' }), makeProfile({ id: 'c' })],
+      });
+      const next = profileFormReducer(prev, { type: 'REMOVE_PROFILE', payload: 'b' });
+      expect(next.profiles.map((p) => p.id)).toEqual(['a', 'c']);
+    });
+  });
+
+  describe('PROFILE_SAVED', () => {
+    it('isNew=true なら profiles 末尾に追加し mode=edit / editingProfileId=profile.id / testResult に payload.message が反映', () => {
+      const prev = stateWith({
+        profiles: [makeProfile({ id: 'a' })],
+        mode: 'new',
+        editingProfileId: null,
+      });
+      const saved = makeProfile({ id: 'b', name: 'New Saved' });
+      const next = profileFormReducer(prev, {
+        type: 'PROFILE_SAVED',
+        payload: { profile: saved, isNew: true, message: 'Profile saved' },
+      });
+      expect(next.profiles.map((p) => p.id)).toEqual(['a', 'b']);
+      expect(next.mode).toBe('edit');
+      expect(next.editingProfileId).toBe('b');
+      expect(next.testResult).toEqual({ success: true, message: 'Profile saved' });
+    });
+
+    it('isNew=false なら previousId 一致を置換し mode=edit / editingProfileId=profile.id を維持', () => {
+      const prev = stateWith({
+        profiles: [makeProfile({ id: 'a', name: 'A' }), makeProfile({ id: 'b', name: 'B' })],
+        mode: 'edit',
+        editingProfileId: 'b',
+      });
+      const updated = makeProfile({ id: 'b', name: 'B-saved' });
+      const next = profileFormReducer(prev, {
+        type: 'PROFILE_SAVED',
+        payload: { profile: updated, isNew: false, previousId: 'b', message: 'Updated' },
+      });
+      expect(next.profiles[1].name).toBe('B-saved');
+      expect(next.mode).toBe('edit');
+      expect(next.editingProfileId).toBe('b');
+      expect(next.testResult).toEqual({ success: true, message: 'Updated' });
+    });
+
+    it('config は変更されない (UI 入力中の値を保持)', () => {
+      const userInput = makeConfig({ name: 'Editing in progress', server: 'typed-host' });
+      const prev = stateWith({ config: userInput, mode: 'new', editingProfileId: null });
+      const saved = makeProfile({ id: 'x' });
+      const next = profileFormReducer(prev, {
+        type: 'PROFILE_SAVED',
+        payload: { profile: saved, isNew: true, message: 'Saved' },
+      });
+      expect(next.config).toBe(userInput);
+    });
+  });
+
+  describe('SELECT_PROFILE', () => {
+    it('mode=edit / editingProfileId=profile.id / testResult=null に遷移', () => {
+      const prev = stateWith({
+        mode: 'new',
+        editingProfileId: null,
+        testResult: { success: true, message: 'x' },
+      });
+      const profile = makeProfile({ id: 'p1', savePassword: true });
+      const next = profileFormReducer(prev, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: 'secret' },
+      });
+      expect(next.mode).toBe('edit');
+      expect(next.editingProfileId).toBe('p1');
+      expect(next.testResult).toBeNull();
+    });
+
+    it('config に profile + password が反映される', () => {
+      const profile = makeProfile({
+        id: 'p1',
+        name: 'My Profile',
+        server: 'srv',
+        port: 5432,
+        database: 'mydb',
+        username: 'me',
+        useWindowsAuth: true,
+        isProduction: true,
+        isReadOnly: true,
+        environment: 'production',
+        dbType: 'postgresql',
+        folderPath: '/tmp/x',
+      });
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: 'pw' },
+      });
+      expect(next.config.name).toBe('My Profile');
+      expect(next.config.server).toBe('srv');
+      expect(next.config.port).toBe(5432);
+      expect(next.config.database).toBe('mydb');
+      expect(next.config.username).toBe('me');
+      expect(next.config.password).toBe('pw');
+      expect(next.config.useWindowsAuth).toBe(true);
+      expect(next.config.isProduction).toBe(true);
+      expect(next.config.isReadOnly).toBe(true);
+      expect(next.config.environment).toBe('production');
+      expect(next.config.dbType).toBe('postgresql');
+      expect(next.config.folderPath).toBe('/tmp/x');
+    });
+
+    it('savePassword は profile.savePassword を反映', () => {
+      const profile = makeProfile({ savePassword: true });
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: 'pw' },
+      });
+      expect(next.savePassword).toBe(true);
+    });
+
+    it('environment 未指定 + isProduction=true なら production に推定', () => {
+      const profile = makeProfile({ isProduction: true });
+      // environment を未指定にする (型上は optional)
+      profile.environment = undefined;
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: '' },
+      });
+      expect(next.config.environment).toBe('production');
+    });
+
+    it('environment 未指定 + isProduction=false なら development に推定', () => {
+      const profile = makeProfile({ isProduction: false });
+      profile.environment = undefined;
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: '' },
+      });
+      expect(next.config.environment).toBe('development');
+    });
+
+    it('dbType 未指定なら sqlserver にフォールバック', () => {
+      const profile = makeProfile();
+      profile.dbType = undefined;
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: '' },
+      });
+      expect(next.config.dbType).toBe('sqlserver');
+    });
+
+    it('ssh 未設定なら DEFAULT_SSH_CONFIG を使用', () => {
+      const profile = makeProfile({ ssh: undefined });
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: '' },
+      });
+      expect(next.config.ssh.enabled).toBe(false);
+      expect(next.config.ssh.host).toBe('');
+      expect(next.config.ssh.port).toBe(22);
+      expect(next.config.ssh.authType).toBe('password');
+    });
+
+    it('ssh 設定ありなら profile.ssh を反映 (password / keyPassphrase は空)', () => {
+      const profile = makeProfile({
+        ssh: {
+          enabled: true,
+          host: 'jump.example',
+          port: 2222,
+          username: 'sshuser',
+          authType: 'privateKey',
+          privateKeyPath: '/keys/id',
+          savePassword: false,
+        },
+      });
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SELECT_PROFILE',
+        payload: { profile, password: '' },
+      });
+      expect(next.config.ssh.enabled).toBe(true);
+      expect(next.config.ssh.host).toBe('jump.example');
+      expect(next.config.ssh.port).toBe(2222);
+      expect(next.config.ssh.username).toBe('sshuser');
+      expect(next.config.ssh.authType).toBe('privateKey');
+      expect(next.config.ssh.privateKeyPath).toBe('/keys/id');
+      expect(next.config.ssh.password).toBe('');
+      expect(next.config.ssh.keyPassphrase).toBe('');
+    });
+  });
+
+  describe('NEW_PROFILE', () => {
+    it('mode=new / editingProfileId=null / savePassword=false / testResult=null にリセット、config は DEFAULT', () => {
+      const prev = stateWith({
+        mode: 'edit',
+        editingProfileId: 'p1',
+        savePassword: true,
+        testResult: { success: false, message: 'x' },
+        config: makeConfig({ name: 'changed' }),
+      });
+      const next = profileFormReducer(prev, { type: 'NEW_PROFILE' });
+      expect(next.mode).toBe('new');
+      expect(next.editingProfileId).toBeNull();
+      expect(next.savePassword).toBe(false);
+      expect(next.testResult).toBeNull();
+      expect(next.config.name).toBe('New Connection');
+      expect(next.config.server).toBe('localhost');
+      expect(next.config.dbType).toBe('sqlserver');
+    });
+  });
+
+  describe('COPY_PROFILE', () => {
+    it('mode=new / editingProfileId=null / config.name に " (Copy)" 付加 / testResult=null', () => {
+      const prev = stateWith({
+        mode: 'edit',
+        editingProfileId: 'p1',
+        config: makeConfig({ name: 'My DB', server: 'host' }),
+        testResult: { success: true, message: 'ok' },
+      });
+      const next = profileFormReducer(prev, { type: 'COPY_PROFILE' });
+      expect(next.mode).toBe('new');
+      expect(next.editingProfileId).toBeNull();
+      expect(next.config.name).toBe('My DB (Copy)');
+      expect(next.config.server).toBe('host');
+      expect(next.testResult).toBeNull();
+    });
+
+    it('savePassword は維持される (リセットしない)', () => {
+      const prev = stateWith({ savePassword: true, mode: 'edit', editingProfileId: 'p1' });
+      const next = profileFormReducer(prev, { type: 'COPY_PROFILE' });
+      expect(next.savePassword).toBe(true);
+    });
+  });
+
+  describe('SET_CONFIG', () => {
+    it('値を直接渡すと config がその値になる', () => {
+      const newCfg = makeConfig({ name: 'Direct', port: 9999 });
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SET_CONFIG',
+        payload: newCfg,
+      });
+      expect(next.config).toEqual(newCfg);
+    });
+
+    it('関数を渡すと prev config を引数に呼ばれた戻り値が config になる (functional updater)', () => {
+      const prev = stateWith({ config: makeConfig({ name: 'Old', port: 1433 }) });
+      const next = profileFormReducer(prev, {
+        type: 'SET_CONFIG',
+        payload: (current) => ({ ...current, name: `${current.name}-new`, port: current.port + 1 }),
+      });
+      expect(next.config.name).toBe('Old-new');
+      expect(next.config.port).toBe(1434);
+    });
+  });
+
+  describe('SET_SAVE_PASSWORD', () => {
+    it('値を直接渡すと savePassword がその値になる', () => {
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SET_SAVE_PASSWORD',
+        payload: true,
+      });
+      expect(next.savePassword).toBe(true);
+    });
+
+    it('関数を渡すと prev を引数に呼ばれた戻り値が savePassword になる', () => {
+      const prev = stateWith({ savePassword: false });
+      const next = profileFormReducer(prev, {
+        type: 'SET_SAVE_PASSWORD',
+        payload: (current) => !current,
+      });
+      expect(next.savePassword).toBe(true);
+    });
+  });
+
+  describe('SET_TEST_RESULT', () => {
+    it('成功結果を設定できる', () => {
+      const next = profileFormReducer(initialProfileFormState, {
+        type: 'SET_TEST_RESULT',
+        payload: { success: true, message: 'ok' },
+      });
+      expect(next.testResult).toEqual({ success: true, message: 'ok' });
+    });
+
+    it('null でクリアできる', () => {
+      const prev = stateWith({ testResult: { success: false, message: 'err' } });
+      const next = profileFormReducer(prev, { type: 'SET_TEST_RESULT', payload: null });
+      expect(next.testResult).toBeNull();
+    });
+
+    it('関数を渡すと prev を引数に呼ばれた戻り値が testResult になる (functional updater)', () => {
+      const prev = stateWith({ testResult: { success: true, message: 'ok' } });
+      const next = profileFormReducer(prev, {
+        type: 'SET_TEST_RESULT',
+        payload: (current) => (current ? { ...current, message: `${current.message}!` } : null),
+      });
+      expect(next.testResult).toEqual({ success: true, message: 'ok!' });
+    });
+  });
+
+  describe('OPEN_DELETE_CONFIRM / CLOSE_DELETE_CONFIRM', () => {
+    it('OPEN で deleteConfirmOpen=true', () => {
+      const next = profileFormReducer(initialProfileFormState, { type: 'OPEN_DELETE_CONFIRM' });
+      expect(next.deleteConfirmOpen).toBe(true);
+    });
+
+    it('CLOSE で deleteConfirmOpen=false', () => {
+      const prev = stateWith({ deleteConfirmOpen: true });
+      const next = profileFormReducer(prev, { type: 'CLOSE_DELETE_CONFIRM' });
+      expect(next.deleteConfirmOpen).toBe(false);
+    });
+  });
+
+  describe('参照不変性', () => {
+    it('action 適用後は新しい state オブジェクトを返す (state !== prev)', () => {
+      const prev = stateWith();
+      const next = profileFormReducer(prev, { type: 'NEW_PROFILE' });
+      expect(next).not.toBe(prev);
+    });
+  });
+});


### PR DESCRIPTION
7 useState + 4 useRef に分散していたフォーム state を useReducer に統合。
loadProfile / auto-select / handleNewProfile / handleSaveProfile 等で散在していた setter 一括更新を
`SELECT_PROFILE / NEW_PROFILE / PROFILE_SAVED` 等の 1 dispatch に集約し、関連 state の整合性を transition レベルで担保。

主な変更:

- 新規 useConnectionProfile.reducer.ts: ProfileFormState / ProfileFormAction / profileFormReducer
- 新規 useConnectionProfile.reducer.test.ts: 各 action × 期待状態の unit test (27 ケース)
- useConnectionProfile.ts: useState 7 個を 1 useReducer に統合 (405 → 280 行)
- IPC レスポンス → SavedConnectionProfile 変換を normalizeProfile に抽出
- 既存 hook 戻り値 (UseConnectionProfileResult) シグネチャ不変
- functional updater 互換 (SET_CONFIG / SET_SAVE_PASSWORD / SET_TEST_RESULT)
- PROFILE_SAVED は isNew で discriminated union 化、message を payload で受領
- useRef 群は async 競合制御目的のため踏襲

関連 issue: #406 (本 PR 対象), #392 (親), #436 (後続: 型切出)

Closes #406