### PR TITLE
refactor(frontend): MainLayout の dialog state を useDialogState hook に抽出 (#458)

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,5 +1,6 @@
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { bridge } from '../../api/bridge';
+import { useDialogState } from '../../hooks/useDialogState';
 import { useFileDrop } from '../../hooks/useFileDrop';
 import { useKeyboardShortcutHandler } from '../../hooks/useKeyboardShortcutHandler';
 import { applyConnectionMigration } from '../../store/connectionMigration';
@@ -53,16 +54,22 @@ export function MainLayout() {
   const [isLeftPanelVisible, setIsLeftPanelVisible] = useState(savedLeftPanelVisible);
   // Bottom panel is hidden by default on startup, shown when query is executed
   const [isBottomPanelVisible, setIsBottomPanelVisible] = useState(false);
-  const [isConnectionDialogOpen, setIsConnectionDialogOpen] = useState(false);
-  const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
-  const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
-  const [queryConfirmDialog, setQueryConfirmDialog] = useState<{
-    isOpen: boolean;
-    title: string;
-    message: string;
-    details?: string;
-    isBlocked?: boolean;
-  }>({ isOpen: false, title: '', message: '' });
+
+  const {
+    isConnectionDialogOpen,
+    openConnectionDialog,
+    closeConnectionDialog,
+    isSearchDialogOpen,
+    openSearchDialog,
+    closeSearchDialog,
+    isSettingsDialogOpen,
+    openSettingsDialog,
+    closeSettingsDialog,
+    queryConfirm,
+    openQueryConfirm,
+    closeQueryConfirm,
+    hasOpenDialog,
+  } = useDialogState();
 
   const { connections, addConnection, cancelConnection, isConnecting } = useConnectionStore();
   const {
@@ -124,7 +131,7 @@ export function MainLayout() {
           : undefined,
       });
       applyConnectionMigration(result.replaced);
-      setIsConnectionDialogOpen(false);
+      closeConnectionDialog();
     } catch {
       // Error is displayed in ConnectionDialog via connectionStore.error
     }
@@ -162,8 +169,7 @@ export function MainLayout() {
       };
     }
 
-    setQueryConfirmDialog({
-      isOpen: true,
+    openQueryConfirm({
       title: result.title,
       message: result.message,
       details: result.details,
@@ -176,22 +182,23 @@ export function MainLayout() {
     isProduction,
     isReadOnly,
     doExecuteQuery,
+    openQueryConfirm,
   ]);
 
   const handleConfirmExecute = useCallback(() => {
-    setQueryConfirmDialog({ isOpen: false, title: '', message: '' });
+    closeQueryConfirm();
     if (pendingExecutionRef.current) {
       const { queryId, connectionId } = pendingExecutionRef.current;
       executeQuery(queryId, connectionId);
       setIsBottomPanelVisible(true);
       pendingExecutionRef.current = null;
     }
-  }, [executeQuery]);
+  }, [executeQuery, closeQueryConfirm]);
 
   const handleCancelExecute = useCallback(() => {
-    setQueryConfirmDialog({ isOpen: false, title: '', message: '' });
+    closeQueryConfirm();
     pendingExecutionRef.current = null;
-  }, []);
+  }, [closeQueryConfirm]);
 
   const handleCancel = useCallback(() => {
     if (!activeQueryConnectionId) return;
@@ -203,14 +210,6 @@ export function MainLayout() {
       formatQuery(activeQueryId);
     }
   }, [activeQueryId, isDataView, formatQuery]);
