### PR TITLE
refactor(frontend): useTableSchemaState の setter 型を Dispatch<SetStateAction<T>> に統一

### DIFF
--- a/frontend/src/components/table/hooks/useTableSchemaState.ts
+++ b/frontend/src/components/table/hooks/useTableSchemaState.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { type Dispatch, type SetStateAction, useState } from 'react';
 import type {
   Column,
   ConstraintInfo,
@@ -11,21 +11,21 @@ import type {
 
 export interface UseTableSchemaStateReturn {
   columns: Column[];
-  setColumns: (v: Column[]) => void;
+  setColumns: Dispatch<SetStateAction<Column[]>>;
   indexes: IndexInfo[];
-  setIndexes: (v: IndexInfo[]) => void;
+  setIndexes: Dispatch<SetStateAction<IndexInfo[]>>;
   constraints: ConstraintInfo[];
-  setConstraints: (v: ConstraintInfo[]) => void;
+  setConstraints: Dispatch<SetStateAction<ConstraintInfo[]>>;
   foreignKeys: ForeignKeyInfo[];
-  setForeignKeys: (v: ForeignKeyInfo[]) => void;
+  setForeignKeys: Dispatch<SetStateAction<ForeignKeyInfo[]>>;
   referencingForeignKeys: ReferencingForeignKeyInfo[];
-  setReferencingForeignKeys: (v: ReferencingForeignKeyInfo[]) => void;
+  setReferencingForeignKeys: Dispatch<SetStateAction<ReferencingForeignKeyInfo[]>>;
   triggers: TriggerInfo[];
-  setTriggers: (v: TriggerInfo[]) => void;
+  setTriggers: Dispatch<SetStateAction<TriggerInfo[]>>;
   metadata: TableMetadata | null;
-  setMetadata: (v: TableMetadata | null) => void;
+  setMetadata: Dispatch<SetStateAction<TableMetadata | null>>;
   ddl: string;
-  setDdl: (v: string) => void;
+  setDdl: Dispatch<SetStateAction<string>>;
 }
 
 export function useTableSchemaState(): UseTableSchemaStateReturn {


### PR DESCRIPTION
## Summary

- #407 サブイシュー (#439/#440/#441) で抽出した 3 hook の setter 型を統一
- 407-A 当時のみ `(v: T) => void` 形式だった useTableSchemaState を 407-B/C と同じ `Dispatch<SetStateAction<T>>` に揃える
- 関数シグネチャ的に上位互換 (より広い受容型) のため呼出側 (TableViewer) は無変更

## Test plan

- [x] vitest 907 件 PASS
- [x] tsc 通過
- [x] biome warning 0
- [x] pdg.py lint ALL PASSED

  Refs #407, #392