### PR TITLE
refactor(frontend): TableViewer data state を useTableDataState hook に抽出

### DIFF
--- a/frontend/src/components/table/TableViewer.tsx
+++ b/frontend/src/components/table/TableViewer.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useConnectionStore } from '../../store/connectionStore';
-import type { ResultSet } from '../../types';
 import { stripBrackets } from '../../utils/stringUtils';
+import { useTableDataState } from './hooks/useTableDataState';
 import { useTableSchemaState } from './hooks/useTableSchemaState';
 import styles from './TableViewer.module.css';
 import { ColumnsTab } from './tabs/ColumnsTab';
@@ -38,9 +38,8 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Data state
-  const [resultSet, setResultSet] = useState<ResultSet | null>(null);
-  const [whereClause, setWhereClause] = useState('');
+  // Data state (関心事別に hook 化)
+  const { resultSet, setResultSet, whereClause, setWhereClause } = useTableDataState();
 
   // Schema state (関心事別に hook 化)
   const {
@@ -96,7 +95,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } finally {
       setIsLoading(false);
     }
-  }, [activeConnectionId, fullTableName, whereClause]);
+  }, [activeConnectionId, fullTableName, whereClause, setResultSet]);
 
   const loadColumns = useCallback(async () => {
     if (!activeConnectionId) return;

--- a/frontend/src/components/table/hooks/useTableDataState.ts
+++ b/frontend/src/components/table/hooks/useTableDataState.ts
@@ -1,0 +1,21 @@
+import { type Dispatch, type SetStateAction, useState } from 'react';
+import type { ResultSet } from '../../../types';
+
+export interface UseTableDataStateReturn {
+  resultSet: ResultSet | null;
+  setResultSet: Dispatch<SetStateAction<ResultSet | null>>;
+  whereClause: string;
+  setWhereClause: Dispatch<SetStateAction<string>>;
+}
+
+export function useTableDataState(): UseTableDataStateReturn {
+  const [resultSet, setResultSet] = useState<ResultSet | null>(null);
+  const [whereClause, setWhereClause] = useState('');
+
+  return {
+    resultSet,
+    setResultSet,
+    whereClause,
+    setWhereClause,
+  };
+}

--- a/frontend/src/tests/hooks/useTableDataState.test.ts
+++ b/frontend/src/tests/hooks/useTableDataState.test.ts
@@ -1,0 +1,84 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useTableDataState } from '../../components/table/hooks/useTableDataState';
+import type { ResultSet } from '../../types';
+
+describe('useTableDataState', () => {
+  it('returns null resultSet and empty whereClause as initial values', () => {
+    const { result } = renderHook(() => useTableDataState());
+
+    expect(result.current.resultSet).toBeNull();
+    expect(result.current.whereClause).toBe('');
+  });
+
+  it('updates resultSet via setResultSet', () => {
+    const { result } = renderHook(() => useTableDataState());
+    const resultSet: ResultSet = {
+      columns: [{ name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true }],
+      rows: [['1']],
+      affectedRows: 1,
+      executionTimeMs: 10,
+    };
+
+    act(() => {
+      result.current.setResultSet(resultSet);
+    });
+
+    expect(result.current.resultSet).toEqual(resultSet);
+  });
+
+  it('clears resultSet when set to null', () => {
+    const { result } = renderHook(() => useTableDataState());
+    const resultSet: ResultSet = {
+      columns: [],
+      rows: [],
+      affectedRows: 0,
+      executionTimeMs: 0,
+    };
+
+    act(() => {
+      result.current.setResultSet(resultSet);
+    });
+    expect(result.current.resultSet).not.toBeNull();
+
+    act(() => {
+      result.current.setResultSet(null);
+    });
+    expect(result.current.resultSet).toBeNull();
+  });
+
+  it('updates whereClause via setWhereClause', () => {
+    const { result } = renderHook(() => useTableDataState());
+
+    act(() => {
+      result.current.setWhereClause("name = 'foo'");
+    });
+
+    expect(result.current.whereClause).toBe("name = 'foo'");
+  });
+
+  it('resets whereClause to empty string', () => {
+    const { result } = renderHook(() => useTableDataState());
+
+    act(() => {
+      result.current.setWhereClause('id > 10');
+    });
+    expect(result.current.whereClause).toBe('id > 10');
+
+    act(() => {
+      result.current.setWhereClause('');
+    });
+    expect(result.current.whereClause).toBe('');
+  });
+
+  it('keeps resultSet and whereClause independent', () => {
+    const { result } = renderHook(() => useTableDataState());
+
+    act(() => {
+      result.current.setWhereClause('id > 10');
+    });
+
+    expect(result.current.whereClause).toBe('id > 10');
+    expect(result.current.resultSet).toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

- 2 data state (\`resultSet\`, \`whereClause\`) を \`useTableDataState\` hook に集約
- TDD で hook 単体テスト 6 件 (初期値 / setResultSet / null クリア / setWhereClause / リセット / 独立性)
- setter 型は \`Dispatch<SetStateAction<T>>\` で関数形 setter を許容
- fetch ロジック (loadData) は TableViewer に残置 (issue 要件準拠)
- コンポーネント API (props) 不変

## Test plan

- [x] vitest 900 件 PASS
- [x] biome lint warning 0
- [x] TypeScript 型チェック PASS
- [x] uv run scripts/pdg.py lint PASS

Closes #440
Refs #407, #392