-
-  const handleOpenSearch = useCallback(() => {
-    setIsSearchDialogOpen(true);
-  }, []);
-
-  const handleOpenSettings = useCallback(() => {
-    setIsSettingsDialogOpen(true);
-  }, []);
 
   const handleCloseTab = useCallback(() => {
     if (activeQueryId) {
@@ -245,15 +244,13 @@ export function MainLayout() {
 
   // Note: isBottomPanelVisible is NOT persisted - it's always hidden on startup
 
-  const hasOpenDialog = isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen;
-
   useKeyboardShortcutHandler({
     onNewQuery: handleNewQuery,
     onCloseTab: handleCloseTab,
     onExecute: handleExecute,
     onFormat: handleFormat,
-    onOpenSearch: handleOpenSearch,
-    onOpenSettings: handleOpenSettings,
+    onOpenSearch: openSearchDialog,
+    onOpenSettings: openSettingsDialog,
     onCancel: handleCancel,
     isExecuting,
     hasOpenDialog,
@@ -322,7 +319,7 @@ export function MainLayout() {
       <header className={styles.toolbar}>
         {/* Connection */}
         <div className={styles.toolbarGroup}>
-          <button onClick={() => setIsConnectionDialogOpen(true)} title="新規接続">
+          <button onClick={openConnectionDialog} title="新規接続">
             <ToolbarIcons.Database />
             <span>接続</span>
           </button>
@@ -381,12 +378,12 @@ export function MainLayout() {
         <div className={styles.toolbarGroup}>
           <button
             className={styles.iconButton}
-            onClick={handleOpenSearch}
+            onClick={openSearchDialog}
             title="検索 (Ctrl+Shift+P)"
           >
             <ToolbarIcons.Search />
           </button>
-          <button className={styles.iconButton} onClick={handleOpenSettings} title="設定 (Ctrl+,)">
+          <button className={styles.iconButton} onClick={openSettingsDialog} title="設定 (Ctrl+,)">
             <ToolbarIcons.Settings />
           </button>
         </div>
@@ -508,7 +505,7 @@ export function MainLayout() {
             isOpen={isConnectionDialogOpen}
             onClose={() => {
               if (isConnecting) cancelConnection();
-              setIsConnectionDialogOpen(false);
+              closeConnectionDialog();
             }}
             onConnect={connectToDatabase}
             isConnecting={isConnecting}
@@ -521,7 +518,7 @@ export function MainLayout() {
         <Suspense fallback={<LoadingFallback />}>
           <SearchDialog
             isOpen={isSearchDialogOpen}
-            onClose={() => setIsSearchDialogOpen(false)}
+            onClose={closeSearchDialog}
             onResultSelect={handleSearchResultSelect}
           />
         </Suspense>
@@ -529,23 +526,20 @@ export function MainLayout() {
 
       {isSettingsDialogOpen && (
         <Suspense fallback={<LoadingFallback />}>
-          <SettingsDialog
-            isOpen={isSettingsDialogOpen}
-            onClose={() => setIsSettingsDialogOpen(false)}
-          />
+          <SettingsDialog isOpen={isSettingsDialogOpen} onClose={closeSettingsDialog} />
         </Suspense>
       )}
 
       {/* Query Confirm Dialog for Production/Read-Only Mode */}
       <QueryConfirmDialog
-        isOpen={queryConfirmDialog.isOpen}
-        title={queryConfirmDialog.title}
-        message={queryConfirmDialog.message}
-        details={queryConfirmDialog.details}
+        isOpen={queryConfirm.isOpen}
+        title={queryConfirm.title}
+        message={queryConfirm.message}
+        details={queryConfirm.details}
         isDestructive={true}
-        confirmLabel={queryConfirmDialog.isBlocked ? 'OK' : 'Execute Anyway'}
-        cancelLabel={queryConfirmDialog.isBlocked ? undefined : 'Cancel'}
-        onConfirm={queryConfirmDialog.isBlocked ? handleCancelExecute : handleConfirmExecute}
+        confirmLabel={queryConfirm.isBlocked ? 'OK' : 'Execute Anyway'}
+        cancelLabel={queryConfirm.isBlocked ? undefined : 'Cancel'}
+        onConfirm={queryConfirm.isBlocked ? handleCancelExecute : handleConfirmExecute}
         onCancel={handleCancelExecute}
       />
     </div>

--- a/frontend/src/hooks/useDialogState.ts
+++ b/frontend/src/hooks/useDialogState.ts
@@ -1,0 +1,84 @@
+import { useCallback, useState } from 'react';
+
+export interface QueryConfirmState {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  details?: string;
+  isBlocked?: boolean;
+}
+
+export interface UseDialogStateResult {
+  isConnectionDialogOpen: boolean;
+  openConnectionDialog: () => void;
+  closeConnectionDialog: () => void;
+
+  isSearchDialogOpen: boolean;
+  openSearchDialog: () => void;
+  closeSearchDialog: () => void;
+
+  isSettingsDialogOpen: boolean;
+  openSettingsDialog: () => void;
+  closeSettingsDialog: () => void;
+
+  queryConfirm: QueryConfirmState;
+  openQueryConfirm: (params: Omit<QueryConfirmState, 'isOpen'>) => void;
+  closeQueryConfirm: () => void;
+
+  hasOpenDialog: boolean;
+}
+
+const QUERY_CONFIRM_INITIAL: QueryConfirmState = {
+  isOpen: false,
+  title: '',
+  message: '',
+};
+
+/**
+ * MainLayout の dialog open/close state を集約する管理層 hook。
+ * Connection / Search / Settings / QueryConfirm の 4 系統を保持し、open/close API と
+ * keyboard shortcut 抑止用の hasOpenDialog (queryConfirm を除く 3 dialog の OR) を返す。
+ *
+ * 運用ルール: callback (e.g. handleConfirmExecute) はビジネスロジックとの結合点のため
+ * 本 hook には含めず、呼び出し側 (MainLayout) で組み立てる。
+ */
+export function useDialogState(): UseDialogStateResult {
+  const [isConnectionDialogOpen, setIsConnectionDialogOpen] = useState(false);
+  const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
+  const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
+  const [queryConfirm, setQueryConfirm] = useState<QueryConfirmState>(QUERY_CONFIRM_INITIAL);
+
+  const openConnectionDialog = useCallback(() => setIsConnectionDialogOpen(true), []);
+  const closeConnectionDialog = useCallback(() => setIsConnectionDialogOpen(false), []);
+
+  const openSearchDialog = useCallback(() => setIsSearchDialogOpen(true), []);
+  const closeSearchDialog = useCallback(() => setIsSearchDialogOpen(false), []);
+
+  const openSettingsDialog = useCallback(() => setIsSettingsDialogOpen(true), []);
+  const closeSettingsDialog = useCallback(() => setIsSettingsDialogOpen(false), []);
+
+  const openQueryConfirm = useCallback((params: Omit<QueryConfirmState, 'isOpen'>) => {
+    setQueryConfirm({ isOpen: true, ...params });
+  }, []);
+  const closeQueryConfirm = useCallback(() => setQueryConfirm(QUERY_CONFIRM_INITIAL), []);
+
+  // queryConfirm は意図的に除外: production/read-only 警告ダイアログ open 中も
+  // Escape (cancelQuery) を効かせるため、キーボードショートカット抑止対象外とする
+  const hasOpenDialog = isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen;
+
+  return {
+    isConnectionDialogOpen,
+    openConnectionDialog,
+    closeConnectionDialog,
+    isSearchDialogOpen,
+    openSearchDialog,
+    closeSearchDialog,
+    isSettingsDialogOpen,
+    openSettingsDialog,
+    closeSettingsDialog,
+    queryConfirm,
+    openQueryConfirm,
+    closeQueryConfirm,
+    hasOpenDialog,
+  };
+}

--- a/frontend/src/tests/hooks/useDialogState.test.ts
+++ b/frontend/src/tests/hooks/useDialogState.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useDialogState } from '../../hooks/useDialogState';
+
+describe('useDialogState', () => {
+  it('初期状態 → 全 dialog が閉じており hasOpenDialog が false', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    expect(result.current.isConnectionDialogOpen).toBe(false);
+    expect(result.current.isSearchDialogOpen).toBe(false);
+    expect(result.current.isSettingsDialogOpen).toBe(false);
+    expect(result.current.queryConfirm).toEqual({
+      isOpen: false,
+      title: '',
+      message: '',
+    });
+    expect(result.current.hasOpenDialog).toBe(false);
+  });
+
+  it('openConnectionDialog → isConnectionDialogOpen と hasOpenDialog が true', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openConnectionDialog();
+    });
+
+    expect(result.current.isConnectionDialogOpen).toBe(true);
+    expect(result.current.hasOpenDialog).toBe(true);
+  });
+
+  it('closeConnectionDialog → open 後 close で isConnectionDialogOpen が false に戻る', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openConnectionDialog();
+    });
+    act(() => {
+      result.current.closeConnectionDialog();
+    });
+
+    expect(result.current.isConnectionDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(false);
+  });
+
+  it('openSearchDialog / closeSearchDialog → isSearchDialogOpen が独立に切り替わる', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openSearchDialog();
+    });
+    expect(result.current.isSearchDialogOpen).toBe(true);
+    expect(result.current.isConnectionDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(true);
+
+    act(() => {
+      result.current.closeSearchDialog();
+    });
+    expect(result.current.isSearchDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(false);
+  });
+
+  it('openSettingsDialog / closeSettingsDialog → isSettingsDialogOpen が独立に切り替わる', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openSettingsDialog();
+    });
+    expect(result.current.isSettingsDialogOpen).toBe(true);
+    expect(result.current.isSearchDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(true);
+
+    act(() => {
+      result.current.closeSettingsDialog();
+    });
+    expect(result.current.isSettingsDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(false);
+  });
+
+  it('openQueryConfirm → 渡した値が反映され isOpen が true', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openQueryConfirm({
+        title: '本番環境警告',
+        message: '本当に実行しますか?',
+        details: 'DROP TABLE users',
+        isBlocked: false,
+      });
+    });
+
+    expect(result.current.queryConfirm).toEqual({
+      isOpen: true,
+      title: '本番環境警告',
+      message: '本当に実行しますか?',
+      details: 'DROP TABLE users',
+      isBlocked: false,
+    });
+  });
+
+  it('openQueryConfirm 単独 → hasOpenDialog は false のまま (現状の振る舞いを維持)', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openQueryConfirm({
+        title: '読み取り専用モード',
+        message: 'UPDATE は実行できません',
+      });
+    });
+
+    expect(result.current.queryConfirm.isOpen).toBe(true);
+    expect(result.current.hasOpenDialog).toBe(false);
+  });
+
+  it('closeQueryConfirm → isOpen が false に戻り title/message も初期値にリセット', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openQueryConfirm({
+        title: '本番環境警告',
+        message: 'DROP TABLE は禁止されています',
+        details: 'DROP TABLE users',
+        isBlocked: true,
+      });
+    });
+    act(() => {
+      result.current.closeQueryConfirm();
+    });
+
+    expect(result.current.queryConfirm).toEqual({
+      isOpen: false,
+      title: '',
+      message: '',
+    });
+  });
+
+  it('複数 dialog 同時 open → 各 isXxxOpen が独立に true、hasOpenDialog も true', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openConnectionDialog();
+      result.current.openSettingsDialog();
+    });
+
+    expect(result.current.isConnectionDialogOpen).toBe(true);
+    expect(result.current.isSettingsDialogOpen).toBe(true);
+    expect(result.current.isSearchDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(true);
+  });
+});


### PR DESCRIPTION
4 系統 dialog (connection / search / settings / queryConfirm) の open/close state を散在状態から管理層 hook `useDialogState` に集約。

- 抽出: `useState` × 4 → `useDialogState()` 1 行
- API: `set*` (bool 引数) を廃し `open*Dialog` / `close*Dialog` に統一
- `hasOpenDialog` 派生値は hook 内で計算 (queryConfirm は警告中も Escape を効かせるため意図的に除外する従来振る舞いを維持)
- `handleOpenSearch` / `handleOpenSettings` の素通しラッパーを削除し `openSearchDialog` / `openSettingsDialog` を toolbar onClick /`useKeyboardShortcutHandler` に直接渡し
- callback (`handleConfirmExecute` 等) はビジネスロジック結合点のため `MainLayout` 残置 (Issue 仕様)
- 新規 unit test 9 件 (renderHook + act): 初期値 / 各 dialog の open/close / 複数同時 open / queryConfirm 引数反映 / hasOpenDialog 振る舞い

Closes #458