### PR TITLE
refactor(backend): SettingsProvider の暗黙ワイヤリングを除去し DI 完全化 (#456)

### DIFF
--- a/backend/contexts/system_context.cpp
+++ b/backend/contexts/system_context.cpp
@@ -1,5 +1,7 @@
 #include "system_context.h"
 
+#include "../accessors/session_accessor.h"
+#include "../accessors/settings_accessor.h"
 #include "../database/query_history.h"
 #include "../providers/async_query_provider.h"
 #include "../providers/connection_provider.h"
@@ -17,23 +19,37 @@
 
 namespace velocitydb {
 
-SystemContext::SystemContext()
-    : m_connections(std::make_unique<ConnectionProvider>())
-    , m_settings(std::make_unique<SettingsProvider>(m_connections.get()))
+namespace {
+
+[[nodiscard]] std::unique_ptr<QueryHistory> makeQueryHistory(const SettingsAccessor& settingsAccessor) {
     // 設定ファイル破損時の防御: maxQueryHistory が 0 や負値だった場合は最低 1 件にクランプして
     // QueryHistory が常に有効状態で動作するようにする。
-    , m_queryHistory(std::make_unique<QueryHistory>(static_cast<size_t>(std::max(1, m_settings->settingsAccessor().getSettings().general.maxQueryHistory))))
-    , m_queries(std::make_unique<QueryProvider>(*m_connections, *m_queryHistory))
-    , m_asyncQueries(std::make_unique<AsyncQueryProvider>(*m_connections, *m_queryHistory))
-    , m_schema(std::make_unique<SchemaProvider>(*m_connections))
-    , m_transactions(std::make_unique<TransactionProvider>(*m_connections))
-    , m_exports(std::make_unique<ExportProvider>(*m_connections))
-    , m_search(std::make_unique<SearchProvider>(*m_connections))
-    , m_utility(std::make_unique<UtilityProvider>())
-    , m_io(std::make_unique<IOProvider>())
-    , m_lint(std::make_unique<LintProvider>()) {
-    // settings 経由の maxQueryHistory 変更をランタイムで反映できるよう wiring。
-    m_settings->setQueryHistory(m_queryHistory.get());
+    const auto maxItems = static_cast<size_t>(std::max(1, settingsAccessor.getSettings().general.maxQueryHistory));
+    return std::make_unique<QueryHistory>(maxItems);
+}
+
+}  // namespace
+
+SystemContext::SystemContext() {
+    // accessor の load は SystemContext で先行実施する: QueryHistory が settings.general.maxQueryHistory を
+    // 構築時に必要とし、その値は SettingsAccessor を load 済みでなければ取得できないため。
+    auto settingsAccessor = std::make_unique<SettingsAccessor>();
+    (void)settingsAccessor->load();
+    auto sessionAccessor = std::make_unique<SessionAccessor>();
+    (void)sessionAccessor->load();
+
+    m_connections = std::make_unique<ConnectionProvider>();
+    m_queryHistory = makeQueryHistory(*settingsAccessor);
+    m_settings = std::make_unique<SettingsProvider>(std::move(settingsAccessor), std::move(sessionAccessor), m_connections.get(), *m_queryHistory);
+    m_queries = std::make_unique<QueryProvider>(*m_connections, *m_queryHistory);
+    m_asyncQueries = std::make_unique<AsyncQueryProvider>(*m_connections, *m_queryHistory);
+    m_schema = std::make_unique<SchemaProvider>(*m_connections);
+    m_transactions = std::make_unique<TransactionProvider>(*m_connections);
+    m_exports = std::make_unique<ExportProvider>(*m_connections);
+    m_search = std::make_unique<SearchProvider>(*m_connections);
+    m_utility = std::make_unique<UtilityProvider>();
+    m_io = std::make_unique<IOProvider>();
+    m_lint = std::make_unique<LintProvider>();
 }
 
 SystemContext::~SystemContext() = default;

--- a/backend/contexts/system_context.h
+++ b/backend/contexts/system_context.h
@@ -7,7 +7,6 @@
 namespace velocitydb {
 
 class QueryHistory;
-class SettingsProvider;
 
 /// Concrete implementation of ISystemContext, owning all provider instances.
 class SystemContext : public ISystemContext {
@@ -33,11 +32,11 @@ public:
     [[nodiscard]] ILintProvider& lint() noexcept override;
 
 private:
-    // 宣言順 = 初期化順。m_settings は m_queryHistory の構築値を提供するため先に置く。
-    // m_settings は具象型: setQueryHistory() を SystemContext から呼ぶため (interface には公開しない)。
+    // 宣言順 = 初期化順 (および destruction 逆順)。
+    // m_queryHistory は m_settings の依存先、m_settings は m_queryHistory より後に構築される。
     std::unique_ptr<IConnectionProvider> m_connections;
-    std::unique_ptr<SettingsProvider> m_settings;
     std::unique_ptr<QueryHistory> m_queryHistory;
+    std::unique_ptr<ISettingsProvider> m_settings;
     std::unique_ptr<IQueryProvider> m_queries;
     std::unique_ptr<IAsyncQueryProvider> m_asyncQueries;
     std::unique_ptr<ISchemaProvider> m_schema;

--- a/backend/providers/settings_provider.cpp
+++ b/backend/providers/settings_provider.cpp
@@ -158,11 +158,11 @@ namespace {
 
 }  // namespace
 
-SettingsProvider::SettingsProvider(IConnectionProvider* connections)
-    : m_settingsAccessor(std::make_unique<SettingsAccessor>()), m_sessionAccessor(std::make_unique<SessionAccessor>()), m_connections(connections) {
-    (void)m_settingsAccessor->load();
-    (void)m_sessionAccessor->load();
-    applyQueryTimeoutToConnections(m_settingsAccessor->getSettings().query.timeoutSeconds);
+SettingsProvider::SettingsProvider(std::unique_ptr<SettingsAccessor> settingsAccessor, std::unique_ptr<SessionAccessor> sessionAccessor, IConnectionProvider* connections, QueryHistory& queryHistory)
+    : m_settingsAccessor(std::move(settingsAccessor)), m_sessionAccessor(std::move(sessionAccessor)), m_connections(connections), m_queryHistory(queryHistory) {
+    const auto& settings = m_settingsAccessor->getSettings();
+    applyQueryTimeoutToConnections(settings.query.timeoutSeconds);
+    applyMaxQueryHistoryToInstance(settings.general.maxQueryHistory);
 }
 
 void SettingsProvider::applyQueryTimeoutToConnections(int seconds) {
@@ -172,22 +172,12 @@ void SettingsProvider::applyQueryTimeoutToConnections(int seconds) {
 }
 
 void SettingsProvider::applyMaxQueryHistoryToInstance(int maxItems) {
-    if (m_queryHistory && maxItems > 0) {
-        m_queryHistory->setMaxItems(static_cast<size_t>(maxItems));
-    }
-}
-
-void SettingsProvider::setQueryHistory(QueryHistory* queryHistory) {
-    m_queryHistory = queryHistory;
-    // 初回 wiring 時に load 済み settings を即時反映する。
-    if (m_queryHistory) {
-        applyMaxQueryHistoryToInstance(m_settingsAccessor->getSettings().general.maxQueryHistory);
+    if (maxItems > 0) {
+        m_queryHistory.setMaxItems(static_cast<size_t>(maxItems));
     }
 }
 
 SettingsProvider::~SettingsProvider() = default;
-SettingsProvider::SettingsProvider(SettingsProvider&&) noexcept = default;
-SettingsProvider& SettingsProvider::operator=(SettingsProvider&&) noexcept = default;
 
 std::string SettingsProvider::getSettings() {
     const auto& s = m_settingsAccessor->getSettings();

--- a/backend/providers/settings_provider.h
+++ b/backend/providers/settings_provider.h
@@ -16,20 +16,18 @@ class QueryHistory;
 /// Provider for application settings and session management
 class SettingsProvider : public ISettingsProvider {
 public:
+    /// @param settingsAccessor 既に load() 済みの SettingsAccessor を所有権ごと受け取る。
+    /// @param sessionAccessor  既に load() 済みの SessionAccessor を所有権ごと受け取る。
     /// @param connections Used to propagate query.timeoutSeconds changes to active drivers.
     ///                    May be nullptr for unit tests that don't exercise timeout propagation.
-    explicit SettingsProvider(IConnectionProvider* connections = nullptr);
+    /// @param queryHistory 非所有参照。general.maxQueryHistory 変更時に setMaxItems() が呼ばれる (Issue #426)。
+    SettingsProvider(std::unique_ptr<SettingsAccessor> settingsAccessor, std::unique_ptr<SessionAccessor> sessionAccessor, IConnectionProvider* connections, QueryHistory& queryHistory);
     ~SettingsProvider() override;
-
-    /// Wire the QueryHistory instance whose maxItems is updated when
-    /// general.maxQueryHistory changes via updateSettings().
-    /// May be called once after construction; pass nullptr to detach.
-    void setQueryHistory(QueryHistory* queryHistory);
 
     SettingsProvider(const SettingsProvider&) = delete;
     SettingsProvider& operator=(const SettingsProvider&) = delete;
-    SettingsProvider(SettingsProvider&&) noexcept;
-    SettingsProvider& operator=(SettingsProvider&&) noexcept;
+    SettingsProvider(SettingsProvider&&) = delete;
+    SettingsProvider& operator=(SettingsProvider&&) = delete;
 
     [[nodiscard]] std::string getSettings() override;
     [[nodiscard]] std::string updateSettings(std::string_view params) override;
@@ -53,8 +51,8 @@ private:
 
     std::unique_ptr<SettingsAccessor> m_settingsAccessor;
     std::unique_ptr<SessionAccessor> m_sessionAccessor;
-    IConnectionProvider* m_connections;      // Non-owning; may be null in tests
-    QueryHistory* m_queryHistory = nullptr;  // Non-owning; wired post-construction by SystemContext
+    IConnectionProvider* m_connections;  // Non-owning; may be null in tests
+    QueryHistory& m_queryHistory;        // Non-owning; wired at construction
 };
 
 }  // namespace velocitydb

--- a/tests/providers/test_settings_provider.cpp
+++ b/tests/providers/test_settings_provider.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <format>
+#include <memory>
 
 #include "database/query_history.h"
 #include "interfaces/providers/app_settings_accessor.h"
@@ -18,24 +19,35 @@ protected:
     // settings.json は %LOCALAPPDATA%\Velocity-DB\ に永続化されるため、テスト間および
     // ユーザー設定との state リークを防ぐ。SetUp で元の maxQueryHistory を退避してから
     // 1000 にリセット、TearDown で退避値に復元する (ユーザー設定を破壊しない)。
+    // m_queryHistory は provider より先に宣言: SettingsProvider が QueryHistory& を保持するため
+    // (ライフタイム順序保証)。
     void SetUp() override {
-        m_savedMaxQueryHistory = provider.settingsAccessor().getSettings().general.maxQueryHistory;
-        auto resetResult = provider.updateSettings(R"({"general":{"maxQueryHistory":1000}})");
+        auto settingsAccessor = std::make_unique<SettingsAccessor>();
+        (void)settingsAccessor->load();
+        m_savedMaxQueryHistory = settingsAccessor->getSettings().general.maxQueryHistory;
+        auto sessionAccessor = std::make_unique<SessionAccessor>();
+        (void)sessionAccessor->load();
+
+        m_queryHistory = std::make_unique<QueryHistory>(1000);
+        provider = std::make_unique<SettingsProvider>(std::move(settingsAccessor), std::move(sessionAccessor), nullptr, *m_queryHistory);
+
+        auto resetResult = provider->updateSettings(R"({"general":{"maxQueryHistory":1000}})");
         ASSERT_NE(resetResult.find("\"saved\""), std::string::npos);
     }
 
     void TearDown() override {
         const auto restoreJson = std::format(R"({{"general":{{"maxQueryHistory":{}}}}})", m_savedMaxQueryHistory);
-        (void)provider.updateSettings(restoreJson);
+        (void)provider->updateSettings(restoreJson);
     }
 
-    SettingsProvider provider;
+    std::unique_ptr<QueryHistory> m_queryHistory;
+    std::unique_ptr<SettingsProvider> provider;
     int m_savedMaxQueryHistory = 1000;
 };
 
 TEST_F(SettingsProviderTest, AccessSettingsAccessor) {
     // Verify direct access to SettingsAccessor works
-    auto& accessor = provider.settingsAccessor();
+    auto& accessor = provider->settingsAccessor();
     const auto& settings = accessor.getSettings();
 
     // Default settings should have reasonable values
@@ -45,7 +57,7 @@ TEST_F(SettingsProviderTest, AccessSettingsAccessor) {
 
 TEST_F(SettingsProviderTest, AccessSessionAccessor) {
     // Verify direct access to SessionAccessor works
-    auto& accessor = provider.sessionAccessor();
+    auto& accessor = provider->sessionAccessor();
     const auto& state = accessor.getState();
 
     // Default session state should have reasonable values
@@ -55,27 +67,26 @@ TEST_F(SettingsProviderTest, AccessSessionAccessor) {
 
 TEST_F(SettingsProviderTest, GetProfilePasswordNotFound) {
     // Non-existent profile should return error JSON
-    auto result = provider.getProfilePassword(R"({"id":"non_existent_profile_id"})");
+    auto result = provider->getProfilePassword(R"({"id":"non_existent_profile_id"})");
     EXPECT_FALSE(result.empty());
     EXPECT_NE(result.find("error"), std::string::npos);
 }
 
 TEST_F(SettingsProviderTest, GetSshPasswordNotFound) {
     // Non-existent profile should return error JSON
-    auto result = provider.getSshPassword(R"({"id":"non_existent_profile_id"})");
+    auto result = provider->getSshPassword(R"({"id":"non_existent_profile_id"})");
     EXPECT_FALSE(result.empty());
     EXPECT_NE(result.find("error"), std::string::npos);
 }
 
 TEST_F(SettingsProviderTest, DeleteNonExistentProfile) {
     // Deleting non-existent profile should succeed (idempotent)
-    auto result = provider.deleteConnectionProfile(R"({"id":"non_existent_profile_id"})");
+    auto result = provider->deleteConnectionProfile(R"({"id":"non_existent_profile_id"})");
     EXPECT_FALSE(result.empty());
 }
 
 TEST_F(SettingsProviderTest, UpdateSettingsAppliesMaxQueryHistoryToInstance) {
     // Issue #426: settings.maxQueryHistory の変更が wired QueryHistory に伝播することを検証する。
-    QueryHistory queryHistory{10000};
     for (int i = 0; i < 20; ++i) {
         HistoryItem item;
         item.id = generateHistoryId();
@@ -83,55 +94,61 @@ TEST_F(SettingsProviderTest, UpdateSettingsAppliesMaxQueryHistoryToInstance) {
         item.timestamp = std::chrono::system_clock::now();
         item.success = true;
         // 全て非 favorite (eviction 対象)
-        queryHistory.add(item);
+        m_queryHistory->add(item);
     }
-    ASSERT_EQ(queryHistory.getAll().size(), 20);
+    ASSERT_EQ(m_queryHistory->getAll().size(), 20);
 
-    provider.setQueryHistory(&queryHistory);
-
-    auto result = provider.updateSettings(R"({"general":{"maxQueryHistory":5}})");
+    auto result = provider->updateSettings(R"({"general":{"maxQueryHistory":5}})");
 
     EXPECT_NE(result.find("\"saved\""), std::string::npos);
-    EXPECT_EQ(queryHistory.getAll().size(), 5u);
+    EXPECT_EQ(m_queryHistory->getAll().size(), 5u);
 }
 
-TEST_F(SettingsProviderTest, SetQueryHistoryAppliesLoadedMaxToInstance) {
-    // wiring 時点の settings.maxQueryHistory が QueryHistory に即時反映されることを検証する。
-    // 1) settings を maxQueryHistory=3 に変更 (この時点では m_queryHistory 未 wire のため伝播は no-op)。
-    auto updateResult = provider.updateSettings(R"({"general":{"maxQueryHistory":3}})");
+TEST_F(SettingsProviderTest, ConstructionAppliesLoadedMaxToInstance) {
+    // SettingsProvider 構築時点の settings.maxQueryHistory が wire された QueryHistory に
+    // 即時反映されることを検証する (load 済み設定が新規 instance に適用される保証)。
+    // 1) fixture の provider 経由で settings を maxQueryHistory=3 に変更し disk に永続化。
+    auto updateResult = provider->updateSettings(R"({"general":{"maxQueryHistory":3}})");
     ASSERT_NE(updateResult.find("\"saved\""), std::string::npos);
 
-    // 2) ローカル QueryHistory は上限 1000 で 10 件保持。
-    QueryHistory queryHistory{1000};
+    // 2) 別の SettingsAccessor を新規 load (disk から maxQueryHistory=3 を取得)。
+    auto freshSettings = std::make_unique<SettingsAccessor>();
+    (void)freshSettings->load();
+    auto freshSession = std::make_unique<SessionAccessor>();
+    (void)freshSession->load();
+    ASSERT_EQ(freshSettings->getSettings().general.maxQueryHistory, 3);
+
+    // 3) ローカル QueryHistory は上限 1000 で 10 件保持。
+    QueryHistory localHistory{1000};
     for (int i = 0; i < 10; ++i) {
         HistoryItem item;
         item.id = generateHistoryId();
         item.sql = "SELECT " + std::to_string(i);
         item.timestamp = std::chrono::system_clock::now();
         item.success = true;
-        queryHistory.add(item);
+        localHistory.add(item);
     }
-    ASSERT_EQ(queryHistory.getAll().size(), 10);
+    ASSERT_EQ(localHistory.getAll().size(), 10);
 
-    // 3) wire 時点で setMaxItems(3) が呼ばれて 3 件まで縮小される。
-    provider.setQueryHistory(&queryHistory);
+    // 4) 新規 SettingsProvider を構築 → ctor 内で applyMaxQueryHistoryToInstance(3) 呼出 → 3 件に縮小。
+    SettingsProvider freshProvider{std::move(freshSettings), std::move(freshSession), nullptr, localHistory};
 
-    EXPECT_EQ(queryHistory.getAll().size(), 3u);
+    EXPECT_EQ(localHistory.getAll().size(), 3u);
 }
 
 TEST_F(SettingsProviderTest, SubInterfacesAreUsableIndependently) {
     // ISP 分割 (#450) の検証: SettingsProvider が各サブ IF として個別に受け取れ、
     // それぞれの代表メソッドが集約 IF 経由と同じ結果を返すことを保証する。Phase 4
     // (#456) で SystemContext がサブ IF を直接公開する際の前提を固める。
-    IAppSettingsAccessor& asAppSettings = provider;
-    IConnectionProfileAccessor& asProfile = provider;
-    ISessionStateAccessor& asSession = provider;
+    IAppSettingsAccessor& asAppSettings = *provider;
+    IConnectionProfileAccessor& asProfile = *provider;
+    ISessionStateAccessor& asSession = *provider;
 
     // 集約 IF 経由とサブ IF 経由で同一値が返ることを検証する。
     // Phase 4 (#456) でサブ IF を直接公開した際の振る舞い等価性を保証する。
-    EXPECT_EQ(asAppSettings.getSettings(), provider.getSettings());
-    EXPECT_EQ(asProfile.getConnectionProfiles(), provider.getConnectionProfiles());
-    EXPECT_EQ(asSession.getSessionState(), provider.getSessionState());
+    EXPECT_EQ(asAppSettings.getSettings(), provider->getSettings());
+    EXPECT_EQ(asProfile.getConnectionProfiles(), provider->getConnectionProfiles());
+    EXPECT_EQ(asSession.getSessionState(), provider->getSessionState());
 }
 
 }  // namespace


### PR DESCRIPTION
- `setQueryHistory()` の `post-construction wiring` を削除しコンストラクタ注入に統一
- `SettingsAccessor/SessionAccessor` を `unique_ptr` で外部注入 (load は `SystemContext` が実施)
- `m_queryHistory` を `QueryHistory&` に変更し null 不可を型で表明
- `SystemContext` で `QueryHistory` を makeQueryHistory(general.maxQueryHistory) として先行構築

Closes #456