### PR TITLE
refactor(frontend): MainLayout の panel layout state を usePanelLayoutState hook に抽出 (#459)

### DIFF
--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,12 +1,12 @@
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useRef } from 'react';
 import { bridge } from '../../api/bridge';
 import { useDialogState } from '../../hooks/useDialogState';
 import { useFileDrop } from '../../hooks/useFileDrop';
 import { useKeyboardShortcutHandler } from '../../hooks/useKeyboardShortcutHandler';
+import { usePanelLayoutState } from '../../hooks/usePanelLayoutState';
 import { applyConnectionMigration } from '../../store/connectionMigration';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useQueryStore } from '../../store/queryStore';
-import { useSessionStore } from '../../store/sessionStore';
 import type { ConnectionConfig } from '../../types/connectionForm';
 import { lazyWithRetry } from '../../utils/lazyWithRetry';
 import { checkQueryExecutability } from '../../utils/queryExecutionCheck';
@@ -39,22 +39,6 @@ function LoadingFallback() {
 }
 
 export function MainLayout() {
-  // Session store for persisted layout state
-  const {
-    leftPanelWidth: savedLeftPanelWidth,
-    bottomPanelHeight: savedBottomPanelHeight,
-    isLeftPanelVisible: savedLeftPanelVisible,
-    setLeftPanelWidth: saveLeftPanelWidth,
-    setBottomPanelHeight: saveBottomPanelHeight,
-    setLeftPanelVisible: saveLeftPanelVisible,
-  } = useSessionStore();
-
-  const [leftPanelWidth, setLeftPanelWidth] = useState(savedLeftPanelWidth);
-  const [bottomPanelHeight, setBottomPanelHeight] = useState(savedBottomPanelHeight);
-  const [isLeftPanelVisible, setIsLeftPanelVisible] = useState(savedLeftPanelVisible);
-  // Bottom panel is hidden by default on startup, shown when query is executed
-  const [isBottomPanelVisible, setIsBottomPanelVisible] = useState(false);
-
   const {
     isConnectionDialogOpen,
     openConnectionDialog,
@@ -93,15 +77,21 @@ export function MainLayout() {
   const isReadOnly = activeQueryConnection?.isReadOnly ?? false;
   const isDataView = activeQuery?.isDataView === true;
 
-  // Hide bottom panel when in data view mode (table display)
-  const shouldShowBottomPanel = isBottomPanelVisible && !isDataView;
-
-  // Auto-show bottom panel when query results are available
-  useEffect(() => {
-    if (activeQueryId && results[activeQueryId] && !isDataView) {
-      setIsBottomPanelVisible(true);
-    }
-  }, [activeQueryId, results, isDataView]);
+  const {
+    leftPanelWidth,
+    setLeftPanelWidth,
+    bottomPanelHeight,
+    setBottomPanelHeight,
+    isLeftPanelVisible,
+    setIsLeftPanelVisible,
+    isBottomPanelVisible,
+    setIsBottomPanelVisible,
+    shouldShowBottomPanel,
+  } = usePanelLayoutState({
+    activeQueryId,
+    hasActiveResult: activeQueryId !== null && results[activeQueryId] !== undefined,
+    isDataView,
+  });
 
   const connectToDatabase = async (config: ConnectionConfig) => {
     try {
@@ -150,7 +140,7 @@ export function MainLayout() {
       executeQuery(activeQueryId, activeQueryConnectionId);
       setIsBottomPanelVisible(true);
     }
-  }, [activeQueryId, activeQueryConnectionId, executeQuery]);
+  }, [activeQueryId, activeQueryConnectionId, executeQuery, setIsBottomPanelVisible]);
 
   const handleExecute = useCallback(() => {
     if (!activeQueryId || !activeQueryConnectionId || !activeQuery) return;
@@ -193,7 +183,7 @@ export function MainLayout() {
       setIsBottomPanelVisible(true);
       pendingExecutionRef.current = null;
     }
-  }, [executeQuery, closeQueryConfirm]);
+  }, [executeQuery, closeQueryConfirm, setIsBottomPanelVisible]);
 
   const handleCancelExecute = useCallback(() => {
     closeQueryConfirm();
@@ -228,21 +218,6 @@ export function MainLayout() {
     },
     [activeQueryId]
   );
-
-  // Persist layout changes
-  useEffect(() => {
-    saveLeftPanelWidth(leftPanelWidth);
-  }, [leftPanelWidth, saveLeftPanelWidth]);
-
-  useEffect(() => {
-    saveBottomPanelHeight(bottomPanelHeight);
-  }, [bottomPanelHeight, saveBottomPanelHeight]);
-
-  useEffect(() => {
-    saveLeftPanelVisible(isLeftPanelVisible);
-  }, [isLeftPanelVisible, saveLeftPanelVisible]);
-
-  // Note: isBottomPanelVisible is NOT persisted - it's always hidden on startup
 
   useKeyboardShortcutHandler({
     onNewQuery: handleNewQuery,

--- a/frontend/src/hooks/usePanelLayoutState.ts
+++ b/frontend/src/hooks/usePanelLayoutState.ts
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { useSessionStore } from '../store/sessionStore';
+
+export interface UsePanelLayoutStateParams {
+  activeQueryId: string | null;
+  hasActiveResult: boolean;
+  isDataView: boolean;
+}
+
+export interface UsePanelLayoutStateResult {
+  leftPanelWidth: number;
+  setLeftPanelWidth: (width: number) => void;
+  bottomPanelHeight: number;
+  setBottomPanelHeight: (height: number) => void;
+  isLeftPanelVisible: boolean;
+  setIsLeftPanelVisible: (visible: boolean) => void;
+  isBottomPanelVisible: boolean;
+  setIsBottomPanelVisible: (visible: boolean) => void;
+  shouldShowBottomPanel: boolean;
+}
+
+/**
+ * MainLayout の panel 幅 / 表示 state を集約する管理層 hook。
+ * leftPanelWidth / bottomPanelHeight / isLeftPanelVisible は sessionStore に永続化する。
+ * isBottomPanelVisible は意図的に永続化せず、起動時は常に非表示で始まり、クエリ結果取得を
+ * 契機に auto-show する (data view モード時は除外)。
+ */
+export function usePanelLayoutState(params: UsePanelLayoutStateParams): UsePanelLayoutStateResult {
+  const { activeQueryId, hasActiveResult, isDataView } = params;
+
+  const savedLeftPanelWidth = useSessionStore((state) => state.leftPanelWidth);
+  const savedBottomPanelHeight = useSessionStore((state) => state.bottomPanelHeight);
+  const savedLeftPanelVisible = useSessionStore((state) => state.isLeftPanelVisible);
+  const saveLeftPanelWidth = useSessionStore((state) => state.setLeftPanelWidth);
+  const saveBottomPanelHeight = useSessionStore((state) => state.setBottomPanelHeight);
+  const saveLeftPanelVisible = useSessionStore((state) => state.setLeftPanelVisible);
+
+  const [leftPanelWidth, setLeftPanelWidth] = useState(savedLeftPanelWidth);
+  const [bottomPanelHeight, setBottomPanelHeight] = useState(savedBottomPanelHeight);
+  const [isLeftPanelVisible, setIsLeftPanelVisible] = useState(savedLeftPanelVisible);
+  const [isBottomPanelVisible, setIsBottomPanelVisible] = useState(false);
+
+  useEffect(() => {
+    if (activeQueryId && hasActiveResult && !isDataView) {
+      setIsBottomPanelVisible(true);
+    }
+  }, [activeQueryId, hasActiveResult, isDataView]);
+
+  useEffect(() => {
+    saveLeftPanelWidth(leftPanelWidth);
+  }, [leftPanelWidth, saveLeftPanelWidth]);
+
+  useEffect(() => {
+    saveBottomPanelHeight(bottomPanelHeight);
+  }, [bottomPanelHeight, saveBottomPanelHeight]);
+
+  useEffect(() => {
+    saveLeftPanelVisible(isLeftPanelVisible);
+  }, [isLeftPanelVisible, saveLeftPanelVisible]);
+
+  const shouldShowBottomPanel = isBottomPanelVisible && !isDataView;
+
+  return {
+    leftPanelWidth,
+    setLeftPanelWidth,
+    bottomPanelHeight,
+    setBottomPanelHeight,
+    isLeftPanelVisible,
+    setIsLeftPanelVisible,
+    isBottomPanelVisible,
+    setIsBottomPanelVisible,
+    shouldShowBottomPanel,
+  };
+}

--- a/frontend/src/tests/hooks/usePanelLayoutState.test.ts
+++ b/frontend/src/tests/hooks/usePanelLayoutState.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  type UsePanelLayoutStateParams,
+  usePanelLayoutState,
+} from '../../hooks/usePanelLayoutState';
+import { useSessionStore } from '../../store/sessionStore';
+
+const DEFAULT_PARAMS: UsePanelLayoutStateParams = {
+  activeQueryId: null,
+  hasActiveResult: false,
+  isDataView: false,
+};
+
+describe('usePanelLayoutState', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSessionStore.setState({
+      leftPanelWidth: 320,
+      bottomPanelHeight: 200,
+      isLeftPanelVisible: true,
+      isBottomPanelVisible: false,
+    });
+  });
+
+  it('初期状態 → sessionStore の永続値で width/height/leftVisible が初期化され bottomVisible は false', () => {
+    useSessionStore.setState({
+      leftPanelWidth: 280,
+      bottomPanelHeight: 150,
+      isLeftPanelVisible: false,
+    });
+
+    const { result } = renderHook(() => usePanelLayoutState(DEFAULT_PARAMS));
+
+    expect(result.current.leftPanelWidth).toBe(280);
+    expect(result.current.bottomPanelHeight).toBe(150);
+    expect(result.current.isLeftPanelVisible).toBe(false);
+    expect(result.current.isBottomPanelVisible).toBe(false);
+    expect(result.current.shouldShowBottomPanel).toBe(false);
+  });
+
+  it('setLeftPanelWidth → ローカル state 更新と sessionStore への永続化', () => {
+    const { result } = renderHook(() => usePanelLayoutState(DEFAULT_PARAMS));
+
+    act(() => {
+      result.current.setLeftPanelWidth(420);
+    });
+
+    expect(result.current.leftPanelWidth).toBe(420);
+    expect(useSessionStore.getState().leftPanelWidth).toBe(420);
+  });
+
+  it('setBottomPanelHeight → ローカル state 更新と sessionStore への永続化', () => {
+    const { result } = renderHook(() => usePanelLayoutState(DEFAULT_PARAMS));
+
+    act(() => {
+      result.current.setBottomPanelHeight(350);
+    });
+
+    expect(result.current.bottomPanelHeight).toBe(350);
+    expect(useSessionStore.getState().bottomPanelHeight).toBe(350);
+  });
+
+  it('setIsLeftPanelVisible → ローカル state 更新と sessionStore への永続化', () => {
+    const { result } = renderHook(() => usePanelLayoutState(DEFAULT_PARAMS));
+
+    act(() => {
+      result.current.setIsLeftPanelVisible(false);
+    });
+
+    expect(result.current.isLeftPanelVisible).toBe(false);
+    expect(useSessionStore.getState().isLeftPanelVisible).toBe(false);
+  });
+
+  it('setIsBottomPanelVisible → bottom panel は永続化されない (sessionStore は変化しない)', () => {
+    const { result } = renderHook(() => usePanelLayoutState(DEFAULT_PARAMS));
+    const initialPersisted = useSessionStore.getState().isBottomPanelVisible;
+
+    act(() => {
+      result.current.setIsBottomPanelVisible(true);
+    });
+
+    expect(result.current.isBottomPanelVisible).toBe(true);
+    expect(useSessionStore.getState().isBottomPanelVisible).toBe(initialPersisted);
+  });
+
+  it('auto-show: activeQueryId + hasActiveResult + !isDataView → isBottomPanelVisible が true', () => {
+    const { result, rerender } = renderHook(
+      (props: UsePanelLayoutStateParams) => usePanelLayoutState(props),
+      { initialProps: DEFAULT_PARAMS }
+    );
+
+    expect(result.current.isBottomPanelVisible).toBe(false);
+
+    rerender({ activeQueryId: 'q1', hasActiveResult: true, isDataView: false });
+
+    expect(result.current.isBottomPanelVisible).toBe(true);
+    expect(result.current.shouldShowBottomPanel).toBe(true);
+  });
+
+  it('auto-show 抑止: isDataView=true の時は結果取得しても auto-show しない', () => {
+    const { result, rerender } = renderHook(
+      (props: UsePanelLayoutStateParams) => usePanelLayoutState(props),
+      { initialProps: DEFAULT_PARAMS }
+    );
+
+    rerender({ activeQueryId: 'q1', hasActiveResult: true, isDataView: true });
+
+    expect(result.current.isBottomPanelVisible).toBe(false);
+    expect(result.current.shouldShowBottomPanel).toBe(false);
+  });
+
+  it('auto-show 抑止: hasActiveResult=false の時は auto-show しない', () => {
+    const { result, rerender } = renderHook(
+      (props: UsePanelLayoutStateParams) => usePanelLayoutState(props),
+      { initialProps: DEFAULT_PARAMS }
+    );
+
+    rerender({ activeQueryId: 'q1', hasActiveResult: false, isDataView: false });
+
+    expect(result.current.isBottomPanelVisible).toBe(false);
+  });
+
+  it('shouldShowBottomPanel: isBottomPanelVisible=true でも isDataView=true なら false', () => {
+    const { result, rerender } = renderHook(
+      (props: UsePanelLayoutStateParams) => usePanelLayoutState(props),
+      { initialProps: DEFAULT_PARAMS }
+    );
+
+    act(() => {
+      result.current.setIsBottomPanelVisible(true);
+    });
+    expect(result.current.shouldShowBottomPanel).toBe(true);
+
+    rerender({ activeQueryId: 'q1', hasActiveResult: false, isDataView: true });
+
+    expect(result.current.isBottomPanelVisible).toBe(true);
+    expect(result.current.shouldShowBottomPanel).toBe(false);
+  });
+});


### PR DESCRIPTION
panel 幅 / 表示 state 4 つ + 永続化 effect 3 つ + auto-show effect 1 つ + shouldShowBottomPanel 派生値を管理層 hook に集約。

- usePanelLayoutState: zustand selector で 6 フィールド個別購読、auto-show は引数(activeQueryId / hasActiveResult / isDataView)経由で結合点を明示
- isBottomPanelVisible は意図的に非永続化 (起動時は常に非表示で開始)
- MainLayout: -44 / +19、useSessionStore 直接依存を削除

Closes #459