### PR TITLE
refactor(frontend): React.Dispatch を import 形式に統一 (#407)

### DIFF
--- a/frontend/src/components/dialogs/hooks/useConnectionProfile.ts
+++ b/frontend/src/components/dialogs/hooks/useConnectionProfile.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useReducer, useRef } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+} from 'react';
 import { bridge } from '../../../api/bridge';
 import { useConnectionStore } from '../../../store/connectionStore';
 import {
@@ -57,9 +64,9 @@ interface UseConnectionProfileResult {
   savePassword: boolean;
   testResult: { success: boolean; message: string } | null;
   deleteConfirmOpen: boolean;
-  setConfig: React.Dispatch<React.SetStateAction<ConnectionConfig>>;
-  setSavePassword: React.Dispatch<React.SetStateAction<boolean>>;
-  setTestResult: React.Dispatch<React.SetStateAction<{ success: boolean; message: string } | null>>;
+  setConfig: Dispatch<SetStateAction<ConnectionConfig>>;
+  setSavePassword: Dispatch<SetStateAction<boolean>>;
+  setTestResult: Dispatch<SetStateAction<{ success: boolean; message: string } | null>>;
   handleProfileSelect: (profileId: string) => void;
   handleNewProfile: () => void;
   handleSaveProfile: () => Promise<void>;
@@ -81,16 +88,16 @@ export function useConnectionProfile(isOpen: boolean): UseConnectionProfileResul
   modeRef.current = mode;
   editingProfileIdRef.current = editingProfileId;
 
-  const setConfig = useCallback<React.Dispatch<React.SetStateAction<ConnectionConfig>>>((value) => {
+  const setConfig = useCallback<Dispatch<SetStateAction<ConnectionConfig>>>((value) => {
     dispatch({ type: 'SET_CONFIG', payload: value });
   }, []);
 
-  const setSavePassword = useCallback<React.Dispatch<React.SetStateAction<boolean>>>((value) => {
+  const setSavePassword = useCallback<Dispatch<SetStateAction<boolean>>>((value) => {
     dispatch({ type: 'SET_SAVE_PASSWORD', payload: value });
   }, []);
 
   const setTestResult = useCallback<
-    React.Dispatch<React.SetStateAction<{ success: boolean; message: string } | null>>
+    Dispatch<SetStateAction<{ success: boolean; message: string } | null>>
   >((value) => {
     dispatch({ type: 'SET_TEST_RESULT', payload: value });
   }, []);

--- a/frontend/src/components/grid/hooks/useColumnAutoSize.ts
+++ b/frontend/src/components/grid/hooks/useColumnAutoSize.ts
@@ -1,5 +1,13 @@
 import type { ColumnDef } from '@tanstack/react-table';
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import type { ResultSet } from '../../../types';
 import { isDateType, isNumericType, type RowData } from '../../../types/grid';
 import { log } from '../../../utils/logger';
@@ -12,7 +20,7 @@ interface UseColumnAutoSizeOptions {
 
 interface UseColumnAutoSizeResult {
   columnSizing: Record<string, number>;
-  setColumnSizing: React.Dispatch<React.SetStateAction<Record<string, number>>>;
+  setColumnSizing: Dispatch<SetStateAction<Record<string, number>>>;
   /** 全列を強制的に再計算する */
   triggerAutoSize: () => void;
   /** 指定列のみ再計算する (他列の現在幅は保持) */

--- a/frontend/src/components/grid/hooks/useGridKeyboard.ts
+++ b/frontend/src/components/grid/hooks/useGridKeyboard.ts
@@ -1,5 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table';
-import { useCallback, useState } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { useKeyboardHandler } from '../../../hooks/useKeyboardHandler';
 import { isSystemColumn, type RowData } from '../../../types/grid';
@@ -37,7 +37,7 @@ interface UseGridKeyboardOptions {
 interface UseGridKeyboardResult {
   editingCell: EditingCell | null;
   editValue: string;
-  setEditValue: React.Dispatch<React.SetStateAction<string>>;
+  setEditValue: Dispatch<SetStateAction<string>>;
   copySelection: () => Promise<void>;
   pasteFromClipboard: () => Promise<void>;
   startEdit: (rowIndex: number, columnId: string, currentValue: string | null) => void;

--- a/frontend/src/hooks/useColumnActions.ts
+++ b/frontend/src/hooks/useColumnActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
 import { bridge } from '../api/bridge';
 import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
 import { log } from '../utils/logger';
@@ -51,7 +51,7 @@ interface UseColumnActionsParams {
   dbType?: DatabaseType;
   isReadOnly: boolean;
   loadColumns: (schema: string, tableName: string) => Promise<DatabaseObject[]>;
-  setTreeData: React.Dispatch<React.SetStateAction<DatabaseObject[]>>;
+  setTreeData: Dispatch<SetStateAction<DatabaseObject[]>>;
   onDdlError?: (error: unknown) => void;
 }
 

--- a/frontend/src/hooks/useTableActions.ts
+++ b/frontend/src/hooks/useTableActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
 import { bridge } from '../api/bridge';
 import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
 import { log } from '../utils/logger';
@@ -30,7 +30,7 @@ interface UseTableActionsParams {
   connectionId: string;
   dbType?: DatabaseType;
   loadTables: () => Promise<DatabaseObject[]>;
-  setTreeData: React.Dispatch<React.SetStateAction<DatabaseObject[]>>;
+  setTreeData: Dispatch<SetStateAction<DatabaseObject[]>>;
   onDdlError?: (error: unknown) => void;
 }
 


### PR DESCRIPTION
3 hook 分離 (#442/#443/#444/#445) で導入した import 形式(`import { type Dispatch, type SetStateAction } from 'react'`) に
既存 5 ファイル 10 箇所を揃える。codebase 内で`React.Dispatch<React.SetStateAction<T>>` と`Dispatch<SetStateAction<T>>` の 2 形式が混在していたため
#407 フォローアップのフェーズ C として解消。

`React.RefObject` 等 setter 以外の React.namespace は今回スコープ外。