### PR TITLE
refactor(backend): BaseDriver 基底に sqlserver/postgresql 共通処理を抽出 (#455)

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -19,6 +19,7 @@ set(LIB_SOURCES
     ipc_handler.cpp
     # Database
     database/odbc_helpers.cpp
+    database/base_driver.cpp
     database/sqlserver_driver.cpp
     database/sqlserver_dialect.cpp
     database/postgresql_driver.cpp
@@ -88,6 +89,7 @@ set(HEADERS
     ipc_handler.h
     # Database
     database/driver_interface.h
+    database/base_driver.h
     database/sqlserver_driver.h
     database/odbc_helpers.h
     database/sqlserver_dialect.h

--- a/backend/database/base_driver.cpp
+++ b/backend/database/base_driver.cpp
@@ -1,0 +1,15 @@
+#include "base_driver.h"
+
+namespace velocitydb {
+
+void BaseDriver::setQueryTimeout(std::chrono::seconds timeout) {
+    std::lock_guard lock(m_executeMutex);
+    setQueryTimeoutLocked(timeout);
+}
+
+std::string BaseDriver::getLastError() const {
+    std::lock_guard lock(m_executeMutex);
+    return m_lastError;
+}
+
+}  // namespace velocitydb

--- a/backend/database/base_driver.h
+++ b/backend/database/base_driver.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "driver_interface.h"
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+
+namespace velocitydb {
+
+/// Common state and accessor implementations shared by SQLServerDriver / PostgreSqlDriver.
+///
+/// Hierarchy: IDatabaseDriver <- BaseDriver <- SQLServerDriver / PostgreSqlDriver (depth 2).
+/// Holds the four members that were previously duplicated across both drivers
+/// (connection flag / last error / query timeout / execute mutex) and provides
+/// non-virtual default implementations of the accessors that have identical
+/// semantics in both drivers. Subclasses still implement protocol-specific
+/// connect/disconnect/execute/cancel and may override accessors when a
+/// driver-specific side effect is required (PostgreSqlDriver::setQueryTimeout
+/// issues `SET statement_timeout` to the live connection).
+class BaseDriver : public IDatabaseDriver {
+public:
+    [[nodiscard]] bool isConnected() const noexcept override { return m_connected.load(std::memory_order_acquire); }
+
+    [[nodiscard]] std::chrono::seconds queryTimeout() const noexcept override { return m_queryTimeout; }
+
+    void setQueryTimeout(std::chrono::seconds timeout) override;
+    [[nodiscard]] std::string getLastError() const override;
+
+protected:
+    BaseDriver() = default;
+    ~BaseDriver() override = default;
+
+    /// Assign to m_queryTimeout. Caller must already hold m_executeMutex.
+    /// Provided so subclasses adding side effects (e.g. PostgreSqlDriver
+    /// pushing SET statement_timeout) can reuse the assignment without
+    /// re-acquiring the lock.
+    void setQueryTimeoutLocked(std::chrono::seconds timeout) noexcept { m_queryTimeout = timeout; }
+
+    std::atomic<bool> m_connected{false};
+    std::string m_lastError;  // guarded by m_executeMutex
+    std::chrono::seconds m_queryTimeout{kDefaultQueryTimeout};
+    /// Guards m_lastError / m_queryTimeout. Subclasses additionally hold this
+    /// during execute()/disconnect() to serialize against cancel() and getLastError().
+    mutable std::mutex m_executeMutex;
+};
+
+}  // namespace velocitydb

--- a/backend/database/postgresql_driver.cpp
+++ b/backend/database/postgresql_driver.cpp
@@ -212,16 +212,12 @@ ResultSet PostgreSqlDriver::execute(std::string_view sql) {
 
 void PostgreSqlDriver::setQueryTimeout(std::chrono::seconds timeout) {
     std::lock_guard lock(m_executeMutex);
-    m_queryTimeout = timeout;
+    setQueryTimeoutLocked(timeout);
     auto* conn = m_conn.load(std::memory_order_acquire);
     if (conn) {
         auto cmd = std::format("SET statement_timeout = '{}s'", timeout.count());
         PQclear(PQexec(conn, cmd.c_str()));
     }
-}
-
-std::chrono::seconds PostgreSqlDriver::queryTimeout() const noexcept {
-    return m_queryTimeout;
 }
 
 void PostgreSqlDriver::cancel() {
@@ -234,11 +230,6 @@ void PostgreSqlDriver::cancel() {
         PQcancel(cancelObj, errbuf, sizeof(errbuf));
         PQfreeCancel(cancelObj);
     }
-}
-
-std::string PostgreSqlDriver::getLastError() const {
-    std::lock_guard lock(m_executeMutex);
-    return m_lastError;
 }
 
 }  // namespace velocitydb

--- a/backend/database/postgresql_driver.h
+++ b/backend/database/postgresql_driver.h
@@ -1,21 +1,19 @@
 #pragma once
 
 #include "../interfaces/statement_handler.h"
-#include "driver_interface.h"
+#include "base_driver.h"
 
 #include <libpq-fe.h>
 
 #include <atomic>
 #include <chrono>
 #include <memory>
-#include <mutex>
-#include <string>
 #include <string_view>
 #include <vector>
 
 namespace velocitydb {
 
-class PostgreSqlDriver : public IDatabaseDriver {
+class PostgreSqlDriver : public BaseDriver {
 public:
     PostgreSqlDriver();
     ~PostgreSqlDriver() override;
@@ -28,22 +26,18 @@ public:
     // IDatabaseDriver interface
     [[nodiscard]] bool connect(std::string_view connectionString) override;
     void disconnect() override;
-    [[nodiscard]] bool isConnected() const noexcept override { return m_connected.load(std::memory_order_acquire); }
 
     [[nodiscard]] ResultSet execute(std::string_view sql) override;
     void cancel() override;
-    void setQueryTimeout(std::chrono::seconds timeout) override;
-    [[nodiscard]] std::chrono::seconds queryTimeout() const noexcept override;
 
-    [[nodiscard]] std::string getLastError() const override;
+    /// PostgreSQL needs to push the new timeout to the live connection in
+    /// addition to updating the cached value, so it overrides the base impl.
+    void setQueryTimeout(std::chrono::seconds timeout) override;
+
     [[nodiscard]] DriverType getType() const noexcept override { return DriverType::PostgreSQL; }
 
 private:
     std::atomic<PGconn*> m_conn{nullptr};
-    std::atomic<bool> m_connected{false};
-    std::string m_lastError;
-    std::chrono::seconds m_queryTimeout{kDefaultQueryTimeout};
-    mutable std::mutex m_executeMutex;
 
     /// OCP: special statement protocol handlers
     std::vector<std::unique_ptr<IStatementHandler>> m_handlers;

--- a/backend/database/sqlserver_driver.cpp
+++ b/backend/database/sqlserver_driver.cpp
@@ -189,18 +189,4 @@ void SQLServerDriver::cancel() {
     odbc::cancelStatement(m_stmt.load(std::memory_order_acquire));
 }
 
-void SQLServerDriver::setQueryTimeout(std::chrono::seconds timeout) {
-    std::lock_guard lock(m_executeMutex);
-    m_queryTimeout = timeout;
-}
-
-std::chrono::seconds SQLServerDriver::queryTimeout() const noexcept {
-    return m_queryTimeout;
-}
-
-std::string SQLServerDriver::getLastError() const {
-    std::lock_guard lock(m_executeMutex);
-    return m_lastError;
-}
-
 }  // namespace velocitydb

--- a/backend/database/sqlserver_driver.h
+++ b/backend/database/sqlserver_driver.h
@@ -1,21 +1,18 @@
 #pragma once
 
+#include "base_driver.h"
 #include "connection_types.h"
-#include "driver_interface.h"
 
 #include <Windows.h>
 #include <sql.h>
 #include <sqlext.h>
 
 #include <atomic>
-#include <chrono>
-#include <mutex>
-#include <string>
 #include <string_view>
 
 namespace velocitydb {
 
-class SQLServerDriver : public IDatabaseDriver {
+class SQLServerDriver : public BaseDriver {
 public:
     SQLServerDriver();
     ~SQLServerDriver() override;
@@ -28,26 +25,18 @@ public:
     // IDatabaseDriver interface
     [[nodiscard]] bool connect(std::string_view connectionString) override;
     void disconnect() override;
-    [[nodiscard]] bool isConnected() const noexcept override { return m_connected.load(std::memory_order_acquire); }
     void setConnectionTimeout(unsigned int seconds) override;
 
     [[nodiscard]] ResultSet execute(std::string_view sql) override;
     void cancel() override;
-    void setQueryTimeout(std::chrono::seconds timeout) override;
-    [[nodiscard]] std::chrono::seconds queryTimeout() const noexcept override;
 
-    [[nodiscard]] std::string getLastError() const override;
     [[nodiscard]] DriverType getType() const noexcept override { return DriverType::SQLServer; }
 
 private:
     SQLHENV m_env = SQL_NULL_HENV;
     SQLHDBC m_dbc = SQL_NULL_HDBC;
     std::atomic<SQLHSTMT> m_stmt{SQL_NULL_HSTMT};
-    std::atomic<bool> m_connected{false};
-    std::string m_lastError;
-    std::chrono::seconds m_queryTimeout{kDefaultQueryTimeout};
     unsigned int m_connectionTimeout{kDefaultConnectionTimeoutSeconds};
-    mutable std::mutex m_executeMutex;  // Serializes concurrent execute()/disconnect()/getLastError() calls
 };
 
 }  // namespace velocitydb


### PR DESCRIPTION
## Summary

SQLServerDriver と PostgreSqlDriver で重複していた接続状態管理 (m_connected / m_lastError / m_queryTimeout / m_executeMutex) と
accessor 4 メソッド(isConnected / queryTimeout / setQueryTimeout / getLastError) を BaseDriver 基底に持ち上げ DRY 違反を解消。

- 継承深度: IDatabaseDriver ← BaseDriver ← {SQLServerDriver, PostgreSqlDriver} (2 段、oop-composition-over-inheritance.md 準拠)
- PostgreSqlDriver::setQueryTimeout は SET statement_timeout を live connection に発行する副作用があるため override。lock+assignmentは基底の setQueryTimeoutLocked() ヘルパで共有
- API 段数差の大きい connect/disconnect/execute/cancel は基底に持ち上げず virtual hook のまま (Issue 文面の Template Method部分は撤回)
- ODBC (SQLAllocHandle→SQLDriverConnect→SQLDisconnect→SQLFreeHandle) と libpq (PQconnectdb→PQfinish) の API 段数・粒度差が大きく、Template Method 強制すると不自然な階段関数構造になる。リスコフ置換観点でも各派生 connect/disconnect は独立完結で問題なし。Issue 趣旨である DRY 違反解消は「メンバ持ち上げ + 共通アクセサ抽出」だけで十分達成

## Test plan

- [x] backend ビルド (Release)
- [x] backend テスト 全 PASS
- [x] lint ALL PASSED
- [ ] SQL Server / PostgreSQL 実接続動作確認

Closes #455