### PR TITLE
feat: IQueryProvider/ISettingsProvider を ISP 準拠の sub-IF に分割

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -118,6 +118,12 @@ set(HEADERS
     interfaces/system_context.h
     interfaces/providers/connection_provider.h
     interfaces/providers/query_provider.h
+    # ISP-split sub-IFs of IQueryProvider (#449); 集約 IF は Phase 4 (#456) で解体予定
+    interfaces/providers/query_executor.h
+    interfaces/providers/result_filter.h
+    interfaces/providers/result_cache_control.h
+    interfaces/providers/query_history_accessor.h
+    interfaces/providers/dialect_sql_builder.h
     interfaces/providers/async_query_provider.h
     interfaces/providers/schema_provider.h
     interfaces/providers/transaction_provider.h
@@ -125,6 +131,10 @@ set(HEADERS
     interfaces/providers/search_provider.h
     interfaces/providers/utility_provider.h
     interfaces/providers/settings_provider.h
+    # ISP-split sub-IFs of ISettingsProvider (#450); 集約 IF は Phase 4 (#456) で解体予定
+    interfaces/providers/app_settings_accessor.h
+    interfaces/providers/connection_profile_accessor.h
+    interfaces/providers/session_state_accessor.h
     interfaces/providers/io_provider.h
     interfaces/providers/lint_provider.h
     # Contexts

--- a/backend/interfaces/providers/app_settings_accessor.h
+++ b/backend/interfaces/providers/app_settings_accessor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for application-wide settings retrieval and update (操作層)
+class IAppSettingsAccessor {
+public:
+    virtual ~IAppSettingsAccessor() = default;
+
+    [[nodiscard]] virtual std::string getSettings() = 0;
+    [[nodiscard]] virtual std::string updateSettings(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/connection_profile_accessor.h
+++ b/backend/interfaces/providers/connection_profile_accessor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for connection profile CRUD and credential retrieval (操作層).
+/// NOTE: credential getters (getProfilePassword / getSshPassword / getSshKeyPassphrase)
+/// are co-located here per issue #450 directive, but represent a secondary responsibility.
+/// Re-evaluate splitting into ICredentialAccessor alongside Phase 4 (#456).
+class IConnectionProfileAccessor {
+public:
+    virtual ~IConnectionProfileAccessor() = default;
+
+    [[nodiscard]] virtual std::string getConnectionProfiles() = 0;
+    [[nodiscard]] virtual std::string saveConnectionProfile(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string deleteConnectionProfile(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getProfilePassword(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getSshPassword(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getSshKeyPassphrase(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/dialect_sql_builder.h
+++ b/backend/interfaces/providers/dialect_sql_builder.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for dialect-aware SQL string construction (操作層;
+/// hierarchical-architecture 命名表の許容句「責務が操作層に一致」を適用)
+class IDialectSqlBuilder {
+public:
+    virtual ~IDialectSqlBuilder() = default;
+
+    [[nodiscard]] virtual std::string buildDataViewSql(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string buildWhereClause(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string buildDmlStatements(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/query_executor.h
+++ b/backend/interfaces/providers/query_executor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for query execution and cancellation (操作層;
+/// hierarchical-architecture 命名表の許容句「責務が操作層に一致」を適用)
+class IQueryExecutor {
+public:
+    virtual ~IQueryExecutor() = default;
+
+    [[nodiscard]] virtual std::string executeQuery(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string executeQueryPaginated(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string getRowCount(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string cancelQuery(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/query_history_accessor.h
+++ b/backend/interfaces/providers/query_history_accessor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for query history CRUD operations (操作層)
+class IQueryHistoryAccessor {
+public:
+    virtual ~IQueryHistoryAccessor() = default;
+
+    [[nodiscard]] virtual std::string getQueryHistory(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string removeQueryHistory(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string clearQueryHistory(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string setQueryHistoryFavorite(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/query_provider.h
+++ b/backend/interfaces/providers/query_provider.h
@@ -1,31 +1,24 @@
 #pragma once
 
-#include <string>
-#include <string_view>
+#include "interfaces/providers/dialect_sql_builder.h"
+#include "interfaces/providers/query_executor.h"
+#include "interfaces/providers/query_history_accessor.h"
+#include "interfaces/providers/result_cache_control.h"
+#include "interfaces/providers/result_filter.h"
 
 namespace velocitydb {
 
-/// Interface for query execution, cache, history, and filtering
-class IQueryProvider {
+/// Aggregate interface for query-related responsibilities (ISP-split into 5 sub-interfaces).
+/// Retained for SystemContext / ipc_handler return-type compatibility; scheduled to be
+/// dissolved in #456 (Phase 4) once SystemContext exposes the sub-interfaces directly.
+class IQueryProvider
+    : public IQueryExecutor
+    , public IResultFilter
+    , public IResultCacheControl
+    , public IQueryHistoryAccessor
+    , public IDialectSqlBuilder {
 public:
-    virtual ~IQueryProvider() = default;
-
-    [[nodiscard]] virtual std::string executeQuery(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string executeQueryPaginated(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getRowCount(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string cancelQuery(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string filterResultSet(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getCacheStats(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string clearCache(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getQueryHistory(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string removeQueryHistory(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string clearQueryHistory(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string setQueryHistoryFavorite(std::string_view params) = 0;
-
-    // SQL builder (dialect-aware)
-    [[nodiscard]] virtual std::string buildDataViewSql(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string buildWhereClause(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string buildDmlStatements(std::string_view params) = 0;
+    ~IQueryProvider() override = default;
 };
 
 }  // namespace velocitydb

--- a/backend/interfaces/providers/result_cache_control.h
+++ b/backend/interfaces/providers/result_cache_control.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for query result cache inspection and control (操作層)
+class IResultCacheControl {
+public:
+    virtual ~IResultCacheControl() = default;
+
+    [[nodiscard]] virtual std::string getCacheStats(std::string_view params) = 0;
+    [[nodiscard]] virtual std::string clearCache(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/result_filter.h
+++ b/backend/interfaces/providers/result_filter.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for filtering an existing result set (操作層;
+/// hierarchical-architecture 命名表の許容句「責務が操作層に一致」を適用)
+class IResultFilter {
+public:
+    virtual ~IResultFilter() = default;
+
+    [[nodiscard]] virtual std::string filterResultSet(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/session_state_accessor.h
+++ b/backend/interfaces/providers/session_state_accessor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+/// Interface for session state persistence (操作層)
+class ISessionStateAccessor {
+public:
+    virtual ~ISessionStateAccessor() = default;
+
+    [[nodiscard]] virtual std::string getSessionState() = 0;
+    [[nodiscard]] virtual std::string saveSessionState(std::string_view params) = 0;
+};
+
+}  // namespace velocitydb

--- a/backend/interfaces/providers/settings_provider.h
+++ b/backend/interfaces/providers/settings_provider.h
@@ -1,25 +1,20 @@
 #pragma once
 
-#include <string>
-#include <string_view>
+#include "interfaces/providers/app_settings_accessor.h"
+#include "interfaces/providers/connection_profile_accessor.h"
+#include "interfaces/providers/session_state_accessor.h"
 
 namespace velocitydb {
 
-/// Interface for application settings and session management
-class ISettingsProvider {
+/// Aggregate interface for settings-related responsibilities (ISP-split into 3 sub-interfaces).
+/// Retained for SystemContext / ipc_handler return-type compatibility; scheduled to be
+/// dissolved in #456 (Phase 4) once SystemContext exposes the sub-interfaces directly.
+class ISettingsProvider
+    : public IAppSettingsAccessor
+    , public IConnectionProfileAccessor
+    , public ISessionStateAccessor {
 public:
-    virtual ~ISettingsProvider() = default;
-
-    [[nodiscard]] virtual std::string getSettings() = 0;
-    [[nodiscard]] virtual std::string updateSettings(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getConnectionProfiles() = 0;
-    [[nodiscard]] virtual std::string saveConnectionProfile(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string deleteConnectionProfile(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getProfilePassword(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getSshPassword(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getSshKeyPassphrase(std::string_view params) = 0;
-    [[nodiscard]] virtual std::string getSessionState() = 0;
-    [[nodiscard]] virtual std::string saveSessionState(std::string_view params) = 0;
+    ~ISettingsProvider() override = default;
 };
 
 }  // namespace velocitydb

--- a/tests/providers/test_settings_provider.cpp
+++ b/tests/providers/test_settings_provider.cpp
@@ -3,6 +3,9 @@
 #include <format>
 
 #include "database/query_history.h"
+#include "interfaces/providers/app_settings_accessor.h"
+#include "interfaces/providers/connection_profile_accessor.h"
+#include "interfaces/providers/session_state_accessor.h"
 #include "providers/settings_provider.h"
 #include "accessors/session_accessor.h"
 #include "accessors/settings_accessor.h"
@@ -114,6 +117,21 @@ TEST_F(SettingsProviderTest, SetQueryHistoryAppliesLoadedMaxToInstance) {
     provider.setQueryHistory(&queryHistory);
 
     EXPECT_EQ(queryHistory.getAll().size(), 3u);
+}
+
+TEST_F(SettingsProviderTest, SubInterfacesAreUsableIndependently) {
+    // ISP 分割 (#450) の検証: SettingsProvider が各サブ IF として個別に受け取れ、
+    // それぞれの代表メソッドが集約 IF 経由と同じ結果を返すことを保証する。Phase 4
+    // (#456) で SystemContext がサブ IF を直接公開する際の前提を固める。
+    IAppSettingsAccessor& asAppSettings = provider;
+    IConnectionProfileAccessor& asProfile = provider;
+    ISessionStateAccessor& asSession = provider;
+
+    // 集約 IF 経由とサブ IF 経由で同一値が返ることを検証する。
+    // Phase 4 (#456) でサブ IF を直接公開した際の振る舞い等価性を保証する。
+    EXPECT_EQ(asAppSettings.getSettings(), provider.getSettings());
+    EXPECT_EQ(asProfile.getConnectionProfiles(), provider.getConnectionProfiles());
+    EXPECT_EQ(asSession.getSessionState(), provider.getSessionState());
 }
 
 }  // namespace


### PR DESCRIPTION
- IQueryProvider を 5 sub-IF に分割 (#449): `IQueryExecutor / IResultFilter / IResultCacheControl / IQueryHistoryAccessor / IDialectSqlBuilder`
- ISettingsProvider を 3 sub-IF に分割 (#450): `IAppSettingsAccessor / IConnectionProfileAccessor / ISessionStateAccessor`
- 旧 IF は新 sub-IF を多重継承する集約 IF として保持し `SystemContext / ipc_handler / frontend / 既存テスト` はすべて無変更 (IPC 互換維持) 
- Phase 4 (#456) で集約 IF を解体し `SystemContext` から `sub-IF` を直接公開予定
- ISP 分割の振る舞い等価性を集約 IF vs sub-IF の同値検証で保証する `SubInterfacesAreUsableIndependently` テストを追加 

premise-questioning: skipped (理由: 親 #393 で承認済みの ISP 分割
振る舞い不変・外部依存追加なし・IPC 互換維持の純粋な構造リファクタ)
feature-pruning: 対象外 (機能追加・削除なし)

Closes #449
Closes #450