### PR TITLE
refactor(frontend): MainLayout の keyboard shortcut を useKeyboardShortcutHandler (操作層) に抽出 (#460)

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useFileDrop } from '../../hooks/useFileDrop';
-import { useKeyboardHandler } from '../../hooks/useKeyboardHandler';
+import { useKeyboardShortcutHandler } from '../../hooks/useKeyboardShortcutHandler';
 import { applyConnectionMigration } from '../../store/connectionMigration';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useQueryStore } from '../../store/queryStore';
@@ -247,37 +247,16 @@ export function MainLayout() {
 
   const hasOpenDialog = isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen;
 
-  // Keyboard shortcuts
-  useKeyboardHandler((e: KeyboardEvent) => {
-    // Prevent F5 page reload
-    if (e.key === 'F5') {
-      e.preventDefault();
-      return;
-    }
-
-    if (e.ctrlKey && e.key === 'n') {
-      e.preventDefault();
-      handleNewQuery();
-    } else if (e.ctrlKey && e.key === 'w') {
-      e.preventDefault();
-      handleCloseTab();
-    } else if (e.key === 'F9' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
-      // F9 単独のみ実行トリガ。Ctrl/Shift/Alt+F9 は将来の拡張用に予約
-      e.preventDefault();
-      handleExecute();
-    } else if (e.ctrlKey && e.shiftKey && e.key === 'F') {
-      e.preventDefault();
-      handleFormat();
-    } else if (e.ctrlKey && e.shiftKey && e.key === 'P') {
-      e.preventDefault();
-      handleOpenSearch();
-    } else if (e.ctrlKey && e.key === ',') {
-      e.preventDefault();
-      handleOpenSettings();
-    } else if (e.key === 'Escape' && isExecuting && !hasOpenDialog) {
-      e.preventDefault();
-      handleCancel();
-    }
+  useKeyboardShortcutHandler({
+    onNewQuery: handleNewQuery,
+    onCloseTab: handleCloseTab,
+    onExecute: handleExecute,
+    onFormat: handleFormat,
+    onOpenSearch: handleOpenSearch,
+    onOpenSettings: handleOpenSettings,
+    onCancel: handleCancel,
+    isExecuting,
+    hasOpenDialog,
   });
 
   // Track and save window size/position

--- a/frontend/src/hooks/useKeyboardShortcutHandler.ts
+++ b/frontend/src/hooks/useKeyboardShortcutHandler.ts
@@ -1,0 +1,57 @@
+import { useKeyboardHandler } from './useKeyboardHandler';
+
+export interface KeyboardShortcutCallbacks {
+  onNewQuery: () => void;
+  onCloseTab: () => void;
+  onExecute: () => void;
+  onFormat: () => void;
+  onOpenSearch: () => void;
+  onOpenSettings: () => void;
+  onCancel: () => void;
+}
+
+export interface UseKeyboardShortcutHandlerParams extends KeyboardShortcutCallbacks {
+  isExecuting: boolean;
+  hasOpenDialog: boolean;
+}
+
+/**
+ * MainLayout レベルのアプリケーションショートカット束を window keydown に bind する操作層 hook。
+ * 内部で useKeyboardHandler (capture phase + ref-based) を 1 個だけ呼び、
+ * Monaco Editor の stopPropagation を貫通させる。
+ *
+ * 運用ルール: 同一キーへの listener 二重登録を避けるため、本 hook を MainLayout 以外で呼ばない。
+ * 詳細は useKeyboardHandler.ts L3-6 (Monaco stopPropagation 貫通のための capture phase 仕様) 参照。
+ */
+export function useKeyboardShortcutHandler(params: UseKeyboardShortcutHandlerParams): void {
+  useKeyboardHandler((e: KeyboardEvent) => {
+    if (e.key === 'F5') {
+      e.preventDefault();
+      return;
+    }
+
+    if (e.ctrlKey && e.key === 'n') {
+      e.preventDefault();
+      params.onNewQuery();
+    } else if (e.ctrlKey && e.key === 'w') {
+      e.preventDefault();
+      params.onCloseTab();
+    } else if (e.key === 'F9' && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      // F9 単独のみ実行トリガ。Ctrl/Shift/Alt+F9 は将来の拡張用に予約
+      e.preventDefault();
+      params.onExecute();
+    } else if (e.ctrlKey && e.shiftKey && e.key === 'F') {
+      e.preventDefault();
+      params.onFormat();
+    } else if (e.ctrlKey && e.shiftKey && e.key === 'P') {
+      e.preventDefault();
+      params.onOpenSearch();
+    } else if (e.ctrlKey && e.key === ',') {
+      e.preventDefault();
+      params.onOpenSettings();
+    } else if (e.key === 'Escape' && params.isExecuting && !params.hasOpenDialog) {
+      e.preventDefault();
+      params.onCancel();
+    }
+  });
+}

--- a/frontend/src/tests/hooks/useKeyboardShortcutHandler.test.ts
+++ b/frontend/src/tests/hooks/useKeyboardShortcutHandler.test.ts
@@ -1,0 +1,228 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  type KeyboardShortcutCallbacks,
+  useKeyboardShortcutHandler,
+} from '../../hooks/useKeyboardShortcutHandler';
+
+function createCallbacks(): KeyboardShortcutCallbacks {
+  return {
+    onNewQuery: vi.fn(),
+    onCloseTab: vi.fn(),
+    onExecute: vi.fn(),
+    onFormat: vi.fn(),
+    onOpenSearch: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onCancel: vi.fn(),
+  };
+}
+
+function dispatchKey(init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { cancelable: true, ...init });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe('useKeyboardShortcutHandler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('invokes onNewQuery on Ctrl+N and prevents default', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: 'n', ctrlKey: true });
+
+    expect(cbs.onNewQuery).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('invokes onCloseTab on Ctrl+W and prevents default', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: 'w', ctrlKey: true });
+
+    expect(cbs.onCloseTab).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('invokes onExecute on F9 alone and prevents default', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: 'F9' });
+
+    expect(cbs.onExecute).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does NOT invoke onExecute on Ctrl+F9', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    dispatchKey({ key: 'F9', ctrlKey: true });
+
+    expect(cbs.onExecute).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invoke onExecute on Shift+F9', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    dispatchKey({ key: 'F9', shiftKey: true });
+
+    expect(cbs.onExecute).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invoke onExecute on Alt+F9', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    dispatchKey({ key: 'F9', altKey: true });
+
+    expect(cbs.onExecute).not.toHaveBeenCalled();
+  });
+
+  it('invokes onFormat on Ctrl+Shift+F and prevents default', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: 'F', ctrlKey: true, shiftKey: true });
+
+    expect(cbs.onFormat).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('invokes onOpenSearch on Ctrl+Shift+P and prevents default', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: 'P', ctrlKey: true, shiftKey: true });
+
+    expect(cbs.onOpenSearch).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('invokes onOpenSettings on Ctrl+, and prevents default', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: ',', ctrlKey: true });
+
+    expect(cbs.onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('invokes onCancel on Escape when isExecuting=true and hasOpenDialog=false', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: true, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: 'Escape' });
+
+    expect(cbs.onCancel).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does NOT invoke onCancel on Escape when isExecuting=false', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    dispatchKey({ key: 'Escape' });
+
+    expect(cbs.onCancel).not.toHaveBeenCalled();
+  });
+
+  it('does NOT invoke onCancel on Escape when hasOpenDialog=true', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: true, hasOpenDialog: true })
+    );
+
+    dispatchKey({ key: 'Escape' });
+
+    expect(cbs.onCancel).not.toHaveBeenCalled();
+  });
+
+  it('prevents default on F5 to block page reload and invokes no callback', () => {
+    const cbs = createCallbacks();
+    renderHook(() =>
+      useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false })
+    );
+
+    const event = dispatchKey({ key: 'F5' });
+
+    expect(event.defaultPrevented).toBe(true);
+    for (const cb of Object.values(cbs)) {
+      expect(cb).not.toHaveBeenCalled();
+    }
+  });
+
+  it('reflects latest isExecuting/hasOpenDialog after rerender (no stale closure on boolean params)', () => {
+    const cbs = createCallbacks();
+
+    const { rerender } = renderHook(
+      ({ isExecuting, hasOpenDialog }: { isExecuting: boolean; hasOpenDialog: boolean }) =>
+        useKeyboardShortcutHandler({ ...cbs, isExecuting, hasOpenDialog }),
+      { initialProps: { isExecuting: false, hasOpenDialog: false } }
+    );
+
+    dispatchKey({ key: 'Escape' });
+    expect(cbs.onCancel).not.toHaveBeenCalled();
+
+    act(() => {
+      rerender({ isExecuting: true, hasOpenDialog: false });
+    });
+    dispatchKey({ key: 'Escape' });
+    expect(cbs.onCancel).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      rerender({ isExecuting: true, hasOpenDialog: true });
+    });
+    dispatchKey({ key: 'Escape' });
+    expect(cbs.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses latest callbacks after rerender (no stale closure)', () => {
+    const first = createCallbacks();
+    const second = createCallbacks();
+
+    const { rerender } = renderHook(
+      ({ cbs }: { cbs: KeyboardShortcutCallbacks }) =>
+        useKeyboardShortcutHandler({ ...cbs, isExecuting: false, hasOpenDialog: false }),
+      { initialProps: { cbs: first } }
+    );
+
+    act(() => {
+      rerender({ cbs: second });
+    });
+
+    dispatchKey({ key: 'n', ctrlKey: true });
+
+    expect(first.onNewQuery).not.toHaveBeenCalled();
+    expect(second.onNewQuery).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Phase 1 of #457
Closes  #460
