### PR TITLE
refactor(frontend): TableViewer schema state を useTableSchemaState hook に抽出

### DIFF
--- a/frontend/src/components/table/TableViewer.tsx
+++ b/frontend/src/components/table/TableViewer.tsx
@@ -1,17 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useConnectionStore } from '../../store/connectionStore';
-import type {
-  Column,
-  ConstraintInfo,
-  ForeignKeyInfo,
-  IndexInfo,
-  ReferencingForeignKeyInfo,
-  ResultSet,
-  TableMetadata,
-  TriggerInfo,
-} from '../../types';
+import type { ResultSet } from '../../types';
 import { stripBrackets } from '../../utils/stringUtils';
+import { useTableSchemaState } from './hooks/useTableSchemaState';
 import styles from './TableViewer.module.css';
 import { ColumnsTab } from './tabs/ColumnsTab';
 import { ConstraintsTab } from './tabs/ConstraintsTab';
@@ -50,17 +42,25 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
   const [resultSet, setResultSet] = useState<ResultSet | null>(null);
   const [whereClause, setWhereClause] = useState('');
 
-  // Schema state
-  const [columns, setColumns] = useState<Column[]>([]);
-  const [indexes, setIndexes] = useState<IndexInfo[]>([]);
-  const [constraints, setConstraints] = useState<ConstraintInfo[]>([]);
-  const [foreignKeys, setForeignKeys] = useState<ForeignKeyInfo[]>([]);
-  const [referencingForeignKeys, setReferencingForeignKeys] = useState<ReferencingForeignKeyInfo[]>(
-    []
-  );
-  const [triggers, setTriggers] = useState<TriggerInfo[]>([]);
-  const [metadata, setMetadata] = useState<TableMetadata | null>(null);
-  const [ddl, setDdl] = useState<string>('');
+  // Schema state (関心事別に hook 化)
+  const {
+    columns,
+    setColumns,
+    indexes,
+    setIndexes,
+    constraints,
+    setConstraints,
+    foreignKeys,
+    setForeignKeys,
+    referencingForeignKeys,
+    setReferencingForeignKeys,
+    triggers,
+    setTriggers,
+    metadata,
+    setMetadata,
+    ddl,
+    setDdl,
+  } = useTableSchemaState();
 
   const fullTableName = schemaName ? `[${schemaName}].[${tableName}]` : `[${tableName}]`;
 
