### PR TITLE
refactor(frontend): TableViewer UI state を useTableUIState hook に抽出 (#441)

### DIFF
--- a/frontend/src/components/table/TableViewer.tsx
+++ b/frontend/src/components/table/TableViewer.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { bridge } from '../../api/bridge';
 import { useConnectionStore } from '../../store/connectionStore';
 import { stripBrackets } from '../../utils/stringUtils';
 import { useTableDataState } from './hooks/useTableDataState';
 import { useTableSchemaState } from './hooks/useTableSchemaState';
+import { type TabType, useTableUIState } from './hooks/useTableUIState';
 import styles from './TableViewer.module.css';
 import { ColumnsTab } from './tabs/ColumnsTab';
 import { ConstraintsTab } from './tabs/ConstraintsTab';
@@ -15,17 +16,6 @@ import { ReferencingForeignKeysTab } from './tabs/ReferencingForeignKeysTab';
 import { SourceTab } from './tabs/SourceTab';
 import { TriggersTab } from './tabs/TriggersTab';
 
-type TabType =
-  | 'data'
-  | 'columns'
-  | 'indexes'
-  | 'constraints'
-  | 'foreignKeys'
-  | 'referencingForeignKeys'
-  | 'triggers'
-  | 'rdbmsInfo'
-  | 'source';
-
 interface TableViewerProps {
   tableName: string;
   schemaName?: string;
@@ -33,10 +23,18 @@ interface TableViewerProps {
 
 export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps) {
   const activeConnectionId = useConnectionStore((state) => state.activeConnectionId);
-  const [activeTab, setActiveTab] = useState<TabType>('data');
-  const [showLogicalNames, setShowLogicalNames] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+
+  // UI state (関心事別に hook 化)
+  const {
+    activeTab,
+    setActiveTab,
+    showLogicalNames,
+    setShowLogicalNames,
+    isLoading,
+    setIsLoading,
+    error,
+    setError,
+  } = useTableUIState();
 
   // Data state (関心事別に hook 化)
   const { resultSet, setResultSet, whereClause, setWhereClause } = useTableDataState();
@@ -95,7 +93,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
     } finally {
       setIsLoading(false);
     }
-  }, [activeConnectionId, fullTableName, whereClause, setResultSet]);
+  }, [activeConnectionId, fullTableName, whereClause, setResultSet, setIsLoading, setError]);
 
   const loadColumns = useCallback(async () => {
     if (!activeConnectionId) return;

--- a/frontend/src/components/table/hooks/useTableUIState.ts
+++ b/frontend/src/components/table/hooks/useTableUIState.ts
@@ -1,0 +1,41 @@
+import { type Dispatch, type SetStateAction, useState } from 'react';
+
+export type TabType =
+  | 'data'
+  | 'columns'
+  | 'indexes'
+  | 'constraints'
+  | 'foreignKeys'
+  | 'referencingForeignKeys'
+  | 'triggers'
+  | 'rdbmsInfo'
+  | 'source';
+
+export interface UseTableUIStateReturn {
+  activeTab: TabType;
+  setActiveTab: Dispatch<SetStateAction<TabType>>;
+  showLogicalNames: boolean;
+  setShowLogicalNames: Dispatch<SetStateAction<boolean>>;
+  isLoading: boolean;
+  setIsLoading: Dispatch<SetStateAction<boolean>>;
+  error: string | null;
+  setError: Dispatch<SetStateAction<string | null>>;
+}
+
+export function useTableUIState(): UseTableUIStateReturn {
+  const [activeTab, setActiveTab] = useState<TabType>('data');
+  const [showLogicalNames, setShowLogicalNames] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  return {
+    activeTab,
+    setActiveTab,
+    showLogicalNames,
+    setShowLogicalNames,
+    isLoading,
+    setIsLoading,
+    error,
+    setError,
+  };
+}

--- a/frontend/src/tests/hooks/useTableUIState.test.ts
+++ b/frontend/src/tests/hooks/useTableUIState.test.ts
@@ -1,0 +1,85 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useTableUIState } from '../../components/table/hooks/useTableUIState';
+
+describe('useTableUIState', () => {
+  it('returns default initial values', () => {
+    const { result } = renderHook(() => useTableUIState());
+
+    expect(result.current.activeTab).toBe('data');
+    expect(result.current.showLogicalNames).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('updates activeTab via setActiveTab', () => {
+    const { result } = renderHook(() => useTableUIState());
+
+    act(() => {
+      result.current.setActiveTab('columns');
+    });
+
+    expect(result.current.activeTab).toBe('columns');
+  });
+
+  it('toggles showLogicalNames via setShowLogicalNames', () => {
+    const { result } = renderHook(() => useTableUIState());
+
+    act(() => {
+      result.current.setShowLogicalNames(true);
+    });
+    expect(result.current.showLogicalNames).toBe(true);
+
+    act(() => {
+      result.current.setShowLogicalNames(false);
+    });
+    expect(result.current.showLogicalNames).toBe(false);
+  });
+
+  it('updates isLoading via setIsLoading', () => {
+    const { result } = renderHook(() => useTableUIState());
+
+    act(() => {
+      result.current.setIsLoading(true);
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('updates error via setError', () => {
+    const { result } = renderHook(() => useTableUIState());
+
+    act(() => {
+      result.current.setError('connection failed');
+    });
+
+    expect(result.current.error).toBe('connection failed');
+  });
+
+  it('clears error when set to null', () => {
+    const { result } = renderHook(() => useTableUIState());
+
+    act(() => {
+      result.current.setError('some error');
+    });
+    expect(result.current.error).toBe('some error');
+
+    act(() => {
+      result.current.setError(null);
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('keeps each state independent', () => {
+    const { result } = renderHook(() => useTableUIState());
+
+    act(() => {
+      result.current.setActiveTab('source');
+    });
+
+    expect(result.current.activeTab).toBe('source');
+    expect(result.current.showLogicalNames).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});


### PR DESCRIPTION

## Summary

- issue #407 の 3 hook 分離 最終フェーズ (#439 / #440 完了済み → 本 PR で完結)
- UI state 4 個 (activeTab / showLogicalNames / isLoading / error) を useTableUIState hook に集約
- TabType 型を hook 側へ移動・export (activeTab との凝集度を優先)
- 副次効果: TableViewer.tsx 側の useState 直接利用が皆無になり import 削除

## Test plan

- [x] vitest 907 件 PASS
- [x] tsc 通過
- [x] biome warning 0
- [x] pdg.py lint ALL PASSED

Closes #441
Refs #407, #392