### PR TITLE
refactor(backend): utils/ → accessors/ レイヤー昇格 + Accessor へリネーム (#447)

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -61,13 +61,14 @@ set(LIB_SOURCES
     exporters/csv_exporter.cpp
     exporters/json_exporter.cpp
     exporters/excel_exporter.cpp
+    # Accessors (Layer #4 — direct resource access)
+    accessors/settings_accessor.cpp
+    accessors/session_accessor.cpp
     # Utils
     utils/json_utils.cpp
     utils/simd_filter.cpp
     utils/file_utils.cpp
     utils/file_dialog.cpp
-    utils/settings_manager.cpp
-    utils/session_manager.cpp
     utils/global_search.cpp
     utils/credential_protector.cpp
     utils/logger.cpp
@@ -156,14 +157,15 @@ set(HEADERS
     exporters/json_exporter.h
     exporters/excel_exporter.h
     exporters/data_exporter.h
+    # Accessors (Layer #4 — direct resource access)
+    accessors/settings_accessor.h
+    accessors/session_accessor.h
+    accessors/glaze_meta.h
     # Utils
     utils/json_utils.h
     utils/simd_filter.h
     utils/file_utils.h
     utils/file_dialog.h
-    utils/settings_manager.h
-    utils/session_manager.h
-    utils/glaze_meta.h
     utils/sql_escape.h
     utils/global_search.h
     utils/credential_protector.h

--- a/backend/accessors/glaze_meta.h
+++ b/backend/accessors/glaze_meta.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "session_manager.h"
-#include "settings_manager.h"
+#include "session_accessor.h"
+#include "settings_accessor.h"
 
 #include <glaze/glaze.hpp>
 

--- a/backend/accessors/session_accessor.cpp
+++ b/backend/accessors/session_accessor.cpp
@@ -1,7 +1,7 @@
-#include "session_manager.h"
+#include "accessors/session_accessor.h"
 
-#include "glaze_meta.h"
-#include "logger.h"
+#include "accessors/glaze_meta.h"
+#include "utils/logger.h"
 
 #include <Windows.h>
 
@@ -14,7 +14,7 @@
 
 namespace velocitydb {
 
-SessionManager::SessionManager() {
+SessionAccessor::SessionAccessor() {
     // Get AppData\Local path
     wchar_t* localAppData = nullptr;
     if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppData))) {
@@ -28,7 +28,7 @@ SessionManager::SessionManager() {
     m_sessionPath /= "session.json";
 }
 
-std::expected<void, std::string> SessionManager::load() {
+std::expected<void, std::string> SessionAccessor::load() {
     std::lock_guard lock(m_mutex);
 
     if (!std::filesystem::exists(m_sessionPath)) {
@@ -48,7 +48,7 @@ std::expected<void, std::string> SessionManager::load() {
     return {};
 }
 
-std::expected<void, std::string> SessionManager::save() {
+std::expected<void, std::string> SessionAccessor::save() {
     std::lock_guard lock(m_mutex);
 
     m_state.lastSaved = std::chrono::system_clock::now();
@@ -70,34 +70,34 @@ std::expected<void, std::string> SessionManager::save() {
     return {};
 }
 
-void SessionManager::updateState(const SessionState& state) {
+void SessionAccessor::updateState(const SessionState& state) {
     std::lock_guard lock(m_mutex);
     m_state = state;
 }
 
-void SessionManager::addTab(const EditorTab& tab) {
+void SessionAccessor::addTab(const EditorTab& tab) {
     std::lock_guard lock(m_mutex);
     m_state.openTabs.push_back(tab);
 }
 
-void SessionManager::updateTab(const EditorTab& tab) {
+void SessionAccessor::updateTab(const EditorTab& tab) {
     std::lock_guard lock(m_mutex);
     if (auto it = std::ranges::find(m_state.openTabs, tab.id, &EditorTab::id); it != m_state.openTabs.end()) {
         *it = tab;
     }
 }
 
-void SessionManager::removeTab(const std::string& tabId) {
+void SessionAccessor::removeTab(const std::string& tabId) {
     std::lock_guard lock(m_mutex);
     std::erase_if(m_state.openTabs, [&tabId](const EditorTab& t) { return t.id == tabId; });
 }
 
-void SessionManager::setActiveTab(const std::string& tabId) {
+void SessionAccessor::setActiveTab(const std::string& tabId) {
     std::lock_guard lock(m_mutex);
     m_state.activeTabId = tabId;
 }
 
-void SessionManager::updateWindowState(int x, int y, int width, int height, bool maximized) {
+void SessionAccessor::updateWindowState(int x, int y, int width, int height, bool maximized) {
     std::lock_guard lock(m_mutex);
     m_state.windowX = x;
     m_state.windowY = y;
@@ -106,36 +106,36 @@ void SessionManager::updateWindowState(int x, int y, int width, int height, bool
     m_state.isMaximized = maximized;
 }
 
-void SessionManager::updatePanelSizes(int leftWidth, int bottomHeight) {
+void SessionAccessor::updatePanelSizes(int leftWidth, int bottomHeight) {
     std::lock_guard lock(m_mutex);
     m_state.leftPanelWidth = leftWidth;
     m_state.bottomPanelHeight = bottomHeight;
 }
 
-void SessionManager::setActiveConnection(const std::string& connectionId) {
+void SessionAccessor::setActiveConnection(const std::string& connectionId) {
     std::lock_guard lock(m_mutex);
     m_state.activeConnectionId = connectionId;
 }
 
-void SessionManager::setExpandedNodes(const std::vector<std::string>& nodeIds) {
+void SessionAccessor::setExpandedNodes(const std::vector<std::string>& nodeIds) {
     std::lock_guard lock(m_mutex);
     m_state.expandedTreeNodes = nodeIds;
 }
 
-void SessionManager::enableAutoSave(int intervalSeconds) {
+void SessionAccessor::enableAutoSave(int intervalSeconds) {
     m_autoSaveEnabled = true;
     m_autoSaveInterval = intervalSeconds;
 }
 
-void SessionManager::disableAutoSave() {
+void SessionAccessor::disableAutoSave() {
     m_autoSaveEnabled = false;
 }
 
-std::filesystem::path SessionManager::getSessionPath() const {
+std::filesystem::path SessionAccessor::getSessionPath() const {
     return m_sessionPath;
 }
 
-std::string SessionManager::serializeSession() const {
+std::string SessionAccessor::serializeSession() const {
     std::string buffer;
     if (auto ec = glz::write<glz::opts{.prettify = true}>(m_state, buffer); bool(ec)) {
         log<LogLevel::WARNING>("Failed to serialize session state");
@@ -144,7 +144,7 @@ std::string SessionManager::serializeSession() const {
     return buffer;
 }
 
-bool SessionManager::deserializeSession(std::string_view json) {
+bool SessionAccessor::deserializeSession(std::string_view json) {
     auto ec = glz::read_json(m_state, json);
     if (bool(ec)) {
         log<LogLevel::WARNING>(std::format("Failed to parse session.json: {}", glz::format_error(ec, json)));

--- a/backend/accessors/session_accessor.h
+++ b/backend/accessors/session_accessor.h
@@ -38,13 +38,13 @@ struct SessionState {
     [[nodiscard]] int64_t writeLastSavedEpoch() const { return std::chrono::duration_cast<std::chrono::seconds>(lastSaved.time_since_epoch()).count(); }
 };
 
-class SessionManager {
+class SessionAccessor {
 public:
-    SessionManager();
-    ~SessionManager() = default;
+    SessionAccessor();
+    ~SessionAccessor() = default;
 
-    SessionManager(const SessionManager&) = delete;
-    SessionManager& operator=(const SessionManager&) = delete;
+    SessionAccessor(const SessionAccessor&) = delete;
+    SessionAccessor& operator=(const SessionAccessor&) = delete;
 
     /// Load session state from disk
     [[nodiscard]] std::expected<void, std::string> load();

--- a/backend/accessors/settings_accessor.cpp
+++ b/backend/accessors/settings_accessor.cpp
@@ -1,8 +1,8 @@
-#include "settings_manager.h"
+#include "accessors/settings_accessor.h"
 
-#include "credential_protector.h"
-#include "glaze_meta.h"
-#include "logger.h"
+#include "accessors/glaze_meta.h"
+#include "utils/credential_protector.h"
+#include "utils/logger.h"
 
 #include <Windows.h>
 
@@ -15,7 +15,7 @@
 
 namespace velocitydb {
 
-SettingsManager::SettingsManager() {
+SettingsAccessor::SettingsAccessor() {
     // Get AppData\Local path
     wchar_t* localAppData = nullptr;
     if (SUCCEEDED(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &localAppData))) {
@@ -31,7 +31,7 @@ SettingsManager::SettingsManager() {
     m_settingsPath /= "settings.json";
 }
 
-std::expected<void, std::string> SettingsManager::load() {
+std::expected<void, std::string> SettingsAccessor::load() {
     std::lock_guard lock(m_mutex);
 
     if (!std::filesystem::exists(m_settingsPath)) {
@@ -59,7 +59,7 @@ std::expected<void, std::string> SettingsManager::load() {
     return {};
 }
 
-std::expected<void, std::string> SettingsManager::save() {
+std::expected<void, std::string> SettingsAccessor::save() {
     std::lock_guard lock(m_mutex);
 
     auto json = serializeSettings();
@@ -79,29 +79,29 @@ std::expected<void, std::string> SettingsManager::save() {
     return {};
 }
 
-void SettingsManager::updateSettings(const AppSettings& settings) {
+void SettingsAccessor::updateSettings(const AppSettings& settings) {
     std::lock_guard lock(m_mutex);
     m_settings = settings;
 }
 
-void SettingsManager::addConnectionProfile(const ConnectionProfile& profile) {
+void SettingsAccessor::addConnectionProfile(const ConnectionProfile& profile) {
     std::lock_guard lock(m_mutex);
     m_settings.connectionProfiles.push_back(profile);
 }
 
-void SettingsManager::updateConnectionProfile(const ConnectionProfile& profile) {
+void SettingsAccessor::updateConnectionProfile(const ConnectionProfile& profile) {
     std::lock_guard lock(m_mutex);
     if (auto it = std::ranges::find(m_settings.connectionProfiles, profile.id, &ConnectionProfile::id); it != m_settings.connectionProfiles.end()) {
         *it = profile;
     }
 }
 
-void SettingsManager::removeConnectionProfile(const std::string& id) {
+void SettingsAccessor::removeConnectionProfile(const std::string& id) {
     std::lock_guard lock(m_mutex);
     std::erase_if(m_settings.connectionProfiles, [&id](const ConnectionProfile& p) { return p.id == id; });
 }
 
-std::optional<ConnectionProfile> SettingsManager::getConnectionProfile(const std::string& id) const {
+std::optional<ConnectionProfile> SettingsAccessor::getConnectionProfile(const std::string& id) const {
     std::lock_guard lock(m_mutex);
     if (auto it = std::ranges::find(m_settings.connectionProfiles, id, &ConnectionProfile::id); it != m_settings.connectionProfiles.end()) {
         return *it;
@@ -109,11 +109,11 @@ std::optional<ConnectionProfile> SettingsManager::getConnectionProfile(const std
     return std::nullopt;
 }
 
-const std::vector<ConnectionProfile>& SettingsManager::getConnectionProfiles() const {
+const std::vector<ConnectionProfile>& SettingsAccessor::getConnectionProfiles() const {
     return m_settings.connectionProfiles;
 }
 
-std::expected<void, std::string> SettingsManager::setProfilePassword(const std::string& profileId, std::string_view plainPassword) {
+std::expected<void, std::string> SettingsAccessor::setProfilePassword(const std::string& profileId, std::string_view plainPassword) {
     std::lock_guard lock(m_mutex);
 
     auto it = std::ranges::find(m_settings.connectionProfiles, profileId, &ConnectionProfile::id);
@@ -137,7 +137,7 @@ std::expected<void, std::string> SettingsManager::setProfilePassword(const std::
     return {};
 }
 
-std::expected<std::string, std::string> SettingsManager::getProfilePassword(const std::string& profileId) const {
+std::expected<std::string, std::string> SettingsAccessor::getProfilePassword(const std::string& profileId) const {
     std::lock_guard lock(m_mutex);
 
     auto it = std::ranges::find(m_settings.connectionProfiles, profileId, &ConnectionProfile::id);
@@ -151,11 +151,11 @@ std::expected<std::string, std::string> SettingsManager::getProfilePassword(cons
     return CredentialProtector::decrypt(it->encryptedPassword);
 }
 
-std::filesystem::path SettingsManager::getSettingsPath() const {
+std::filesystem::path SettingsAccessor::getSettingsPath() const {
     return m_settingsPath;
 }
 
-std::expected<void, std::string> SettingsManager::setSshPassword(const std::string& profileId, std::string_view plainPassword) {
+std::expected<void, std::string> SettingsAccessor::setSshPassword(const std::string& profileId, std::string_view plainPassword) {
     std::lock_guard lock(m_mutex);
 
     auto it = std::ranges::find(m_settings.connectionProfiles, profileId, &ConnectionProfile::id);
@@ -177,7 +177,7 @@ std::expected<void, std::string> SettingsManager::setSshPassword(const std::stri
     return {};
 }
 
-std::expected<std::string, std::string> SettingsManager::getSshPassword(const std::string& profileId) const {
+std::expected<std::string, std::string> SettingsAccessor::getSshPassword(const std::string& profileId) const {
     std::lock_guard lock(m_mutex);
 
     auto it = std::ranges::find(m_settings.connectionProfiles, profileId, &ConnectionProfile::id);
@@ -191,7 +191,7 @@ std::expected<std::string, std::string> SettingsManager::getSshPassword(const st
     return CredentialProtector::decrypt(it->ssh.encryptedPassword);
 }
 
-std::expected<void, std::string> SettingsManager::setSshKeyPassphrase(const std::string& profileId, std::string_view passphrase) {
+std::expected<void, std::string> SettingsAccessor::setSshKeyPassphrase(const std::string& profileId, std::string_view passphrase) {
     std::lock_guard lock(m_mutex);
 
     auto it = std::ranges::find(m_settings.connectionProfiles, profileId, &ConnectionProfile::id);
@@ -213,7 +213,7 @@ std::expected<void, std::string> SettingsManager::setSshKeyPassphrase(const std:
     return {};
 }
 
-std::expected<std::string, std::string> SettingsManager::getSshKeyPassphrase(const std::string& profileId) const {
+std::expected<std::string, std::string> SettingsAccessor::getSshKeyPassphrase(const std::string& profileId) const {
     std::lock_guard lock(m_mutex);
 
     auto it = std::ranges::find(m_settings.connectionProfiles, profileId, &ConnectionProfile::id);
@@ -227,7 +227,7 @@ std::expected<std::string, std::string> SettingsManager::getSshKeyPassphrase(con
     return CredentialProtector::decrypt(it->ssh.encryptedKeyPassphrase);
 }
 
-std::string SettingsManager::serializeSettings() const {
+std::string SettingsAccessor::serializeSettings() const {
     std::string buffer;
     if (auto ec = glz::write<glz::opts{.prettify = true}>(m_settings, buffer); bool(ec)) {
         log<LogLevel::WARNING>("Failed to serialize settings");
@@ -236,7 +236,7 @@ std::string SettingsManager::serializeSettings() const {
     return buffer;
 }
 
-bool SettingsManager::deserializeSettings(std::string_view json) {
+bool SettingsAccessor::deserializeSettings(std::string_view json) {
     auto ec = glz::read_json(m_settings, json);
     if (bool(ec)) {
         log<LogLevel::WARNING>(std::format("Failed to parse settings.json: {}", glz::format_error(ec, json)));

--- a/backend/accessors/settings_accessor.h
+++ b/backend/accessors/settings_accessor.h
@@ -97,13 +97,13 @@ struct AppSettings {
     std::vector<ConnectionProfile> connectionProfiles;
 };
 
-class SettingsManager {
+class SettingsAccessor {
 public:
-    SettingsManager();
-    ~SettingsManager() = default;
+    SettingsAccessor();
+    ~SettingsAccessor() = default;
 
-    SettingsManager(const SettingsManager&) = delete;
-    SettingsManager& operator=(const SettingsManager&) = delete;
+    SettingsAccessor(const SettingsAccessor&) = delete;
+    SettingsAccessor& operator=(const SettingsAccessor&) = delete;
 
     /// Load settings from disk
     [[nodiscard]] std::expected<void, std::string> load();

--- a/backend/contexts/system_context.cpp
+++ b/backend/contexts/system_context.cpp
@@ -22,7 +22,7 @@ SystemContext::SystemContext()
     , m_settings(std::make_unique<SettingsProvider>(m_connections.get()))
     // 設定ファイル破損時の防御: maxQueryHistory が 0 や負値だった場合は最低 1 件にクランプして
     // QueryHistory が常に有効状態で動作するようにする。
-    , m_queryHistory(std::make_unique<QueryHistory>(static_cast<size_t>(std::max(1, m_settings->settingsManager().getSettings().general.maxQueryHistory))))
+    , m_queryHistory(std::make_unique<QueryHistory>(static_cast<size_t>(std::max(1, m_settings->settingsAccessor().getSettings().general.maxQueryHistory))))
     , m_queries(std::make_unique<QueryProvider>(*m_connections, *m_queryHistory))
     , m_asyncQueries(std::make_unique<AsyncQueryProvider>(*m_connections, *m_queryHistory))
     , m_schema(std::make_unique<SchemaProvider>(*m_connections))

--- a/backend/database/query_history.h
+++ b/backend/database/query_history.h
@@ -52,7 +52,7 @@ struct HistoryItem {
 
 class QueryHistory {
 public:
-    /// デフォルト値は GeneralSettings::maxQueryHistory (settings_manager.h) と一致させる。
+    /// デフォルト値は GeneralSettings::maxQueryHistory (accessors/settings_accessor.h) と一致させる。
     /// 不一致は Issue #426 を参照。
     explicit QueryHistory(size_t maxItems = 1000) : m_maxItems(maxItems) {}
     ~QueryHistory() = default;

--- a/backend/providers/connection_provider.h
+++ b/backend/providers/connection_provider.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "../accessors/settings_accessor.h"
 #include "../interfaces/providers/connection_provider.h"
-#include "../utils/settings_manager.h"
 
 #include <atomic>
 #include <memory>

--- a/backend/providers/settings_provider.cpp
+++ b/backend/providers/settings_provider.cpp
@@ -1,11 +1,11 @@
 #include "settings_provider.h"
 
+#include "../accessors/glaze_meta.h"
+#include "../accessors/session_accessor.h"
+#include "../accessors/settings_accessor.h"
 #include "../database/query_history.h"
 #include "../interfaces/providers/connection_provider.h"
-#include "../utils/glaze_meta.h"
 #include "../utils/json_utils.h"
-#include "../utils/session_manager.h"
-#include "../utils/settings_manager.h"
 #include "simdjson.h"
 
 #include <algorithm>
@@ -159,10 +159,10 @@ namespace {
 }  // namespace
 
 SettingsProvider::SettingsProvider(IConnectionProvider* connections)
-    : m_settingsManager(std::make_unique<SettingsManager>()), m_sessionManager(std::make_unique<SessionManager>()), m_connections(connections) {
-    (void)m_settingsManager->load();
-    (void)m_sessionManager->load();
-    applyQueryTimeoutToConnections(m_settingsManager->getSettings().query.timeoutSeconds);
+    : m_settingsAccessor(std::make_unique<SettingsAccessor>()), m_sessionAccessor(std::make_unique<SessionAccessor>()), m_connections(connections) {
+    (void)m_settingsAccessor->load();
+    (void)m_sessionAccessor->load();
+    applyQueryTimeoutToConnections(m_settingsAccessor->getSettings().query.timeoutSeconds);
 }
 
 void SettingsProvider::applyQueryTimeoutToConnections(int seconds) {
@@ -181,7 +181,7 @@ void SettingsProvider::setQueryHistory(QueryHistory* queryHistory) {
     m_queryHistory = queryHistory;
     // 初回 wiring 時に load 済み settings を即時反映する。
     if (m_queryHistory) {
-        applyMaxQueryHistoryToInstance(m_settingsManager->getSettings().general.maxQueryHistory);
+        applyMaxQueryHistoryToInstance(m_settingsAccessor->getSettings().general.maxQueryHistory);
     }
 }
 
@@ -190,7 +190,7 @@ SettingsProvider::SettingsProvider(SettingsProvider&&) noexcept = default;
 SettingsProvider& SettingsProvider::operator=(SettingsProvider&&) noexcept = default;
 
 std::string SettingsProvider::getSettings() {
-    const auto& s = m_settingsManager->getSettings();
+    const auto& s = m_settingsAccessor->getSettings();
     dto::SettingsResponse resp{s.general, s.editor, s.grid, s.query};
     std::string json;
     if (auto ec = glz::write_json(resp, json); bool(ec)) {
@@ -204,7 +204,7 @@ std::string SettingsProvider::updateSettings(std::string_view params) {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
-        AppSettings settings = m_settingsManager->getSettings();
+        AppSettings settings = m_settingsAccessor->getSettings();
 
         if (auto general = doc["general"]; !general.error()) {
             if (auto val = general["autoConnect"].get_bool(); !val.error())
@@ -257,8 +257,8 @@ std::string SettingsProvider::updateSettings(std::string_view params) {
                 settings.window.isMaximized = val.value();
         }
 
-        m_settingsManager->updateSettings(settings);
-        (void)m_settingsManager->save();
+        m_settingsAccessor->updateSettings(settings);
+        (void)m_settingsAccessor->save();
 
         applyQueryTimeoutToConnections(settings.query.timeoutSeconds);
         applyMaxQueryHistoryToInstance(settings.general.maxQueryHistory);
@@ -270,7 +270,7 @@ std::string SettingsProvider::updateSettings(std::string_view params) {
 }
 
 std::string SettingsProvider::getConnectionProfiles() {
-    const auto& profiles = m_settingsManager->getConnectionProfiles();
+    const auto& profiles = m_settingsAccessor->getConnectionProfiles();
     auto responses = profiles | std::views::transform(dto::toProfileResponse) | std::ranges::to<std::vector>();
     std::string profilesJson;
     if (auto ec = glz::write_json(responses, profilesJson); bool(ec)) {
@@ -331,21 +331,21 @@ std::string SettingsProvider::saveConnectionProfile(std::string_view params) {
             profile.id = std::format("profile_{}", std::chrono::system_clock::now().time_since_epoch().count());
         }
 
-        if (m_settingsManager->getConnectionProfile(profile.id).has_value()) {
-            m_settingsManager->updateConnectionProfile(profile);
+        if (m_settingsAccessor->getConnectionProfile(profile.id).has_value()) {
+            m_settingsAccessor->updateConnectionProfile(profile);
         } else {
-            m_settingsManager->addConnectionProfile(profile);
+            m_settingsAccessor->addConnectionProfile(profile);
         }
 
         if (profile.savePassword) {
             if (auto val = doc["password"].get_string(); !val.error()) {
                 auto password = std::string(val.value());
                 if (!password.empty()) {
-                    (void)m_settingsManager->setProfilePassword(profile.id, password);
+                    (void)m_settingsAccessor->setProfilePassword(profile.id, password);
                 }
             }
         } else {
-            (void)m_settingsManager->setProfilePassword(profile.id, "");
+            (void)m_settingsAccessor->setProfilePassword(profile.id, "");
         }
 
         if (auto ssh = doc["ssh"]; !ssh.error()) {
@@ -353,22 +353,22 @@ std::string SettingsProvider::saveConnectionProfile(std::string_view params) {
                 if (auto val = ssh["password"].get_string(); !val.error()) {
                     auto sshPassword = std::string(val.value());
                     if (!sshPassword.empty()) {
-                        (void)m_settingsManager->setSshPassword(profile.id, sshPassword);
+                        (void)m_settingsAccessor->setSshPassword(profile.id, sshPassword);
                     }
                 }
                 if (auto val = ssh["keyPassphrase"].get_string(); !val.error()) {
                     auto keyPassphrase = std::string(val.value());
                     if (!keyPassphrase.empty()) {
-                        (void)m_settingsManager->setSshKeyPassphrase(profile.id, keyPassphrase);
+                        (void)m_settingsAccessor->setSshKeyPassphrase(profile.id, keyPassphrase);
                     }
                 }
             } else {
-                (void)m_settingsManager->setSshPassword(profile.id, "");
-                (void)m_settingsManager->setSshKeyPassphrase(profile.id, "");
+                (void)m_settingsAccessor->setSshPassword(profile.id, "");
+                (void)m_settingsAccessor->setSshKeyPassphrase(profile.id, "");
             }
         }
 
-        (void)m_settingsManager->save();
+        (void)m_settingsAccessor->save();
 
         return JsonUtils::successResponse(std::format(R"({{"id":"{}"}})", JsonUtils::escapeString(profile.id)));
     } catch (const std::exception& e) {
@@ -386,8 +386,8 @@ std::string SettingsProvider::deleteConnectionProfile(std::string_view params) {
             return JsonUtils::errorResponse("Missing required field: id");
         }
         auto profileId = std::string(profileIdResult.value());
-        m_settingsManager->removeConnectionProfile(profileId);
-        (void)m_settingsManager->save();
+        m_settingsAccessor->removeConnectionProfile(profileId);
+        (void)m_settingsAccessor->save();
 
         return JsonUtils::successResponse(R"({"deleted":true})");
     } catch (const std::exception& e) {
@@ -406,7 +406,7 @@ std::string SettingsProvider::getProfilePassword(std::string_view params) {
         }
         auto profileId = std::string(idResult.value());
 
-        auto passwordResult = m_settingsManager->getProfilePassword(profileId);
+        auto passwordResult = m_settingsAccessor->getProfilePassword(profileId);
         if (!passwordResult) {
             return JsonUtils::errorResponse(passwordResult.error());
         }
@@ -428,7 +428,7 @@ std::string SettingsProvider::getSshPassword(std::string_view params) {
         }
         auto profileId = std::string(idResult.value());
 
-        auto passwordResult = m_settingsManager->getSshPassword(profileId);
+        auto passwordResult = m_settingsAccessor->getSshPassword(profileId);
         if (!passwordResult) {
             return JsonUtils::errorResponse(passwordResult.error());
         }
@@ -450,7 +450,7 @@ std::string SettingsProvider::getSshKeyPassphrase(std::string_view params) {
         }
         auto profileId = std::string(idResult.value());
 
-        auto passphraseResult = m_settingsManager->getSshKeyPassphrase(profileId);
+        auto passphraseResult = m_settingsAccessor->getSshKeyPassphrase(profileId);
         if (!passphraseResult) {
             return JsonUtils::errorResponse(passphraseResult.error());
         }
@@ -462,7 +462,7 @@ std::string SettingsProvider::getSshKeyPassphrase(std::string_view params) {
 }
 
 std::string SettingsProvider::getSessionState() {
-    const auto& state = m_sessionManager->getState();
+    const auto& state = m_sessionAccessor->getState();
     auto resp = dto::toSessionResponse(state);
     std::string json;
     if (auto ec = glz::write_json(resp, json); bool(ec)) {
@@ -476,7 +476,7 @@ std::string SettingsProvider::saveSessionState(std::string_view params) {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params);
 
-        SessionState state = m_sessionManager->getState();
+        SessionState state = m_sessionAccessor->getState();
 
         if (auto val = doc["activeConnectionId"].get_string(); !val.error())
             state.activeConnectionId = std::string(val.value());
@@ -528,8 +528,8 @@ std::string SettingsProvider::saveSessionState(std::string_view params) {
             }
         }
 
-        m_sessionManager->updateState(state);
-        (void)m_sessionManager->save();
+        m_sessionAccessor->updateState(state);
+        (void)m_sessionAccessor->save();
 
         return JsonUtils::successResponse(R"({"saved":true})");
     } catch (const std::exception& e) {

--- a/backend/providers/settings_provider.h
+++ b/backend/providers/settings_provider.h
@@ -8,8 +8,8 @@
 
 namespace velocitydb {
 
-class SettingsManager;
-class SessionManager;
+class SettingsAccessor;
+class SessionAccessor;
 class IConnectionProvider;
 class QueryHistory;
 
@@ -42,17 +42,17 @@ public:
     [[nodiscard]] std::string getSessionState() override;
     [[nodiscard]] std::string saveSessionState(std::string_view params) override;
 
-    [[nodiscard]] SettingsManager& settingsManager() { return *m_settingsManager; }
-    [[nodiscard]] const SettingsManager& settingsManager() const { return *m_settingsManager; }
-    [[nodiscard]] SessionManager& sessionManager() { return *m_sessionManager; }
-    [[nodiscard]] const SessionManager& sessionManager() const { return *m_sessionManager; }
+    [[nodiscard]] SettingsAccessor& settingsAccessor() { return *m_settingsAccessor; }
+    [[nodiscard]] const SettingsAccessor& settingsAccessor() const { return *m_settingsAccessor; }
+    [[nodiscard]] SessionAccessor& sessionAccessor() { return *m_sessionAccessor; }
+    [[nodiscard]] const SessionAccessor& sessionAccessor() const { return *m_sessionAccessor; }
 
 private:
     void applyQueryTimeoutToConnections(int seconds);
     void applyMaxQueryHistoryToInstance(int maxItems);
 
-    std::unique_ptr<SettingsManager> m_settingsManager;
-    std::unique_ptr<SessionManager> m_sessionManager;
+    std::unique_ptr<SettingsAccessor> m_settingsAccessor;
+    std::unique_ptr<SessionAccessor> m_sessionAccessor;
     IConnectionProvider* m_connections;      // Non-owning; may be null in tests
     QueryHistory* m_queryHistory = nullptr;  // Non-owning; wired post-construction by SystemContext
 };

--- a/backend/webview_app.cpp
+++ b/backend/webview_app.cpp
@@ -1,10 +1,10 @@
 #include "webview_app.h"
 
+#include "accessors/settings_accessor.h"
 #include "contexts/system_context.h"
 #include "ipc_handler.h"
 #include "simdjson.h"
 #include "utils/logger.h"
-#include "utils/settings_manager.h"
 #include "version_config.h"
 #include "webview.h"
 
@@ -47,9 +47,9 @@ WebViewApp::WebViewApp(HINSTANCE hInstance)
     , m_systemContext(std::make_unique<SystemContext>())
     , m_ipcHandler(std::make_unique<IPCHandler>(*m_systemContext))
     , m_webview(nullptr)
-    , m_settingsManager(std::make_unique<SettingsManager>()) {
+    , m_settingsAccessor(std::make_unique<SettingsAccessor>()) {
     // Load settings (best-effort — defaults used on failure)
-    (void)m_settingsManager->load();
+    (void)m_settingsAccessor->load();
 }
 
 WebViewApp::~WebViewApp() = default;
@@ -86,7 +86,7 @@ std::expected<std::filesystem::path, std::string> WebViewApp::locateFrontendDire
 }
 
 WebViewApp::WindowSize WebViewApp::calculateWindowSize() const {
-    const auto& windowSettings = m_settingsManager->getSettings().window;
+    const auto& windowSettings = m_settingsAccessor->getSettings().window;
 
     // If we have saved settings and they are valid, use them
     if (windowSettings.width > 0 && windowSettings.height > 0) {

--- a/backend/webview_app.h
+++ b/backend/webview_app.h
@@ -15,7 +15,7 @@ namespace velocitydb {
 
 class IPCHandler;
 class SystemContext;
-class SettingsManager;
+class SettingsAccessor;
 
 class WebViewApp {
 public:
@@ -48,7 +48,7 @@ private:
     std::unique_ptr<SystemContext> m_systemContext;
     std::unique_ptr<IPCHandler> m_ipcHandler;
     std::unique_ptr<webview::webview> m_webview;
-    std::unique_ptr<SettingsManager> m_settingsManager;
+    std::unique_ptr<SettingsAccessor> m_settingsAccessor;
 };
 
 }  // namespace velocitydb

--- a/tests/providers/test_settings_provider.cpp
+++ b/tests/providers/test_settings_provider.cpp
@@ -4,8 +4,8 @@
 
 #include "database/query_history.h"
 #include "providers/settings_provider.h"
-#include "utils/session_manager.h"
-#include "utils/settings_manager.h"
+#include "accessors/session_accessor.h"
+#include "accessors/settings_accessor.h"
 
 namespace velocitydb {
 namespace {
@@ -16,7 +16,7 @@ protected:
     // ユーザー設定との state リークを防ぐ。SetUp で元の maxQueryHistory を退避してから
     // 1000 にリセット、TearDown で退避値に復元する (ユーザー設定を破壊しない)。
     void SetUp() override {
-        m_savedMaxQueryHistory = provider.settingsManager().getSettings().general.maxQueryHistory;
+        m_savedMaxQueryHistory = provider.settingsAccessor().getSettings().general.maxQueryHistory;
         auto resetResult = provider.updateSettings(R"({"general":{"maxQueryHistory":1000}})");
         ASSERT_NE(resetResult.find("\"saved\""), std::string::npos);
     }
@@ -30,20 +30,20 @@ protected:
     int m_savedMaxQueryHistory = 1000;
 };
 
-TEST_F(SettingsProviderTest, AccessSettingsManager) {
-    // Verify direct access to SettingsManager works
-    auto& manager = provider.settingsManager();
-    const auto& settings = manager.getSettings();
+TEST_F(SettingsProviderTest, AccessSettingsAccessor) {
+    // Verify direct access to SettingsAccessor works
+    auto& accessor = provider.settingsAccessor();
+    const auto& settings = accessor.getSettings();
 
     // Default settings should have reasonable values
     EXPECT_GT(settings.editor.fontSize, 0);
     EXPECT_FALSE(settings.editor.fontFamily.empty());
 }
 
-TEST_F(SettingsProviderTest, AccessSessionManager) {
-    // Verify direct access to SessionManager works
-    auto& manager = provider.sessionManager();
-    const auto& state = manager.getState();
+TEST_F(SettingsProviderTest, AccessSessionAccessor) {
+    // Verify direct access to SessionAccessor works
+    auto& accessor = provider.sessionAccessor();
+    const auto& state = accessor.getState();
 
     // Default session state should have reasonable values
     EXPECT_GE(state.windowWidth, 0);

--- a/tests/utils/test_glaze_meta_roundtrip.cpp
+++ b/tests/utils/test_glaze_meta_roundtrip.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
-#include "utils/glaze_meta.h"
-#include "utils/settings_manager.h"
+#include "accessors/glaze_meta.h"
+#include "accessors/settings_accessor.h"
 
 #include <glaze/glaze.hpp>
 
@@ -35,7 +35,7 @@ TEST(GlazeMetaConnectionProfile, PreservesFolderPathAcrossRoundTrip) {
 }
 
 TEST(GlazeMetaConnectionProfile, PreservesFolderPathThroughAppSettingsRoundTrip) {
-    // 本番フロー (SettingsManager::serializeSettings/deserializeSettings) と同じ
+    // 本番フロー (SettingsAccessor::serializeSettings/deserializeSettings) と同じ
     // AppSettings → connectionProfiles 経由で folderPath が保持されることを確認する。
     AppSettings original;
     ConnectionProfile a;


### PR DESCRIPTION
Closes #447 (parent: #393)

## Summary

- `SettingsManager` / `SessionManager` を `SettingsAccessor` / `SessionAccessor` にリネームし、`backend/utils/` → `backend/accessors/` に昇格
- `glaze_meta.h` も `accessors/` に同居させ、utils/ (#6) → accessors/ (#4) の下位→上位依存違反を解消
- `~/.claude/rules/hierarchical-architecture.md` の表 #4「特定リソースへのアクセス (`*Accessor` / `*Client`)」に整合

## Why (`*Manager` ではなく `*Accessor` が正しい理由)

| 観点 | 元 (`*Manager`) | 実態 |
| ------ | ---------------- | ------ |
| 他コンポーネントのライフサイクル管理 | あるはず | ❌ 一切なし |
| 内部構成 | サブコンポーネント保有 | POD struct + ファイルパス + mutex のみ |
| 責務 | 下位の生成/破棄 | settings.json + DPAPI 資格情報の **直接アクセス** |

→ 階層アーキテクチャ表 #4 の Accessor が一致。誤って `managers/` に昇格すると provider (#3) → manager (#2)
という下位→上位依存違反が発生していた。

## 変更内容

| 種類 | 対象 |
| ------ | ------ |
| rename + move | `utils/{settings,session}_manager.{cpp,h}` → `accessors/{settings,session}_accessor.{cpp,h}` |
| rename + move | `utils/glaze_meta.h` → `accessors/glaze_meta.h` (レイヤー違反解消) |
| クラス名 | `SettingsManager` / `SessionManager` → `SettingsAccessor` / `SessionAccessor` |
| メンバ名 | `m_settingsManager` / `m_sessionManager` → `m_settingsAccessor` / `m_sessionAccessor` |
| getter | `settingsManager()` / `sessionManager()` → `settingsAccessor()` / `sessionAccessor()` |
| include path 追従 | 14 ファイル (`utils/...` → `accessors/...`) |
| CMakeLists.txt | `# Accessors (Layer #4 — direct resource access)` セクション新設 |

## 影響範囲

| 項目 | 変更 |
| ------ | ------ |
| 動作変更 | **なし** (純粋 rename + move) |
| 公開 IPC API | 変更なし (frontend 影響なし) |
| 設定ファイルフォーマット | 変更なし (settings.json / session.json 互換) |
| include path | 14 ファイルで追従済 (残存参照 0 件確認) |

## 完了条件

- [x] backend ビルド成功 (`uv run scripts/pdg.py build backend` → BUILD SUCCESSFUL)
- [x] backend テスト pass (`uv run scripts/pdg.py test backend` → All tests passed / 316 pass + Disabled 8)
- [x] 残存 `SettingsManager` / `SessionManager` / `settings_manager` / `session_manager` / `utils/glaze_meta` 参照ゼロ確認
- [x] frontend に影響なし (IPC API 互換性維持)
- [x] code-review 2 回パス (#1 で 3 Suggestions 検出 → 全 fix → #2 で PASS)

## Test plan

- [ ] CI: backend build (Release) 緑
- [ ] CI: backend tests 緑
- [ ] レビュアー: `~/.claude/rules/hierarchical-architecture.md` の Accessor 定義との整合確認
- [ ] レビュアー: `backend/accessors/glaze_meta.h` の同層配置が違和感ないか確認

## 次の Phase 1 サブイシュー

- `#448 (393-B)`: `utils/global_search` / `utils/simd_filter` → `backend/search/` 昇格