### PR TITLE
fix(backend): m_queryTimeout データレース + PG cancel UAF 修正

### DIFF
--- a/backend/database/base_driver.cpp
+++ b/backend/database/base_driver.cpp
@@ -2,11 +2,6 @@
 
 namespace velocitydb {
 
-void BaseDriver::setQueryTimeout(std::chrono::seconds timeout) {
-    std::lock_guard lock(m_executeMutex);
-    setQueryTimeoutLocked(timeout);
-}
-
 std::string BaseDriver::getLastError() const {
     std::lock_guard lock(m_executeMutex);
     return m_lastError;

--- a/backend/database/base_driver.h
+++ b/backend/database/base_driver.h
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <mutex>
 #include <string>
 
@@ -23,26 +24,26 @@ class BaseDriver : public IDatabaseDriver {
 public:
     [[nodiscard]] bool isConnected() const noexcept override { return m_connected.load(std::memory_order_acquire); }
 
-    [[nodiscard]] std::chrono::seconds queryTimeout() const noexcept override { return m_queryTimeout; }
+    [[nodiscard]] std::chrono::seconds queryTimeout() const noexcept override { return std::chrono::seconds{m_queryTimeoutSeconds.load(std::memory_order_relaxed)}; }
 
-    void setQueryTimeout(std::chrono::seconds timeout) override;
+    void setQueryTimeout(std::chrono::seconds timeout) override { m_queryTimeoutSeconds.store(timeout.count(), std::memory_order_relaxed); }
     [[nodiscard]] std::string getLastError() const override;
 
 protected:
     BaseDriver() = default;
     ~BaseDriver() override = default;
 
-    /// Assign to m_queryTimeout. Caller must already hold m_executeMutex.
-    /// Provided so subclasses adding side effects (e.g. PostgreSqlDriver
-    /// pushing SET statement_timeout) can reuse the assignment without
-    /// re-acquiring the lock.
-    void setQueryTimeoutLocked(std::chrono::seconds timeout) noexcept { m_queryTimeout = timeout; }
-
     std::atomic<bool> m_connected{false};
     std::string m_lastError;  // guarded by m_executeMutex
-    std::chrono::seconds m_queryTimeout{kDefaultQueryTimeout};
-    /// Guards m_lastError / m_queryTimeout. Subclasses additionally hold this
-    /// during execute()/disconnect() to serialize against cancel() and getLastError().
+    /// Stored as raw seconds count so we can use lock-free std::atomic
+    /// (std::chrono::seconds itself is not trivially copyable on all stdlibs).
+    /// queryTimeout() / setQueryTimeout() handle the chrono conversion.
+    std::atomic<std::int64_t> m_queryTimeoutSeconds{kDefaultQueryTimeout.count()};
+    /// Guards m_lastError. Subclasses additionally hold this during
+    /// execute()/disconnect() and during accessor side effects (e.g.
+    /// PostgreSqlDriver::setQueryTimeout pairs the atomic store with
+    /// SET statement_timeout under this lock to keep cache and live
+    /// session state in sync).
     mutable std::mutex m_executeMutex;
 };
 

--- a/backend/database/postgresql_driver.cpp
+++ b/backend/database/postgresql_driver.cpp
@@ -102,7 +102,8 @@ bool PostgreSqlDriver::connect(std::string_view connectionString) {
     }
 
     PQsetClientEncoding(conn, "UTF8");
-    auto timeoutCmd = std::format("SET statement_timeout = '{}s'", m_queryTimeout.count());
+    auto timeoutSec = m_queryTimeoutSeconds.load(std::memory_order_relaxed);
+    auto timeoutCmd = std::format("SET statement_timeout = '{}s'", timeoutSec);
     PQclear(PQexec(conn, timeoutCmd.c_str()));
 
     m_conn.store(conn, std::memory_order_release);
@@ -112,11 +113,15 @@ bool PostgreSqlDriver::connect(std::string_view connectionString) {
 
 void PostgreSqlDriver::disconnect() {
     std::lock_guard lock(m_executeMutex);
-    if (m_connected.exchange(false, std::memory_order_acq_rel)) {
-        auto* conn = m_conn.exchange(nullptr, std::memory_order_acq_rel);
-        if (conn)
-            PQfinish(conn);
-    }
+    if (!m_connected.exchange(false, std::memory_order_acq_rel))
+        return;
+    /// Hold m_connLifecycleMutex while nulling and PQfinish-ing so that a
+    /// concurrent cancel() (which only takes this lifecycle lock) cannot
+    /// observe a freed conn.
+    std::lock_guard lifecycleLock(m_connLifecycleMutex);
+    auto* conn = m_conn.exchange(nullptr, std::memory_order_acq_rel);
+    if (conn)
+        PQfinish(conn);
 }
 
 ResultSet PostgreSqlDriver::execute(std::string_view sql) {
@@ -211,25 +216,41 @@ ResultSet PostgreSqlDriver::execute(std::string_view sql) {
 }
 
 void PostgreSqlDriver::setQueryTimeout(std::chrono::seconds timeout) {
+    /// Lock encloses BOTH the atomic store and the SET statement_timeout side
+    /// effect. Without this pairing, two concurrent setQueryTimeout calls
+    /// could interleave such that the cached value reflects one writer while
+    /// the live PostgreSQL session reflects the other (last-PQexec wins,
+    /// last-store wins, but they need not agree).
+    /// The lock also defends against disconnect() racing with the conn load
+    /// (PQfinish would otherwise free conn from under us).
     std::lock_guard lock(m_executeMutex);
-    setQueryTimeoutLocked(timeout);
-    auto* conn = m_conn.load(std::memory_order_acquire);
-    if (conn) {
-        auto cmd = std::format("SET statement_timeout = '{}s'", timeout.count());
-        PQclear(PQexec(conn, cmd.c_str()));
-    }
-}
-
-void PostgreSqlDriver::cancel() {
+    BaseDriver::setQueryTimeout(timeout);
     auto* conn = m_conn.load(std::memory_order_acquire);
     if (!conn)
         return;
-    auto* cancelObj = PQgetCancel(conn);
-    if (cancelObj) {
-        char errbuf[256];
-        PQcancel(cancelObj, errbuf, sizeof(errbuf));
-        PQfreeCancel(cancelObj);
+    auto cmd = std::format("SET statement_timeout = '{}s'", timeout.count());
+    PQclear(PQexec(conn, cmd.c_str()));
+}
+
+void PostgreSqlDriver::cancel() {
+    /// Snapshot a PGcancel under the lifecycle lock so disconnect() cannot
+    /// PQfinish() the conn between our load and PQgetCancel(). PQgetCancel
+    /// allocates an independent cancel object; once acquired, PQcancel /
+    /// PQfreeCancel are safe to call without holding any lock (PQcancel is
+    /// documented signal-handler-safe by libpq).
+    PGcancel* cancelObj = nullptr;
+    {
+        std::lock_guard lifecycleLock(m_connLifecycleMutex);
+        auto* conn = m_conn.load(std::memory_order_acquire);
+        if (!conn)
+            return;
+        cancelObj = PQgetCancel(conn);
     }
+    if (!cancelObj)
+        return;
+    char errbuf[256];
+    PQcancel(cancelObj, errbuf, sizeof(errbuf));
+    PQfreeCancel(cancelObj);
 }
 
 }  // namespace velocitydb

--- a/backend/database/postgresql_driver.h
+++ b/backend/database/postgresql_driver.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string_view>
 #include <vector>
 
@@ -38,6 +39,12 @@ public:
 
 private:
     std::atomic<PGconn*> m_conn{nullptr};
+
+    /// Serializes m_conn lifetime against cancel(). cancel() must NOT take
+    /// m_executeMutex (per IQueryExecutable::cancel contract: "execute() が
+    /// ブロック中でもロックなしで呼び出し可能"), so a separate lightweight
+    /// mutex protects PQgetCancel against concurrent PQfinish in disconnect().
+    mutable std::mutex m_connLifecycleMutex;
 
     /// OCP: special statement protocol handlers
     std::vector<std::unique_ptr<IStatementHandler>> m_handlers;

--- a/backend/database/sqlserver_driver.cpp
+++ b/backend/database/sqlserver_driver.cpp
@@ -49,9 +49,15 @@ bool SQLServerDriver::connect(std::string_view connectionString) {
 
 void SQLServerDriver::disconnect() {
     std::lock_guard lock(m_executeMutex);
-    auto stmt = m_stmt.exchange(SQL_NULL_HSTMT, std::memory_order_acq_rel);
-    if (stmt != SQL_NULL_HSTMT) {
-        SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+    {
+        /// Hold lifecycle lock while nulling and SQLFreeHandle-ing m_stmt so
+        /// a concurrent cancel() (which only takes this lock) cannot observe
+        /// a freed handle.
+        std::lock_guard lifecycleLock(m_stmtLifecycleMutex);
+        auto stmt = m_stmt.exchange(SQL_NULL_HSTMT, std::memory_order_acq_rel);
+        if (stmt != SQL_NULL_HSTMT) {
+            SQLFreeHandle(SQL_HANDLE_STMT, stmt);
+        }
     }
     if (m_connected.exchange(false, std::memory_order_acq_rel)) {
         odbc::disconnect(m_dbc);
@@ -68,9 +74,12 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
 
     const auto startTime = std::chrono::high_resolution_clock::now();
 
-    auto oldStmt = m_stmt.exchange(SQL_NULL_HSTMT, std::memory_order_acq_rel);
-    if (oldStmt != SQL_NULL_HSTMT) {
-        SQLFreeHandle(SQL_HANDLE_STMT, oldStmt);
+    {
+        std::lock_guard lifecycleLock(m_stmtLifecycleMutex);
+        auto oldStmt = m_stmt.exchange(SQL_NULL_HSTMT, std::memory_order_acq_rel);
+        if (oldStmt != SQL_NULL_HSTMT) {
+            SQLFreeHandle(SQL_HANDLE_STMT, oldStmt);
+        }
     }
 
     SQLHSTMT stmt = SQL_NULL_HSTMT;
@@ -84,7 +93,7 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
     // Publish new stmt so cancel() can see it immediately
     m_stmt.store(stmt, std::memory_order_release);
 
-    auto queryTimeout = static_cast<SQLULEN>(m_queryTimeout.count());
+    auto queryTimeout = static_cast<SQLULEN>(m_queryTimeoutSeconds.load(std::memory_order_relaxed));
     SQLSetStmtAttr(stmt, SQL_ATTR_QUERY_TIMEOUT, toSqlPointer(queryTimeout), 0);
 
     auto wideSql = utf8ToWide(sql);
@@ -186,6 +195,11 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
 }
 
 void SQLServerDriver::cancel() {
+    /// Take lifecycle lock so disconnect()/execute() cannot SQLFreeHandle
+    /// the stmt between our load and SQLCancel call (lock-order:
+    /// m_executeMutex -> m_stmtLifecycleMutex in disconnect/execute, and
+    /// cancel only takes m_stmtLifecycleMutex; no deadlock possible).
+    std::lock_guard lifecycleLock(m_stmtLifecycleMutex);
     odbc::cancelStatement(m_stmt.load(std::memory_order_acquire));
 }
 

--- a/backend/database/sqlserver_driver.h
+++ b/backend/database/sqlserver_driver.h
@@ -8,6 +8,7 @@
 #include <sqlext.h>
 
 #include <atomic>
+#include <mutex>
 #include <string_view>
 
 namespace velocitydb {
@@ -36,6 +37,11 @@ private:
     SQLHENV m_env = SQL_NULL_HENV;
     SQLHDBC m_dbc = SQL_NULL_HDBC;
     std::atomic<SQLHSTMT> m_stmt{SQL_NULL_HSTMT};
+    /// Serializes m_stmt lifetime against cancel(). cancel() must NOT take
+    /// m_executeMutex (per IQueryExecutable::cancel contract), so a separate
+    /// lightweight mutex protects SQLCancelHandle against concurrent
+    /// SQLFreeHandle in disconnect()/execute().
+    mutable std::mutex m_stmtLifecycleMutex;
     unsigned int m_connectionTimeout{kDefaultConnectionTimeoutSeconds};
 };
 


### PR DESCRIPTION
m_queryTimeout (std::chrono::seconds) は setQueryTimeout で m_executeMutex 下に書き込まれる一方、queryTimeout()/connect()からはロックなしに読み取られておりデータレース (UB)。
また PostgreSqlDriver::cancel() が m_conn を無ロックで読み取り後 PQgetCancel  を呼ぶため、disconnect() 並行で UAF。

- m_queryTimeout を std::atomic<int64_t> m_queryTimeoutSeconds に置換 (relaxed memory order、connection_provider 慣習に整合)
- BaseDriver::queryTimeout/setQueryTimeout を inline atomic load/store 化
- PostgreSqlDriver::setQueryTimeout は m_executeMutex 下で atomic store + PQexec を1ロック内に閉じ、cache と DB session の乖離を防止
- PostgreSqlDriver に m_connLifecycleMutex を追加。cancel() は execute() の lock を取らず (IQueryExecutable 契約)、lifecycle lock 下で PQgetCancel を取得→ロック外で PQcancel
- disconnect() は m_executeMutex → m_connLifecycleMutex の順で取得し PQfinish

premise-questioning: skipped (理由: pre-existing concurrency bug fix)