### PR TITLE
refactor(backend): query_provider から SqlBuilder ロジック抽出 (#451)

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -35,6 +35,7 @@ set(LIB_SOURCES
     database/transaction_manager.cpp
     database/odbc_driver_detector.cpp
     database/connection_utils.cpp
+    database/sql_builder.cpp
     # Contexts
     contexts/system_context.cpp
     # Providers
@@ -102,6 +103,7 @@ set(HEADERS
     database/transaction_manager.h
     database/odbc_driver_detector.h
     database/connection_utils.h
+    database/sql_builder.h
     # Interfaces (Driver ISP)
     interfaces/connectable.h
     interfaces/query_executable.h

--- a/backend/database/sql_builder.cpp
+++ b/backend/database/sql_builder.cpp
@@ -1,0 +1,192 @@
+#include "sql_builder.h"
+
+#include "../interfaces/sql_formattable.h"
+
+namespace velocitydb {
+
+namespace {
+
+/// SET / VALUES で共通の右辺リテラル化。
+/// null → "NULL" / string → quoteLiteral / 他 → minify した値を quoteLiteral で包む。
+void appendValueLiteral(std::string& out, const ISqlFormattable& fmt, simdjson::dom::element value) {
+    if (value.is_null()) {
+        out += "NULL";
+        return;
+    }
+    if (auto v = value.get_string(); !v.error()) {
+        out += fmt.quoteLiteral(v.value());
+        return;
+    }
+    out += fmt.quoteLiteral(simdjson::minify(value));
+}
+
+/// 等値比較 `<col> = <literal>` を whereOut に追記 (null は `IS NULL`)。
+/// 既に節がある場合は ` AND ` を前置。値ソースは Lookup 経由で抽象化 (UPDATE / DELETE 共通)。
+template <typename Lookup>
+void appendEqualityFromLookup(std::string& whereOut, const ISqlFormattable& fmt, std::string_view colName, Lookup&& lookup) {
+    if (!whereOut.empty())
+        whereOut += " AND ";
+    auto col = fmt.quoteIdentifier(colName);
+    auto val = lookup(colName);
+    if (val.error() || val.value().is_null()) {
+        whereOut += col + " IS NULL";
+        return;
+    }
+    if (auto v = val.value().get_string(); !v.error()) {
+        whereOut += col + " = " + fmt.quoteLiteral(v.value());
+        return;
+    }
+    whereOut += col + " = " + fmt.quoteLiteral(simdjson::minify(val.value()));
+}
+
+}  // namespace
+
+SqlBuilder::SqlBuilder(const ISqlFormattable& formatter) noexcept : m_formatter(formatter) {}
+
+std::string SqlBuilder::fullyQualifiedTable(std::string_view schema, std::string_view table) const {
+    if (schema.empty())
+        return m_formatter.quoteIdentifier(table);
+    return m_formatter.quoteIdentifier(schema) + "." + m_formatter.quoteIdentifier(table);
+}
+
+std::string SqlBuilder::buildDataView(std::string_view tableName, std::string_view whereClause, int64_t limit) const {
+    auto quotedTable = m_formatter.quoteIdentifier(tableName);
+    if (!whereClause.empty())
+        return m_formatter.buildSelectAllWhere(quotedTable, whereClause, limit);
+    return m_formatter.buildSelectAll(quotedTable, limit);
+}
+
+std::string SqlBuilder::buildWhere(simdjson::dom::array conditions) const {
+    // NOTE: 数値/真偽値は非 quote 埋め込み (`= 42`)。UPDATE/DELETE 用の
+    //       appendEqualityFromLookup (常に quoteLiteral) とは敢えて挙動を分けている
+    //       (元実装互換)。統一する場合は IPC スキーマと frontend 側
+    //       (api/bridge.ts: buildWhereClause 呼び出し元) の確認が必要。
+    std::string whereClause;
+    for (auto condition : conditions) {
+        auto columnResult = condition["column"].get_string();
+        if (columnResult.error())
+            continue;
+
+        if (!whereClause.empty())
+            whereClause += " AND ";
+
+        auto quotedCol = m_formatter.quoteIdentifier(columnResult.value());
+
+        auto valueEl = condition["value"];
+        if (valueEl.error() || valueEl.is_null()) {
+            whereClause += quotedCol + " IS NULL";
+        } else if (auto v = valueEl.get_string(); !v.error()) {
+            whereClause += quotedCol + " = " + m_formatter.quoteLiteral(v.value());
+        } else if (!valueEl.get_int64().error() || !valueEl.get_uint64().error() || !valueEl.get_double().error() || !valueEl.get_bool().error()) {
+            // 数値/真偽値は文字列内容を持たないので素の値で埋め込み可
+            whereClause += quotedCol + " = " + simdjson::minify(valueEl.value());
+        } else {
+            // 不明型: 安全側に倒して quoteLiteral
+            whereClause += quotedCol + " = " + m_formatter.quoteLiteral(simdjson::minify(valueEl.value()));
+        }
+    }
+    return whereClause;
+}
+
+std::string SqlBuilder::buildUpdateStmt(std::string_view fullTable, const std::vector<std::string>& pkColumns, simdjson::dom::element update) const {
+    auto changesObj = update["changes"].get_object();
+    if (changesObj.error())
+        return {};
+
+    std::string setClauses;
+    for (auto field : changesObj.value()) {
+        if (!setClauses.empty())
+            setClauses += ", ";
+        setClauses += m_formatter.quoteIdentifier(field.key) + " = ";
+        appendValueLiteral(setClauses, m_formatter, field.value);
+    }
+    if (setClauses.empty())
+        return {};
+
+    auto originalObj = update["originalData"].get_object();
+    if (originalObj.error())
+        return {};  // 元値が無いと WHERE を組めない (元実装も whereClauses 空のまま skip)
+
+    auto lookup = [&](std::string_view col) { return originalObj.value()[col]; };
+
+    std::string whereClauses;
+    if (!pkColumns.empty()) {
+        for (const auto& pk : pkColumns)
+            appendEqualityFromLookup(whereClauses, m_formatter, pk, lookup);
+    } else {
+        for (auto field : originalObj.value())
+            appendEqualityFromLookup(whereClauses, m_formatter, field.key, lookup);
+    }
+    if (whereClauses.empty())
+        return {};
+
+    return std::string("UPDATE ").append(fullTable).append(" SET ").append(setClauses).append(" WHERE ").append(whereClauses).append(";");
+}
+
+std::string SqlBuilder::buildInsertStmt(std::string_view fullTable, simdjson::dom::element insert) const {
+    auto obj = insert.get_object();
+    if (obj.error())
+        return {};
+
+    std::string columns, values;
+    for (auto field : obj.value()) {
+        if (!columns.empty()) {
+            columns += ", ";
+            values += ", ";
+        }
+        columns += m_formatter.quoteIdentifier(field.key);
+        appendValueLiteral(values, m_formatter, field.value);
+    }
+    if (columns.empty())
+        return {};
+
+    return std::string("INSERT INTO ").append(fullTable).append(" (").append(columns).append(") VALUES (").append(values).append(");");
+}
+
+std::string SqlBuilder::buildDeleteStmt(std::string_view fullTable, const std::vector<std::string>& pkColumns, simdjson::dom::element del) const {
+    auto obj = del.get_object();
+    if (obj.error())
+        return {};
+
+    auto lookup = [&](std::string_view col) { return obj.value()[col]; };
+
+    std::string whereClauses;
+    if (!pkColumns.empty()) {
+        for (const auto& pk : pkColumns)
+            appendEqualityFromLookup(whereClauses, m_formatter, pk, lookup);
+    } else {
+        for (auto field : obj.value())
+            appendEqualityFromLookup(whereClauses, m_formatter, field.key, lookup);
+    }
+    if (whereClauses.empty())
+        return {};
+
+    return std::string("DELETE FROM ").append(fullTable).append(" WHERE ").append(whereClauses).append(";");
+}
+
+std::vector<std::string> SqlBuilder::buildDml(const DmlInput& input) const {
+    auto fullTable = fullyQualifiedTable(input.schema, input.table);
+    std::vector<std::string> statements;
+
+    auto pushIf = [&](std::string&& s) {
+        if (!s.empty())
+            statements.emplace_back(std::move(s));
+    };
+
+    if (input.updates) {
+        for (auto u : *input.updates)
+            pushIf(buildUpdateStmt(fullTable, input.pkColumns, u));
+    }
+    if (input.inserts) {
+        for (auto i : *input.inserts)
+            pushIf(buildInsertStmt(fullTable, i));
+    }
+    if (input.deletes) {
+        for (auto d : *input.deletes)
+            pushIf(buildDeleteStmt(fullTable, input.pkColumns, d));
+    }
+
+    return statements;
+}
+
+}  // namespace velocitydb

--- a/backend/database/sql_builder.h
+++ b/backend/database/sql_builder.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "simdjson.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace velocitydb {
+
+class ISqlFormattable;
+
+/// DML バッチ入力 (UPDATE/INSERT/DELETE 群)。引数過多回避のため構造体化。
+///
+/// **ライフタイム制約**:
+/// - `schema` / `table` は呼び出し元文字列への非所有ビュー
+/// - `updates` / `inserts` / `deletes` は `simdjson::dom::parser` が保持する
+///   メモリへの非所有ハンドル
+/// `SqlBuilder::buildDml` 呼び出し中、同一 parser が同じ JSON を保持していること。
+/// parser を再 parse すると無効化される。
+struct DmlInput {
+    std::string_view schema;
+    std::string_view table;
+    std::vector<std::string> pkColumns;
+    std::optional<simdjson::dom::array> updates;
+    std::optional<simdjson::dom::array> inserts;
+    std::optional<simdjson::dom::array> deletes;
+};
+
+/// Dialect-aware SQL string builder (操作層).
+/// SQL 構築のみ責務を持つ純粋寄りクラス。JSON parsing / IPC 応答整形は Provider の責務。
+class SqlBuilder {
+public:
+    explicit SqlBuilder(const ISqlFormattable& formatter) noexcept;
+
+    SqlBuilder(const SqlBuilder&) = delete;
+    SqlBuilder& operator=(const SqlBuilder&) = delete;
+    SqlBuilder(SqlBuilder&&) = delete;
+    SqlBuilder& operator=(SqlBuilder&&) = delete;
+
+    /// `SELECT * FROM <tableName> [WHERE <whereClause>] LIMIT <limit>` を方言に従い構築。
+    /// `tableName` は未 quote 値 (内部で quoteIdentifier する)。
+    [[nodiscard]] std::string buildDataView(std::string_view tableName, std::string_view whereClause, int64_t limit) const;
+
+    /// `<col> = <val> [AND <col> = <val> ...]` 形式の WHERE 句本体を構築 (`WHERE` 接頭辞は含まない)。
+    /// 各 condition は `{column, value}` の object。null は `IS NULL`、string は quoteLiteral、
+    /// 数値/真偽値は素のまま埋め込む (内容が無いため安全)。
+    [[nodiscard]] std::string buildWhere(simdjson::dom::array conditions) const;
+
+    /// UPDATE / INSERT / DELETE 文のリストを構築。
+    /// `pkColumns` が空でない場合は WHERE 句に PK のみ使用、空なら originalData の全カラムを使用。
+    [[nodiscard]] std::vector<std::string> buildDml(const DmlInput& input) const;
+
+private:
+    [[nodiscard]] std::string fullyQualifiedTable(std::string_view schema, std::string_view table) const;
+    [[nodiscard]] std::string buildUpdateStmt(std::string_view fullTable, const std::vector<std::string>& pkColumns, simdjson::dom::element update) const;
+    [[nodiscard]] std::string buildInsertStmt(std::string_view fullTable, simdjson::dom::element insert) const;
+    [[nodiscard]] std::string buildDeleteStmt(std::string_view fullTable, const std::vector<std::string>& pkColumns, simdjson::dom::element del) const;
+
+    const ISqlFormattable& m_formatter;
+};
+
+}  // namespace velocitydb

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -5,6 +5,7 @@
 #include "../database/psql_subprocess.h"
 #include "../database/query_history.h"
 #include "../database/result_cache.h"
+#include "../database/sql_builder.h"
 #include "../interfaces/providers/connection_provider.h"
 #include "../interfaces/sql_formattable.h"
 #include "../parsers/copy_block_detector.h"
@@ -20,12 +21,26 @@
 #include <algorithm>
 #include <chrono>
 #include <format>
+#include <optional>
 
 #undef max
 
 using namespace std::literals;
 
 namespace velocitydb {
+
+namespace {
+
+/// simdjson result → optional への小ヘルパ。
+/// IPC 境界で「省略可能なフィールド」を扱う際に頻出するため共通化。
+template <typename T>
+[[nodiscard]] std::optional<T> toOpt(simdjson::simdjson_result<T> r) {
+    if (r.error())
+        return std::nullopt;
+    return r.value();
+}
+
+}  // namespace
 
 QueryProvider::QueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory) : m_connections(connections), m_resultCache(std::make_unique<ResultCache>()), m_queryHistory(queryHistory) {}
 
@@ -459,17 +474,13 @@ std::string QueryProvider::buildDataViewSql(std::string_view params) {
         std::string_view tableName = tableNameResult.value();
         auto limit = std::max(limitResult.value(), int64_t{0});
 
-        auto driverType = m_connections.getDriverType(connectionId);
-        auto formatter = DriverFactory::createSqlFormattable(driverType);
-        auto quotedTable = formatter->quoteIdentifier(tableName);
-
-        std::string sql;
-        if (auto whereResult = doc["whereClause"].get_string(); !whereResult.error() && !whereResult.value().empty()) {
-            sql = formatter->buildSelectAllWhere(quotedTable, whereResult.value(), limit);
-        } else {
-            sql = formatter->buildSelectAll(quotedTable, limit);
+        auto formatter = DriverFactory::createSqlFormattable(m_connections.getDriverType(connectionId));
+        std::string_view whereClause;
+        if (auto whereResult = doc["whereClause"].get_string(); !whereResult.error()) {
+            whereClause = whereResult.value();
         }
 
+        auto sql = SqlBuilder(*formatter).buildDataView(tableName, whereClause, limit);
         return JsonUtils::successResponse(std::format(R"({{"sql":"{}"}})", JsonUtils::escapeString(sql)));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
@@ -486,38 +497,9 @@ std::string QueryProvider::buildWhereClause(std::string_view params) {
         if (connectionIdResult.error() || conditionsResult.error()) [[unlikely]] {
             return JsonUtils::errorResponse("Missing required fields: connectionId or conditions");
         }
-        std::string_view connectionId = connectionIdResult.value();
 
-        auto driverType = m_connections.getDriverType(connectionId);
-        auto formatter = DriverFactory::createSqlFormattable(driverType);
-
-        std::string whereClause;
-        for (auto condition : conditionsResult.value()) {
-            auto columnResult = condition["column"].get_string();
-            if (columnResult.error())
-                continue;
-
-            if (!whereClause.empty()) {
-                whereClause += " AND ";
-            }
-
-            auto quotedCol = formatter->quoteIdentifier(columnResult.value());
-
-            // null → IS NULL, string → quoted literal, numeric → unquoted
-            auto valueEl = condition["value"];
-            if (valueEl.error() || valueEl.is_null()) {
-                whereClause += quotedCol + " IS NULL";
-            } else if (auto v = valueEl.get_string(); !v.error()) {
-                whereClause += quotedCol + " = " + formatter->quoteLiteral(v.value());
-            } else if (!valueEl.get_int64().error() || !valueEl.get_uint64().error() || !valueEl.get_double().error() || !valueEl.get_bool().error()) {
-                // Numeric/bool: embed directly without quoting (safe — no string content)
-                whereClause += quotedCol + " = " + simdjson::minify(valueEl.value());
-            } else {
-                // Unknown type: fall back to quoted literal for safety
-                whereClause += quotedCol + " = " + formatter->quoteLiteral(simdjson::minify(valueEl.value()));
-            }
-        }
-
+        auto formatter = DriverFactory::createSqlFormattable(m_connections.getDriverType(connectionIdResult.value()));
+        auto whereClause = SqlBuilder(*formatter).buildWhere(conditionsResult.value());
         return JsonUtils::successResponse(std::format(R"({{"whereClause":"{}"}})", JsonUtils::escapeString(whereClause)));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
@@ -539,12 +521,6 @@ std::string QueryProvider::buildDmlStatements(std::string_view params) {
         std::string_view schema = schemaResult.error() ? std::string_view{} : schemaResult.value();
         std::string_view table = tableResult.value();
 
-        auto driverType = m_connections.getDriverType(connectionId);
-        auto formatter = DriverFactory::createSqlFormattable(driverType);
-
-        auto fullTableName = schema.empty() ? formatter->quoteIdentifier(table) : formatter->quoteIdentifier(schema) + "." + formatter->quoteIdentifier(table);
-
-        // Collect PK columns
         std::vector<std::string> pkColumns;
         if (auto pkResult = doc["pkColumns"].get_array(); !pkResult.error()) {
             for (auto pk : pkResult.value()) {
@@ -553,137 +529,21 @@ std::string QueryProvider::buildDmlStatements(std::string_view params) {
             }
         }
 
+        auto formatter = DriverFactory::createSqlFormattable(m_connections.getDriverType(connectionId));
+        auto statements = SqlBuilder(*formatter)
+                              .buildDml(DmlInput{.schema = schema,
+                                                 .table = table,
+                                                 .pkColumns = std::move(pkColumns),
+                                                 .updates = toOpt(doc["updates"].get_array()),
+                                                 .inserts = toOpt(doc["inserts"].get_array()),
+                                                 .deletes = toOpt(doc["deletes"].get_array())});
+
         std::string statementsJson = "[";
-        bool firstStmt = true;
-
-        auto appendStmt = [&](const std::string& sql) {
-            if (!firstStmt)
+        for (size_t i = 0; i < statements.size(); ++i) {
+            if (i > 0)
                 statementsJson += ",";
-            firstStmt = false;
-            statementsJson += "\"" + JsonUtils::escapeString(sql) + "\"";
-        };
-
-        // UPDATE statements
-        if (auto updatesResult = doc["updates"].get_array(); !updatesResult.error()) {
-            for (auto update : updatesResult.value()) {
-                auto changesObj = update["changes"].get_object();
-                auto originalObj = update["originalData"].get_object();
-                if (changesObj.error())
-                    continue;
-
-                // SET clause
-                std::string setClauses;
-                for (auto field : changesObj.value()) {
-                    if (!setClauses.empty())
-                        setClauses += ", ";
-                    auto col = formatter->quoteIdentifier(field.key);
-                    if (field.value.is_null()) {
-                        setClauses += col + " = NULL";
-                    } else if (auto v = field.value.get_string(); !v.error()) {
-                        setClauses += col + " = " + formatter->quoteLiteral(v.value());
-                    } else {
-                        setClauses += col + " = " + formatter->quoteLiteral(simdjson::minify(field.value));
-                    }
-                }
-
-                // WHERE clause from PK or all original columns
-                std::string whereClauses;
-                auto buildWhere = [&](std::string_view colName) {
-                    if (!whereClauses.empty())
-                        whereClauses += " AND ";
-                    auto col = formatter->quoteIdentifier(colName);
-                    // Use original value for the WHERE
-                    if (!originalObj.error()) {
-                        auto origVal = originalObj.value()[colName];
-                        if (origVal.is_null() || origVal.error()) {
-                            whereClauses += col + " IS NULL";
-                        } else if (auto v = origVal.get_string(); !v.error()) {
-                            whereClauses += col + " = " + formatter->quoteLiteral(v.value());
-                        } else {
-                            whereClauses += col + " = " + formatter->quoteLiteral(simdjson::minify(origVal.value()));
-                        }
-                    }
-                };
-
-                if (!pkColumns.empty()) {
-                    for (const auto& pk : pkColumns)
-                        buildWhere(pk);
-                } else if (!originalObj.error()) {
-                    for (auto field : originalObj.value())
-                        buildWhere(field.key);
-                }
-
-                if (!setClauses.empty() && !whereClauses.empty()) {
-                    appendStmt("UPDATE " + fullTableName + " SET " + setClauses + " WHERE " + whereClauses + ";");
-                }
-            }
+            statementsJson += "\"" + JsonUtils::escapeString(statements[i]) + "\"";
         }
-
-        // INSERT statements
-        if (auto insertsResult = doc["inserts"].get_array(); !insertsResult.error()) {
-            for (auto insert : insertsResult.value()) {
-                auto obj = insert.get_object();
-                if (obj.error())
-                    continue;
-
-                std::string columns, values;
-                for (auto field : obj.value()) {
-                    if (!columns.empty()) {
-                        columns += ", ";
-                        values += ", ";
-                    }
-                    columns += formatter->quoteIdentifier(field.key);
-                    if (field.value.is_null()) {
-                        values += "NULL";
-                    } else if (auto v = field.value.get_string(); !v.error()) {
-                        values += formatter->quoteLiteral(v.value());
-                    } else {
-                        values += formatter->quoteLiteral(simdjson::minify(field.value));
-                    }
-                }
-
-                if (!columns.empty()) {
-                    appendStmt("INSERT INTO " + fullTableName + " (" + columns + ") VALUES (" + values + ");");
-                }
-            }
-        }
-
-        // DELETE statements
-        if (auto deletesResult = doc["deletes"].get_array(); !deletesResult.error()) {
-            for (auto del : deletesResult.value()) {
-                auto obj = del.get_object();
-                if (obj.error())
-                    continue;
-
-                std::string whereClauses;
-                auto buildWhere = [&](std::string_view colName) {
-                    if (!whereClauses.empty())
-                        whereClauses += " AND ";
-                    auto col = formatter->quoteIdentifier(colName);
-                    auto val = obj.value()[colName];
-                    if (val.is_null() || val.error()) {
-                        whereClauses += col + " IS NULL";
-                    } else if (auto v = val.get_string(); !v.error()) {
-                        whereClauses += col + " = " + formatter->quoteLiteral(v.value());
-                    } else {
-                        whereClauses += col + " = " + formatter->quoteLiteral(simdjson::minify(val.value()));
-                    }
-                };
-
-                if (!pkColumns.empty()) {
-                    for (const auto& pk : pkColumns)
-                        buildWhere(pk);
-                } else {
-                    for (auto field : obj.value())
-                        buildWhere(field.key);
-                }
-
-                if (!whereClauses.empty()) {
-                    appendStmt("DELETE FROM " + fullTableName + " WHERE " + whereClauses + ";");
-                }
-            }
-        }
-
         statementsJson += "]";
         return JsonUtils::successResponse(std::format(R"({{"statements":{}}})", statementsJson));
     } catch (const std::exception& e) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_SOURCES
     database/test_sqlserver_driver.cpp
     database/test_schema_inspector.cpp
     database/test_query_history.cpp
+    database/test_sql_builder.cpp
     database/test_transaction_manager.cpp
     parsers/test_a5er_parser.cpp
     parsers/test_sql_formatter.cpp

--- a/tests/database/test_sql_builder.cpp
+++ b/tests/database/test_sql_builder.cpp
@@ -1,0 +1,193 @@
+#include "database/sql_builder.h"
+
+#include "database/postgresql_dialect.h"
+#include "simdjson.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace velocitydb {
+namespace test {
+
+class SqlBuilderTest : public ::testing::Test {
+protected:
+    PostgreSqlDialect dialect;
+    SqlBuilder builder{dialect};
+
+    /// simdjson::dom::parser は **最後の parse 結果のみ有効** (再 parse で前の結果が無効化される)。
+    /// 1 テスト内で複数 JSON 配列を同時に保持する必要があるため、
+    /// parser を都度新規確保し、vector をオーナーとしてテスト終了まで生存させる。
+    /// 単一 parser を使い回すと dangling な dom::array が DmlInput に格納される。
+    std::vector<std::unique_ptr<simdjson::dom::parser>> parsers;
+
+    simdjson::dom::array parseArray(std::string_view json) {
+        auto& p = parsers.emplace_back(std::make_unique<simdjson::dom::parser>());
+        auto result = p->parse(json).get_array();
+        EXPECT_FALSE(result.error()) << "parseArray: invalid JSON: " << json;
+        return result.value();
+    }
+};
+
+// --- buildDataView ---
+
+TEST_F(SqlBuilderTest, BuildDataView_NoWhere_ReturnsSelectAll) {
+    auto sql = builder.buildDataView("users", {}, 100);
+    EXPECT_NE(sql.find("SELECT *"), std::string::npos);
+    EXPECT_NE(sql.find("\"users\""), std::string::npos);
+    EXPECT_NE(sql.find("LIMIT 100"), std::string::npos);
+    EXPECT_EQ(sql.find("WHERE"), std::string::npos);
+}
+
+TEST_F(SqlBuilderTest, BuildDataView_WithWhere_IncludesWhereClause) {
+    auto sql = builder.buildDataView("users", "id = 1", 50);
+    EXPECT_NE(sql.find("WHERE id = 1"), std::string::npos);
+    EXPECT_NE(sql.find("LIMIT 50"), std::string::npos);
+}
+
+TEST_F(SqlBuilderTest, BuildDataView_TableNameWithSchema_QuotesEachPart) {
+    auto sql = builder.buildDataView("public.users", {}, 10);
+    EXPECT_NE(sql.find("\"public\".\"users\""), std::string::npos);
+}
+
+// --- buildWhere (スタンドアロン: 数値は非 quote 埋め込み) ---
+
+TEST_F(SqlBuilderTest, BuildWhere_StringValue_QuotesLiteral) {
+    auto where = builder.buildWhere(parseArray(R"([{"column":"name","value":"alice"}])"));
+    EXPECT_EQ(where, "\"name\" = 'alice'");
+}
+
+TEST_F(SqlBuilderTest, BuildWhere_NullValue_UsesIsNull) {
+    auto where = builder.buildWhere(parseArray(R"([{"column":"name","value":null}])"));
+    EXPECT_EQ(where, "\"name\" IS NULL");
+}
+
+TEST_F(SqlBuilderTest, BuildWhere_NumericValue_EmbedsDirectly) {
+    auto where = builder.buildWhere(parseArray(R"([{"column":"age","value":42}])"));
+    EXPECT_EQ(where, "\"age\" = 42");
+}
+
+TEST_F(SqlBuilderTest, BuildWhere_MultipleConditions_JoinsWithAnd) {
+    auto where = builder.buildWhere(parseArray(R"([{"column":"a","value":1},{"column":"b","value":"x"}])"));
+    EXPECT_EQ(where, "\"a\" = 1 AND \"b\" = 'x'");
+}
+
+TEST_F(SqlBuilderTest, BuildWhere_MissingColumn_SkipsCondition) {
+    auto where = builder.buildWhere(parseArray(R"([{"value":1},{"column":"b","value":2}])"));
+    EXPECT_EQ(where, "\"b\" = 2");
+}
+
+TEST_F(SqlBuilderTest, BuildWhere_StringWithQuote_EscapesProperly) {
+    auto where = builder.buildWhere(parseArray(R"([{"column":"name","value":"O'Brien"}])"));
+    EXPECT_EQ(where, "\"name\" = 'O''Brien'");
+}
+
+// --- buildDml: INSERT (非 string 値も quoteLiteral) ---
+
+TEST_F(SqlBuilderTest, BuildDml_Insert_BasicRow) {
+    DmlInput input;
+    input.table = "users";
+    input.inserts = parseArray(R"([{"id":1,"name":"alice"}])");
+    auto stmts = builder.buildDml(input);
+    ASSERT_EQ(stmts.size(), 1u);
+    EXPECT_NE(stmts[0].find("INSERT INTO \"users\""), std::string::npos);
+    EXPECT_NE(stmts[0].find("\"id\""), std::string::npos);
+    EXPECT_NE(stmts[0].find("\"name\""), std::string::npos);
+    EXPECT_NE(stmts[0].find("'alice'"), std::string::npos);
+    // 非 string 値も元実装通り quoteLiteral される (quoteLiteral(minify(1)) = '1')
+    EXPECT_NE(stmts[0].find("'1'"), std::string::npos);
+}
+
+TEST_F(SqlBuilderTest, BuildDml_Insert_NullValue_EmitsNullLiteral) {
+    DmlInput input;
+    input.table = "t";
+    input.inserts = parseArray(R"([{"a":null,"b":1}])");
+    auto stmts = builder.buildDml(input);
+    ASSERT_EQ(stmts.size(), 1u);
+    EXPECT_NE(stmts[0].find("VALUES (NULL"), std::string::npos);
+}
+
+// --- buildDml: UPDATE ---
+
+TEST_F(SqlBuilderTest, BuildDml_Update_WithPk_UsesPkInWhere) {
+    DmlInput input;
+    input.table = "users";
+    input.pkColumns = {"id"};
+    input.updates = parseArray(R"([{"changes":{"name":"bob"},"originalData":{"id":7,"name":"alice"}}])");
+    auto stmts = builder.buildDml(input);
+    ASSERT_EQ(stmts.size(), 1u);
+    // 非 string は元実装通り quoteLiteral される
+    EXPECT_EQ(stmts[0], "UPDATE \"users\" SET \"name\" = 'bob' WHERE \"id\" = '7';");
+}
+
+TEST_F(SqlBuilderTest, BuildDml_Update_NoPk_UsesAllOriginalColumns) {
+    DmlInput input;
+    input.table = "t";
+    input.updates = parseArray(R"([{"changes":{"v":2},"originalData":{"a":1,"b":"x"}}])");
+    auto stmts = builder.buildDml(input);
+    ASSERT_EQ(stmts.size(), 1u);
+    EXPECT_NE(stmts[0].find("WHERE \"a\" = '1' AND \"b\" = 'x'"), std::string::npos);
+}
+
+TEST_F(SqlBuilderTest, BuildDml_Update_MissingChanges_Skipped) {
+    DmlInput input;
+    input.table = "t";
+    input.updates = parseArray(R"([{"originalData":{"id":1}}])");
+    EXPECT_TRUE(builder.buildDml(input).empty());
+}
+
+TEST_F(SqlBuilderTest, BuildDml_Update_MissingOriginalData_Skipped) {
+    DmlInput input;
+    input.table = "t";
+    input.pkColumns = {"id"};
+    input.updates = parseArray(R"([{"changes":{"name":"x"}}])");
+    EXPECT_TRUE(builder.buildDml(input).empty());
+}
+
+// --- buildDml: DELETE ---
+
+TEST_F(SqlBuilderTest, BuildDml_Delete_WithPk_UsesPkOnly) {
+    DmlInput input;
+    input.table = "users";
+    input.pkColumns = {"id"};
+    input.deletes = parseArray(R"([{"id":3,"name":"ignored"}])");
+    auto stmts = builder.buildDml(input);
+    ASSERT_EQ(stmts.size(), 1u);
+    EXPECT_EQ(stmts[0], "DELETE FROM \"users\" WHERE \"id\" = '3';");
+}
+
+TEST_F(SqlBuilderTest, BuildDml_Delete_NoPk_UsesAllColumns) {
+    DmlInput input;
+    input.table = "t";
+    input.deletes = parseArray(R"([{"a":1,"b":null}])");
+    auto stmts = builder.buildDml(input);
+    ASSERT_EQ(stmts.size(), 1u);
+    EXPECT_NE(stmts[0].find("WHERE \"a\" = '1' AND \"b\" IS NULL"), std::string::npos);
+}
+
+// --- buildDml: 統合 ---
+
+TEST_F(SqlBuilderTest, BuildDml_AllThreeOperations_OrderedUpdateInsertDelete) {
+    DmlInput input;
+    input.schema = "public";
+    input.table = "t";
+    input.pkColumns = {"id"};
+    input.updates = parseArray(R"([{"changes":{"v":1},"originalData":{"id":1}}])");
+    input.inserts = parseArray(R"([{"id":2,"v":2}])");
+    input.deletes = parseArray(R"([{"id":3}])");
+    auto stmts = builder.buildDml(input);
+    ASSERT_EQ(stmts.size(), 3u);
+    EXPECT_NE(stmts[0].find("UPDATE"), std::string::npos);
+    EXPECT_NE(stmts[1].find("INSERT INTO"), std::string::npos);
+    EXPECT_NE(stmts[2].find("DELETE FROM"), std::string::npos);
+    EXPECT_NE(stmts[0].find("\"public\".\"t\""), std::string::npos);
+}
+
+TEST_F(SqlBuilderTest, BuildDml_AllOptional_EmptyArrays_ReturnsEmpty) {
+    DmlInput input;
+    input.table = "t";
+    EXPECT_TRUE(builder.buildDml(input).empty());
+}
+
+}  // namespace test
+}  // namespace velocitydb


### PR DESCRIPTION
- backend/database/sql_builder.{h,cpp} を新設 (操作層 #4)
- buildDataViewSql / buildWhereClause / buildDmlStatements の SQL 構築ロジックを SqlBuilder に移譲、Provider は IPC routing + 応答整形に専念
- buildDml は DmlInput 構造体で引数集約、UPDATE/INSERT/DELETE をprivate メソッドへ 3 分割
- UPDATE/DELETE WHERE 構築を appendEqualityFromLookup で共通化
- simdjson_result→optional 変換ヘルパ toOpt をファイルスコープに昇格
- tests/database/test_sql_builder.cpp に単体テスト 19 件追加

振る舞い保持: 公開 IF (IDialectSqlBuilder) 不変、IPC schema 不変、backend テスト 336/336 PASS、lint ALL PASSED。
premise-questioning: skipped (理由: 親 issue #393 で戦略確定済、Phase 1-2 #447/#448/#449/#450 で同パターン実装済の継続作業)

Closes #451