### PR TITLE
refactor(backend): CopyFromStdinHandler から m_lastError 参照結合を除去

### DIFF
--- a/backend/database/copy_from_stdin_handler.cpp
+++ b/backend/database/copy_from_stdin_handler.cpp
@@ -8,10 +8,11 @@
 #include <cstring>
 #include <format>
 #include <stdexcept>
+#include <string>
 
 namespace velocitydb {
 
-CopyFromStdinHandler::CopyFromStdinHandler(std::atomic<PGconn*>& conn, std::string& lastError) : m_conn(conn), m_lastError(lastError) {}
+CopyFromStdinHandler::CopyFromStdinHandler(std::atomic<PGconn*>& conn) : m_conn(conn) {}
 
 bool CopyFromStdinHandler::canHandle(std::string_view sql) const {
     return m_detector.startsBlock(sql);
@@ -26,10 +27,10 @@ ResultSet CopyFromStdinHandler::execute(std::string_view sql) {
     // 1. Execute COPY command -> transition to PGRES_COPY_IN state
     PGresultPtr initResult(PQexec(conn, copyCmd.c_str()));
     if (PQresultStatus(initResult.get()) != PGRES_COPY_IN) {
-        m_lastError = PQresultErrorMessage(initResult.get());
-        if (m_lastError.empty())
-            m_lastError = std::format("Expected COPY_IN state, got: {}", PQresStatus(PQresultStatus(initResult.get())));
-        throw std::runtime_error(m_lastError);
+        std::string err = PQresultErrorMessage(initResult.get());
+        if (err.empty())
+            err = std::format("Expected COPY_IN state, got: {}", PQresStatus(PQresultStatus(initResult.get())));
+        throw std::runtime_error(std::move(err));
     }
 
     // 2. Send data in chunks (avoid INT_MAX overflow for large payloads)
@@ -38,28 +39,27 @@ ResultSet CopyFromStdinHandler::execute(std::string_view sql) {
         for (size_t offset = 0; offset < data.size(); offset += kChunkSize) {
             auto chunkLen = std::min(kChunkSize, data.size() - offset);
             if (PQputCopyData(conn, data.c_str() + offset, static_cast<int>(chunkLen)) != 1) {
-                m_lastError = PQerrorMessage(conn);
+                std::string err = PQerrorMessage(conn);
                 PQputCopyEnd(conn, "client error");
                 PGresultPtr drain(PQgetResult(conn));
-                throw std::runtime_error(m_lastError);
+                throw std::runtime_error(std::move(err));
             }
         }
     }
 
     // 3. Signal COPY completion
     if (PQputCopyEnd(conn, nullptr) != 1) {
-        m_lastError = PQerrorMessage(conn);
-        throw std::runtime_error(m_lastError);
+        throw std::runtime_error(PQerrorMessage(conn));
     }
 
     // 4. Get final result
     PGresultPtr finalResult(PQgetResult(conn));
     auto status = PQresultStatus(finalResult.get());
     if (status != PGRES_COMMAND_OK) {
-        m_lastError = PQresultErrorMessage(finalResult.get());
-        if (m_lastError.empty())
-            m_lastError = std::format("COPY failed with status: {}", PQresStatus(status));
-        throw std::runtime_error(m_lastError);
+        std::string err = PQresultErrorMessage(finalResult.get());
+        if (err.empty())
+            err = std::format("COPY failed with status: {}", PQresStatus(status));
+        throw std::runtime_error(std::move(err));
     }
 
     // 5. Build ResultSet

--- a/backend/database/copy_from_stdin_handler.h
+++ b/backend/database/copy_from_stdin_handler.h
@@ -6,21 +6,26 @@
 #include <libpq-fe.h>
 
 #include <atomic>
-#include <string>
+#include <string_view>
 
 namespace velocitydb {
 
-/// IStatementHandler for PostgreSQL COPY ... FROM stdin protocol
+/// IStatementHandler for PostgreSQL COPY ... FROM stdin protocol.
+///
+/// On failure, throws std::runtime_error with the libpq diagnostic message.
+/// The owning driver is responsible for propagating the message to its
+/// last-error cache (via try/catch around execute()), so this handler does not
+/// hold any reference into the driver's mutable state and has no implicit
+/// locking contract with the caller.
 class CopyFromStdinHandler : public IStatementHandler {
 public:
-    explicit CopyFromStdinHandler(std::atomic<PGconn*>& conn, std::string& lastError);
+    explicit CopyFromStdinHandler(std::atomic<PGconn*>& conn);
 
     [[nodiscard]] bool canHandle(std::string_view sql) const override;
     [[nodiscard]] ResultSet execute(std::string_view sql) override;
 
 private:
     std::atomic<PGconn*>& m_conn;
-    std::string& m_lastError;
     CopyBlockDetector m_detector;
 };
 

--- a/backend/database/postgresql_driver.cpp
+++ b/backend/database/postgresql_driver.cpp
@@ -81,7 +81,7 @@ std::string oidToTypeName(Oid oid) {
 }  // namespace
 
 PostgreSqlDriver::PostgreSqlDriver() {
-    m_handlers.push_back(std::make_unique<CopyFromStdinHandler>(m_conn, m_lastError));
+    m_handlers.push_back(std::make_unique<CopyFromStdinHandler>(m_conn));
 }
 
 PostgreSqlDriver::~PostgreSqlDriver() {
@@ -131,10 +131,24 @@ ResultSet PostgreSqlDriver::execute(std::string_view sql) {
         throw std::runtime_error("Not connected to database");
     }
 
-    // OCP: handler chain — new protocols require only handler registration
+    // OCP: handler chain — new protocols require only handler registration.
+    // Handlers don't touch m_lastError (no implicit lock contract); the driver
+    // catches their exceptions here (including from canHandle) and propagates
+    // the message into the mutex-guarded last-error cache before re-throwing.
+    // The catch-all branch defends against handlers that throw non-std types
+    // so getLastError() never silently retains a stale message.
     for (auto& handler : m_handlers) {
-        if (handler->canHandle(sql))
+        try {
+            if (!handler->canHandle(sql))
+                continue;
             return handler->execute(sql);
+        } catch (const std::exception& e) {
+            m_lastError = e.what();
+            throw;
+        } catch (...) {
+            m_lastError = "Unknown handler error (non-std::exception)";
+            throw;
+        }
     }
 
     // Default: standard PQexec() path


### PR DESCRIPTION
handler が BaseDriver::m_lastError への可変参照を保持し、PostgreSqlDriver::executeの m_executeMutex 保持中に書き換える暗黙のロック契約を持っていた。
実際の race は無いが、参照 dangling と暗黙契約のもろさが将来の handler 拡張を阻害する。

例外伝播パターンへ変更:

- handler は m_lastError を一切知らず std::runtime_error を throw のみ
- PostgreSqlDriver::execute() で try/catch (std::exception + catch-all)、m_lastError = e.what() 設定後 re-throw
- canHandle も try 範囲内に含め、非 std::exception 派生型 throw も防御

当初想定の callback 案 (BaseDriver::setLastError 内部 lock + std::function 注入)は m_executeMutex が非再帰のため deadlock 確実、撤回。

検証: backend test 342/342 PASS / lint ALL PASSED / build SUCCESSFUL

premise-questioning: skipped (理由: 局所リファクタ ~50 行、設計判断は一次調査で確定)