@@ -106,7 +106,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load columns:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setColumns]);
 
   const loadIndexes = useCallback(async () => {
     if (!activeConnectionId) return;
@@ -116,7 +116,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load indexes:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setIndexes]);
 
   const loadConstraints = useCallback(async () => {
     if (!activeConnectionId) return;
@@ -126,7 +126,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load constraints:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setConstraints]);
 
   const loadForeignKeys = useCallback(async () => {
     if (!activeConnectionId) return;
@@ -136,7 +136,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load foreign keys:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setForeignKeys]);
 
   const loadReferencingForeignKeys = useCallback(async () => {
     if (!activeConnectionId) return;
@@ -146,7 +146,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load referencing foreign keys:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setReferencingForeignKeys]);
 
   const loadTriggers = useCallback(async () => {
     if (!activeConnectionId) return;
@@ -156,7 +156,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load triggers:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setTriggers]);
 
   const loadMetadata = useCallback(async () => {
     if (!activeConnectionId) return;
@@ -166,7 +166,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load metadata:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setMetadata]);
 
   const loadDdl = useCallback(async () => {
     if (!activeConnectionId) return;
@@ -176,7 +176,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } catch (err) {
       console.error('Failed to load DDL:', err);
     }
-  }, [activeConnectionId, fullTableName]);
+  }, [activeConnectionId, fullTableName, setDdl]);
 
   // Load data when tab changes
   useEffect(() => {

--- a/frontend/src/components/table/hooks/useTableSchemaState.ts
+++ b/frontend/src/components/table/hooks/useTableSchemaState.ts
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import type {
+  Column,
+  ConstraintInfo,
+  ForeignKeyInfo,
+  IndexInfo,
+  ReferencingForeignKeyInfo,
+  TableMetadata,
+  TriggerInfo,
+} from '../../../types';
+
+export interface UseTableSchemaStateReturn {
+  columns: Column[];
+  setColumns: (v: Column[]) => void;
+  indexes: IndexInfo[];
+  setIndexes: (v: IndexInfo[]) => void;
+  constraints: ConstraintInfo[];
+  setConstraints: (v: ConstraintInfo[]) => void;
+  foreignKeys: ForeignKeyInfo[];
+  setForeignKeys: (v: ForeignKeyInfo[]) => void;
+  referencingForeignKeys: ReferencingForeignKeyInfo[];
+  setReferencingForeignKeys: (v: ReferencingForeignKeyInfo[]) => void;
+  triggers: TriggerInfo[];
+  setTriggers: (v: TriggerInfo[]) => void;
+  metadata: TableMetadata | null;
+  setMetadata: (v: TableMetadata | null) => void;
+  ddl: string;
+  setDdl: (v: string) => void;
+}
+
+export function useTableSchemaState(): UseTableSchemaStateReturn {
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [indexes, setIndexes] = useState<IndexInfo[]>([]);
+  const [constraints, setConstraints] = useState<ConstraintInfo[]>([]);
+  const [foreignKeys, setForeignKeys] = useState<ForeignKeyInfo[]>([]);
+  const [referencingForeignKeys, setReferencingForeignKeys] = useState<ReferencingForeignKeyInfo[]>(
+    []
+  );
+  const [triggers, setTriggers] = useState<TriggerInfo[]>([]);
+  const [metadata, setMetadata] = useState<TableMetadata | null>(null);
+  const [ddl, setDdl] = useState<string>('');
+
+  return {
+    columns,
+    setColumns,
+    indexes,
+    setIndexes,
+    constraints,
+    setConstraints,
+    foreignKeys,
+    setForeignKeys,
+    referencingForeignKeys,
+    setReferencingForeignKeys,
+    triggers,
+    setTriggers,
+    metadata,
+    setMetadata,
+    ddl,
+    setDdl,
+  };
+}

--- a/frontend/src/tests/hooks/useTableSchemaState.test.ts
+++ b/frontend/src/tests/hooks/useTableSchemaState.test.ts
@@ -1,0 +1,174 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useTableSchemaState } from '../../components/table/hooks/useTableSchemaState';
+import type {
+  Column,
+  ConstraintInfo,
+  ForeignKeyInfo,
+  IndexInfo,
+  ReferencingForeignKeyInfo,
+  TableMetadata,
+  TriggerInfo,
+} from '../../types';
+
+describe('useTableSchemaState', () => {
+  it('returns empty initial values', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+
+    expect(result.current.columns).toEqual([]);
+    expect(result.current.indexes).toEqual([]);
+    expect(result.current.constraints).toEqual([]);
+    expect(result.current.foreignKeys).toEqual([]);
+    expect(result.current.referencingForeignKeys).toEqual([]);
+    expect(result.current.triggers).toEqual([]);
+    expect(result.current.metadata).toBeNull();
+    expect(result.current.ddl).toBe('');
+  });
+
+  it('updates columns via setColumns', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+    const columns: Column[] = [
+      {
+        name: 'id',
+        type: 'int',
+        size: 4,
+        nullable: false,
+        isPrimaryKey: true,
+      },
+    ];
+
+    act(() => {
+      result.current.setColumns(columns);
+    });
+
+    expect(result.current.columns).toEqual(columns);
+  });
+
+  it('updates indexes via setIndexes', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+    const indexes: IndexInfo[] = [
+      { name: 'idx_id', columns: ['id'], isUnique: true, isPrimaryKey: true, type: 'CLUSTERED' },
+    ];
+
+    act(() => {
+      result.current.setIndexes(indexes);
+    });
+
+    expect(result.current.indexes).toEqual(indexes);
+  });
+
+  it('updates constraints via setConstraints', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+    const constraints: ConstraintInfo[] = [
+      { name: 'pk_users', type: 'PRIMARY KEY', columns: ['id'], definition: 'PRIMARY KEY (id)' },
+    ];
+
+    act(() => {
+      result.current.setConstraints(constraints);
+    });
+
+    expect(result.current.constraints).toEqual(constraints);
+  });
+
+  it('updates foreignKeys via setForeignKeys', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+    const foreignKeys: ForeignKeyInfo[] = [
+      {
+        name: 'fk_user_role',
+        columns: ['role_id'],
+        referencedTable: 'roles',
+        referencedColumns: ['id'],
+        onDelete: 'NO ACTION',
+        onUpdate: 'NO ACTION',
+      },
+    ];
+
+    act(() => {
+      result.current.setForeignKeys(foreignKeys);
+    });
+
+    expect(result.current.foreignKeys).toEqual(foreignKeys);
+  });
+
+  it('updates referencingForeignKeys via setReferencingForeignKeys', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+    const referencingForeignKeys: ReferencingForeignKeyInfo[] = [
+      {
+        name: 'fk_order_user',
+        referencingTable: 'orders',
+        referencingColumns: ['user_id'],
+        columns: ['id'],
+        onDelete: 'CASCADE',
+        onUpdate: 'NO ACTION',
+      },
+    ];
+
+    act(() => {
+      result.current.setReferencingForeignKeys(referencingForeignKeys);
+    });
+
+    expect(result.current.referencingForeignKeys).toEqual(referencingForeignKeys);
+  });
+
+  it('updates triggers via setTriggers', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+    const triggers: TriggerInfo[] = [
+      {
+        name: 'trg_users_audit',
+        type: 'AFTER',
+        events: ['INSERT'],
+        isEnabled: true,
+        definition: 'CREATE TRIGGER ...',
+      },
+    ];
+
+    act(() => {
+      result.current.setTriggers(triggers);
+    });
+
+    expect(result.current.triggers).toEqual(triggers);
+  });
+
+  it('updates metadata via setMetadata', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+    const metadata: TableMetadata = {
+      schema: 'dbo',
+      name: 'users',
+      type: 'TABLE',
+      rowCount: 100,
+      createdAt: '2024-01-01',
+      modifiedAt: '2024-06-01',
+      owner: 'dbo',
+      comment: '',
+    };
+
+    act(() => {
+      result.current.setMetadata(metadata);
+    });
+
+    expect(result.current.metadata).toEqual(metadata);
+  });
+
+  it('updates ddl via setDdl', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+
+    act(() => {
+      result.current.setDdl('CREATE TABLE users (id INT)');
+    });
+
+    expect(result.current.ddl).toBe('CREATE TABLE users (id INT)');
+  });
+
+  it('keeps each state independent', () => {
+    const { result } = renderHook(() => useTableSchemaState());
+
+    act(() => {
+      result.current.setDdl('SELECT 1');
+    });
+
+    expect(result.current.ddl).toBe('SELECT 1');
+    expect(result.current.columns).toEqual([]);
+    expect(result.current.indexes).toEqual([]);
+    expect(result.current.metadata).toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

- TableViewer の 8 schema state を `useTableSchemaState` hook に集約
- TDD で hook 単体テスト 10 件追加
- fetch ロジック (loader callback) は TableViewer に残置 (issue 要件準拠)
- コンポーネント API (props) 不変

## Test plan

- [x] vitest 全 894 件 PASS
- [x] biome lint warning 0
- [x] TypeScript 型チェック PASS
- [x] uv run scripts/pdg.py lint PASS

Closes #439
Refs #407, #392