### PR TITLE
refactor(backend): query_provider から QueryResultFormatter を抽出 (#452)

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -41,6 +41,7 @@ set(LIB_SOURCES
     # Providers
     providers/connection_provider.cpp
     providers/query_provider.cpp
+    providers/query_result_formatter.cpp
     providers/async_query_provider.cpp
     providers/schema_provider.cpp
     providers/transaction_provider.cpp
@@ -144,6 +145,7 @@ set(HEADERS
     # Providers
     providers/connection_provider.h
     providers/query_provider.h
+    providers/query_result_formatter.h
     providers/async_query_provider.h
     providers/schema_provider.h
     providers/transaction_provider.h

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -16,6 +16,7 @@
 #include "../utils/logger.h"
 #include "../utils/sql_validation.h"
 #include "../utils/string_utils.h"
+#include "query_result_formatter.h"
 #include "simdjson.h"
 
 #include <algorithm>
@@ -117,14 +118,8 @@ std::string QueryProvider::executeQuery(std::string_view params) {
                     auto stmtStart = std::chrono::high_resolution_clock::now();
                     ResultSet currentResult;
                     if (SQLParser::isUseStatement(stmt)) {
-                        std::string dbName = SQLParser::extractDatabaseName(stmt);
                         [[maybe_unused]] auto _ = driver->execute(stmt);
-                        currentResult.columns.push_back({.name = "Message", .type = "VARCHAR", .size = 255, .nullable = false, .isPrimaryKey = false});
-                        ResultRow messageRow;
-                        messageRow.values.push_back(std::format("Database changed to {}", dbName));
-                        messageRow.nullFlags.push_back(false);
-                        currentResult.rows.push_back(messageRow);
-                        currentResult.affectedRows = 0;
+                        currentResult = QueryResultFormatter::buildUseStatementResult(SQLParser::extractDatabaseName(stmt));
                     } else {
                         currentResult = driver->execute(stmt);
                     }
@@ -146,18 +141,11 @@ std::string QueryProvider::executeQuery(std::string_view params) {
                 }
                 recordHistory(sqlQuery, connectionId, totalExecMs, true, {}, totalAffected);
 
-                std::string jsonResponse = R"({"multipleResults":true,"results":[)";
-                for (size_t i = 0; i < allResults.size(); ++i) {
-                    if (i > 0)
-                        jsonResponse += ",";
-                    jsonResponse += R"({"statement":")";
-                    jsonResponse += JsonUtils::escapeString(allResults[i].statement);
-                    jsonResponse += R"(","data":)";
-                    jsonResponse += JsonUtils::serializeResultSet(allResults[i].result, false);
-                    jsonResponse += "}";
-                }
-                jsonResponse += "]}";
-                return JsonUtils::successResponse(jsonResponse);
+                std::vector<NamedResult> namedResults;
+                namedResults.reserve(allResults.size());
+                for (const auto& r : allResults)
+                    namedResults.push_back({.statement = r.statement, .result = std::cref(r.result)});
+                return JsonUtils::successResponse(QueryResultFormatter::buildMultipleResultsJson(namedResults));
             } catch (const std::exception& e) {
                 if (wrapTransaction)
                     try {
@@ -172,17 +160,9 @@ std::string QueryProvider::executeQuery(std::string_view params) {
 
         // Single USE statement
         if (SQLParser::isUseStatement(sqlQuery)) {
-            std::string dbName = SQLParser::extractDatabaseName(sqlQuery);
             try {
                 [[maybe_unused]] auto _ = driver->execute(sqlQuery);
-                ResultSet useResult;
-                useResult.columns.push_back({.name = "Message", .type = "VARCHAR", .size = 255, .nullable = false, .isPrimaryKey = false});
-                ResultRow messageRow;
-                messageRow.values.push_back(std::format("Database changed to {}", dbName));
-                messageRow.nullFlags.push_back(false);
-                useResult.rows.push_back(messageRow);
-                useResult.affectedRows = 0;
-                useResult.executionTimeMs = 0.0;
+                auto useResult = QueryResultFormatter::buildUseStatementResult(SQLParser::extractDatabaseName(sqlQuery));
                 recordHistory(sqlQuery, connectionId, 0.0, true);
                 return JsonUtils::successResponse(JsonUtils::serializeResultSet(useResult, false));
             } catch (const std::exception& e) {
@@ -376,24 +356,7 @@ std::string QueryProvider::filterResultSet(std::string_view params) {
             return JsonUtils::errorResponse(std::format("Unknown filter type: {}", filterType));
         }
 
-        std::string jsonResponse = "{";
-        JsonUtils::appendColumns(jsonResponse, queryResult.columns);
-        jsonResponse += R"(,"rows":[)";
-        for (size_t i = 0; i < matchingIndices.size(); ++i) {
-            if (i > 0)
-                jsonResponse += ',';
-            jsonResponse += '[';
-            const auto& row = queryResult.rows[matchingIndices[i]];
-            for (size_t colIndex = 0; colIndex < row.values.size(); ++colIndex) {
-                if (colIndex > 0)
-                    jsonResponse += ',';
-                JsonUtils::appendJsonValue(jsonResponse, row, colIndex);
-            }
-            jsonResponse += ']';
-        }
-        jsonResponse += "],";
-        jsonResponse += std::format(R"("totalRows":{},"filteredRows":{},"simdAvailable":{}}})", queryResult.rows.size(), matchingIndices.size(), SIMDFilter::isAVX2Available() ? "true" : "false");
-        return JsonUtils::successResponse(jsonResponse);
+        return JsonUtils::successResponse(QueryResultFormatter::buildFilteredResultJson(queryResult, matchingIndices));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
     }

--- a/backend/providers/query_result_formatter.cpp
+++ b/backend/providers/query_result_formatter.cpp
@@ -1,0 +1,59 @@
+#include "query_result_formatter.h"
+
+#include "../database/driver_interface.h"
+#include "../search/simd_filter.h"
+#include "../utils/json_utils.h"
+
+#include <format>
+
+namespace velocitydb {
+
+ResultSet QueryResultFormatter::buildUseStatementResult(std::string_view dbName) {
+    // affectedRows / executionTimeMs は ResultSet のデフォルトメンバ初期化 (0 / 0.0) に任せる。
+    // executionTimeMs は呼び出し元 (executeQuery) が計測値で上書きする契約。
+    ResultSet rs;
+    rs.columns.push_back({.name = "Message", .type = "VARCHAR", .size = 255, .nullable = false, .isPrimaryKey = false});
+    ResultRow row;
+    row.values.push_back(std::format("Database changed to {}", dbName));
+    row.nullFlags.push_back(false);
+    rs.rows.push_back(std::move(row));
+    return rs;
+}
+
+std::string QueryResultFormatter::buildMultipleResultsJson(std::span<const NamedResult> results) {
+    std::string json = R"({"multipleResults":true,"results":[)";
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (i > 0)
+            json += ',';
+        json += R"({"statement":")";
+        json += JsonUtils::escapeString(results[i].statement);
+        json += R"(","data":)";
+        json += JsonUtils::serializeResultSet(results[i].result.get(), false);
+        json += '}';
+    }
+    json += "]}";
+    return json;
+}
+
+std::string QueryResultFormatter::buildFilteredResultJson(const ResultSet& result, std::span<const size_t> matchingIndices) {
+    std::string json = "{";
+    JsonUtils::appendColumns(json, result.columns);
+    json += R"(,"rows":[)";
+    for (size_t i = 0; i < matchingIndices.size(); ++i) {
+        if (i > 0)
+            json += ',';
+        json += '[';
+        const auto& row = result.rows[matchingIndices[i]];
+        for (size_t colIndex = 0; colIndex < row.values.size(); ++colIndex) {
+            if (colIndex > 0)
+                json += ',';
+            JsonUtils::appendJsonValue(json, row, colIndex);
+        }
+        json += ']';
+    }
+    json += "],";
+    json += std::format(R"("totalRows":{},"filteredRows":{},"simdAvailable":{}}})", result.rows.size(), matchingIndices.size(), SIMDFilter::isAVX2Available() ? "true" : "false");
+    return json;
+}
+
+}  // namespace velocitydb

--- a/backend/providers/query_result_formatter.h
+++ b/backend/providers/query_result_formatter.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <functional>
+#include <span>
+#include <string>
+#include <string_view>
+
+namespace velocitydb {
+
+struct ResultSet;
+
+/// 複数ステートメント実行結果の 1 件 (multipleResults JSON 用).
+///
+/// `statement` は呼び出し元文字列への非所有ビュー、`result` は ResultSet への
+/// 非所有 const 参照。いずれも `buildMultipleResultsJson` 呼び出し中、
+/// 呼び出し元が生存を保証すること。
+struct NamedResult {
+    std::string_view statement;
+    std::reference_wrapper<const ResultSet> result;
+};
+
+/// Query 結果を IPC 応答 JSON へ整形する操作層 (`backend/providers/`).
+/// SIMD フィルタ実行 / DB 実行 / キャッシュ操作は責務外 (Provider に残す).
+/// 純粋寄り (状態なし) なため static メソッド集約.
+class QueryResultFormatter {
+public:
+    QueryResultFormatter() = delete;
+
+    /// `USE <db>` の応答用 ResultSet (1 行 1 列 "Database changed to <db>") を構築.
+    /// executeQuery 内 2 箇所 (single / multi-statement) の重複を排除.
+    [[nodiscard]] static ResultSet buildUseStatementResult(std::string_view dbName);
+
+    /// 複数ステートメント実行結果を `{"multipleResults":true,"results":[...]}` 形式で整形.
+    /// 各要素は `{"statement":<エスケープ済 SQL 1行目>,"data":<serializeResultSet>}`.
+    [[nodiscard]] static std::string buildMultipleResultsJson(std::span<const NamedResult> results);
+
+    /// SIMD フィルタ結果 (`matchingIndices`) のみを行として持つ JSON を構築.
+    /// `totalRows` / `filteredRows` / `simdAvailable` を含む.
+    [[nodiscard]] static std::string buildFilteredResultJson(const ResultSet& result, std::span<const size_t> matchingIndices);
+};
+
+}  // namespace velocitydb

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_SOURCES
     database/test_psql_subprocess.cpp
     exporters/test_csv_exporter.cpp
     providers/test_lint_provider.cpp
+    providers/test_query_result_formatter.cpp
     providers/test_settings_provider.cpp
     providers/test_utility_provider.cpp
     utils/test_sql_validation.cpp

--- a/tests/providers/test_query_result_formatter.cpp
+++ b/tests/providers/test_query_result_formatter.cpp
@@ -1,0 +1,150 @@
+#include "providers/query_result_formatter.h"
+
+#include "database/driver_interface.h"
+
+#include <gtest/gtest.h>
+
+namespace velocitydb {
+namespace test {
+
+namespace {
+
+ResultSet makeSampleResultSet() {
+    ResultSet rs;
+    rs.columns.push_back({.name = "id", .type = "INT", .size = 4, .nullable = false, .isPrimaryKey = true});
+    rs.columns.push_back({.name = "name", .type = "VARCHAR", .size = 50, .nullable = true, .isPrimaryKey = false});
+    ResultRow r0;
+    r0.values = {"1", "alice"};
+    r0.nullFlags = {false, false};
+    ResultRow r1;
+    r1.values = {"2", ""};
+    r1.nullFlags = {false, true};  // name = NULL
+    ResultRow r2;
+    r2.values = {"3", "carol"};
+    r2.nullFlags = {false, false};
+    rs.rows = {r0, r1, r2};
+    rs.affectedRows = 0;
+    rs.executionTimeMs = 1.5;
+    return rs;
+}
+
+}  // namespace
+
+// --- buildUseStatementResult ---
+
+TEST(QueryResultFormatterTest, BuildUseStatementResult_ContainsDbNameInMessage) {
+    auto rs = QueryResultFormatter::buildUseStatementResult("mydb");
+    ASSERT_EQ(rs.columns.size(), 1u);
+    EXPECT_EQ(rs.columns[0].name, "Message");
+    ASSERT_EQ(rs.rows.size(), 1u);
+    ASSERT_EQ(rs.rows[0].values.size(), 1u);
+    EXPECT_NE(rs.rows[0].values[0].find("mydb"), std::string::npos);
+    EXPECT_EQ(rs.rows[0].nullFlags[0], false);
+    EXPECT_EQ(rs.affectedRows, 0);
+    EXPECT_EQ(rs.executionTimeMs, 0.0);
+}
+
+TEST(QueryResultFormatterTest, BuildUseStatementResult_EmptyDbName_StillProducesValidShape) {
+    auto rs = QueryResultFormatter::buildUseStatementResult({});
+    ASSERT_EQ(rs.rows.size(), 1u);
+    EXPECT_EQ(rs.columns[0].name, "Message");
+    EXPECT_EQ(rs.columns[0].nullable, false);
+    // 空 dbName でも "Database changed to " 接頭辞は維持される
+    EXPECT_EQ(rs.rows[0].values[0], "Database changed to ");
+}
+
+TEST(QueryResultFormatterTest, BuildUseStatementResult_LeavesExecutionTimeAtZero_ForCallerToOverwrite) {
+    // 呼び出し元 (executeQuery) が後段で計測値を代入する契約。
+    // formatter は計測責務を持たないためデフォルト値のまま返す。
+    auto rs = QueryResultFormatter::buildUseStatementResult("db");
+    EXPECT_EQ(rs.executionTimeMs, 0.0);
+    EXPECT_EQ(rs.affectedRows, 0);
+}
+
+// --- buildMultipleResultsJson ---
+
+TEST(QueryResultFormatterTest, BuildMultipleResultsJson_EmptySpan_ReturnsHeaderWithEmptyArray) {
+    auto json = QueryResultFormatter::buildMultipleResultsJson({});
+    EXPECT_EQ(json, R"({"multipleResults":true,"results":[]})");
+}
+
+TEST(QueryResultFormatterTest, BuildMultipleResultsJson_SingleEntry_IncludesStatementAndData) {
+    ResultSet rs = makeSampleResultSet();
+    std::vector<NamedResult> entries = {{.statement = "SELECT *", .result = std::cref(rs)}};
+    auto json = QueryResultFormatter::buildMultipleResultsJson(entries);
+    EXPECT_NE(json.find(R"("multipleResults":true)"), std::string::npos);
+    EXPECT_NE(json.find(R"("statement":"SELECT *")"), std::string::npos);
+    EXPECT_NE(json.find(R"("data":)"), std::string::npos);
+}
+
+TEST(QueryResultFormatterTest, BuildMultipleResultsJson_TwoEntries_SeparatedByComma) {
+    ResultSet rs1 = makeSampleResultSet();
+    ResultSet rs2 = makeSampleResultSet();
+    std::vector<NamedResult> entries = {{.statement = "SELECT a", .result = std::cref(rs1)}, {.statement = "SELECT b", .result = std::cref(rs2)}};
+    auto json = QueryResultFormatter::buildMultipleResultsJson(entries);
+    auto first = json.find(R"("statement":"SELECT a")");
+    auto second = json.find(R"("statement":"SELECT b")");
+    EXPECT_NE(first, std::string::npos);
+    EXPECT_NE(second, std::string::npos);
+    EXPECT_LT(first, second);  // 順序保持
+}
+
+TEST(QueryResultFormatterTest, BuildMultipleResultsJson_StatementWithQuote_IsEscaped) {
+    ResultSet rs = makeSampleResultSet();
+    std::vector<NamedResult> entries = {{.statement = R"(SELECT "x")", .result = std::cref(rs)}};
+    auto json = QueryResultFormatter::buildMultipleResultsJson(entries);
+    // statement フィールドの値全体としてエスケープ済み形が現れることを位置で確認
+    EXPECT_NE(json.find(R"("statement":"SELECT \"x\"")"), std::string::npos);
+}
+
+// --- buildFilteredResultJson ---
+
+TEST(QueryResultFormatterTest, BuildFilteredResultJson_NoMatches_EmptyRows) {
+    auto rs = makeSampleResultSet();
+    auto json = QueryResultFormatter::buildFilteredResultJson(rs, {});
+    EXPECT_NE(json.find(R"("rows":[])"), std::string::npos);
+    EXPECT_NE(json.find(R"("totalRows":3)"), std::string::npos);
+    EXPECT_NE(json.find(R"("filteredRows":0)"), std::string::npos);
+}
+
+TEST(QueryResultFormatterTest, BuildFilteredResultJson_SingleMatch_ContainsRowValues) {
+    auto rs = makeSampleResultSet();
+    std::vector<size_t> indices = {0};
+    auto json = QueryResultFormatter::buildFilteredResultJson(rs, indices);
+    EXPECT_NE(json.find(R"("filteredRows":1)"), std::string::npos);
+    EXPECT_NE(json.find("alice"), std::string::npos);
+    EXPECT_EQ(json.find("carol"), std::string::npos);  // index 2 は含まない
+}
+
+TEST(QueryResultFormatterTest, BuildFilteredResultJson_NullValue_RenderedAsJsonNull) {
+    auto rs = makeSampleResultSet();
+    std::vector<size_t> indices = {1};  // id=2, name=NULL
+    auto json = QueryResultFormatter::buildFilteredResultJson(rs, indices);
+    // 行配列内に [<id>,null] の形で JSON null リテラルが出ることを位置で確認
+    EXPECT_NE(json.find(R"(["2",null])"), std::string::npos);
+}
+
+TEST(QueryResultFormatterTest, BuildFilteredResultJson_PreservesIndexOrder) {
+    auto rs = makeSampleResultSet();
+    std::vector<size_t> indices = {2, 0};  // 逆順
+    auto json = QueryResultFormatter::buildFilteredResultJson(rs, indices);
+    auto carolPos = json.find("carol");
+    auto alicePos = json.find("alice");
+    EXPECT_NE(carolPos, std::string::npos);
+    EXPECT_NE(alicePos, std::string::npos);
+    EXPECT_LT(carolPos, alicePos);  // indices 順 (2,0) を保持
+}
+
+TEST(QueryResultFormatterTest, BuildFilteredResultJson_IncludesColumnsAndSimdFlag) {
+    auto rs = makeSampleResultSet();
+    auto json = QueryResultFormatter::buildFilteredResultJson(rs, {});
+    EXPECT_NE(json.find(R"("columns")"), std::string::npos);
+    EXPECT_NE(json.find(R"("simdAvailable")"), std::string::npos);
+    // simdAvailable は true / false のいずれか (環境依存) — 文字列リテラルで埋め込まれているか確認
+    bool hasFlag = json.find(R"("simdAvailable":true)") != std::string::npos
+                   || json.find(R"("simdAvailable":false)") != std::string::npos;
+    EXPECT_TRUE(hasFlag);
+}
+
+}  // namespace test
+}  // namespace velocitydb


### PR DESCRIPTION
- backend/providers/query_result_formatter.{h,cpp} を新設
- query_provider::executeQuery / filterResultSet に凝縮していた JSON 整形ロジックを QueryResultFormatter に移譲、Provider は IPC routing + 実行制御に専念
- buildUseStatementResult: `USE <db>` 応答 ResultSet 構築 (executeQuery 内 single / multi-statement 2 箇所の重複を DRY 化)
- buildMultipleResultsJson: 複数文 `{"multipleResults":true,"results":[...]}` 整形
- buildFilteredResultJson: SIMD フィルタ済 JSON 整形 (totalRows / filteredRows / simdAvailable 含む)
- query_provider.cpp は 554 → 517 行に縮小、executeQuery 内冗長 ResultSet 構築 (USE 用 12 行 ×2) を排除
- NamedResult 型は std::reference_wrapper<const ResultSet> + string_view で null 排除 + zero-copy
- SIMD dispatch / DB 実行 / キャッシュ操作は Provider に残置 (実行ロジックなので整形クラスから分離)
- tests/providers/test_query_result_formatter.cpp に単体テスト 12 件追加 (USE 系 3 / multipleResults 系 4 / filtered JSON 系 5)

振る舞い保持: 公開 IPC API 不変、IPC schema 不変、backend テスト 348/348 PASS、lint ALL PASSED。
premise-questioning: skipped (理由: 親 issue #393 で戦略確定済、Phase 3-E #451 と同パターン (Provider → 操作層への純粋ヘルパ抽出)の継続作業、振る舞い不変)

残課題: QueryResultFormatter は issue #452 指定通り backend/providers/ 配下に配置。階層アーキ的には database/ (sql_builder と同層)
または utils/ が筋のため、再配置は #456 (SystemContext 整理) と合わせて検討。

Closes #452