### PR TITLE
refactor(frontend): ResultGrid の scroll restore を useScrollRestoreHandler (操作層) に抽出 (#461)

### DIFF
--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -9,16 +9,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import {
-  memo,
-  Suspense,
-  type UIEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEphemeralOpen } from '../../hooks/useEphemeralOpen';
 import { useConnectionStore } from '../../store/connectionStore';
 import {
@@ -31,7 +22,6 @@ import {
   useQueryResult,
   useQueryStore,
 } from '../../store/queryStore';
-import { useScrollPositionStore } from '../../store/scrollPositionStore';
 import { useSessionStore } from '../../store/sessionStore';
 import type { ResultSet } from '../../types';
 import { type ColumnMeta, type GridViewMode, isNumericType, type RowData } from '../../types/grid';
@@ -51,6 +41,7 @@ import { useGridEdit } from './hooks/useGridEdit';
 import { useGridKeyboard } from './hooks/useGridKeyboard';
 import { useGridSelection } from './hooks/useGridSelection';
 import { useRelatedRows } from './hooks/useRelatedRows';
+import { useScrollRestoreHandler } from './hooks/useScrollRestoreHandler';
 import { useWhereFilter } from './hooks/useWhereFilter';
 import styles from './ResultGrid.module.css';
 import { ResultTabs } from './ResultTabs';
@@ -429,119 +420,24 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     return () => observer.disconnect();
   }, [rowVirtualizer]);
 
-  // --- Preserve scroll position per query when switching tabs ---
-  // UI state (sort/filter/selection) は per-tab 独立のためリセット維持。
-  // スクロール位置のみ前 queryId 単位で保存→復元 (Issue #366)。
-  const prevQueryIdRef = useRef<string | null>(null);
-  const scrollRestoredForQueryRef = useRef<string | null>(null);
-  // タブ切替の過渡期 (queryId 変化 → E2 復元完了まで) に発火する scroll event を
-  // ユーザー操作として扱わないための抑止フラグ。スクロール復元の programmatic scroll や
-  // DOM height 変化による clamp-scroll が store[newQueryId] に旧値を書き込むのを防ぐ。
-  const suppressScrollSaveRef = useRef(false);
-
-  // 1. タブ切替時: UI reset + scroll save 抑止 ON (scroll 保存は onScroll で常時実施)
+  // --- Reset per-tab UI state on queryId switch ---
+  // sort / filter / selection は per-tab 独立のためリセット。
+  // scroll 位置の保存/復元は useScrollRestoreHandler が担当 (Issue #366, #461)。
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally triggered by targetQueryId change
   useEffect(() => {
-    // 過渡期に発火する scroll event が新 queryId の store を汚染するのを防ぐ。
-    // E2 復元完了または rows 未到達で成立し得ない場合の timeout でクリア。
-    suppressScrollSaveRef.current = true;
     resetSelection();
     setSorting([]);
     setColumnFilters([]);
     setShowColumnFilters(false);
     setActiveResultIndex(0);
-    prevQueryIdRef.current = targetQueryId;
-    scrollRestoredForQueryRef.current = null;
   }, [targetQueryId]);
 
-  // Scroll 位置を onScroll で常時保存 (closure で現在の targetQueryId に紐付け)。
-  // useEffect での保存は ref=null or 誤 queryId 問題を起こすため廃止。
-  // 復元中の programmatic scroll は scrollRestoredForQueryRef で識別し保存を抑止する必要はない
-  // (同値を保存するだけで害なし)。
-  const handleScroll = useCallback(
-    (e: UIEvent<HTMLDivElement>) => {
-      if (!targetQueryId) return;
-      if (suppressScrollSaveRef.current) return;
-      const el = e.currentTarget;
-      useScrollPositionStore
-        .getState()
-        .savePosition(targetQueryId, { top: el.scrollTop, left: el.scrollLeft });
-    },
-    [targetQueryId]
-  );
-
-  // 2. スクロール位置復元: rows が描画可能になり container が実サイズを持った後に 1 回だけ実施。
-  // WebView2 の flex layout 解決遅延で clientHeight が 0 のままになる可能性があるため、
-  // rAF ループでリトライ。clamp を避けるため scrollToOffset は totalSize 確定後に実行する。
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll restore is a one-shot per queryId
-  useEffect(() => {
-    if (!targetQueryId) return;
-    if (scrollRestoredForQueryRef.current === targetQueryId) return;
-    if (rows.length === 0) return;
-
-    let cancelled = false;
-    let attempts = 0;
-    const MAX_ATTEMPTS = 30;
-
-    const tryRestore = () => {
-      if (cancelled) return;
-      if (scrollRestoredForQueryRef.current === targetQueryId) return;
-
-      const el = tableContainerRef.current;
-      if (!el || el.clientHeight === 0) {
-        if (attempts++ < MAX_ATTEMPTS) {
-          requestAnimationFrame(tryRestore);
-        } else {
-          // 限界超過 — 復元諦めて抑止解除 (user scroll 保存を許可)
-          suppressScrollSaveRef.current = false;
-        }
-        return;
-      }
-
-      rowVirtualizer.measure();
-      const totalSize = rowVirtualizer.getTotalSize();
-      if (totalSize === 0) {
-        if (attempts++ < MAX_ATTEMPTS) {
-          requestAnimationFrame(tryRestore);
-        } else {
-          suppressScrollSaveRef.current = false;
-        }
-        return;
-      }
-
-      const saved = useScrollPositionStore.getState().getPosition(targetQueryId);
-      if (saved) {
-        rowVirtualizer.scrollToOffset(saved.top);
-        el.scrollLeft = saved.left;
-      }
-      scrollRestoredForQueryRef.current = targetQueryId;
-      // 復元 programmatic scroll 完了後に抑止解除。scroll event は同期発火または
-      // 次 microtask で発火するため rAF 2 回待ち (1 回目: event 発火、2 回目: 解除)。
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          suppressScrollSaveRef.current = false;
-        });
-      });
-    };
-
-    requestAnimationFrame(tryRestore);
-    return () => {
-      cancelled = true;
-    };
-  }, [targetQueryId, rows.length]);
-
-  // --- Save scroll position on unmount (tab switched to non-grid view) ---
-  useEffect(() => {
-    return () => {
-      const el = tableContainerRef.current;
-      const qid = prevQueryIdRef.current;
-      if (qid && el) {
-        useScrollPositionStore
-          .getState()
-          .savePosition(qid, { top: el.scrollTop, left: el.scrollLeft });
-      }
-    };
-  }, []);
+  const { handleScroll } = useScrollRestoreHandler({
+    targetQueryId,
+    scrollerRef: tableContainerRef,
+    rowVirtualizer,
+    rowsLength: rows.length,
+  });
 
   // --- Infinite scroll: fetch more rows when nearing bottom ---
   useEffect(() => {

--- a/frontend/src/components/grid/hooks/useScrollRestoreHandler.ts
+++ b/frontend/src/components/grid/hooks/useScrollRestoreHandler.ts
@@ -1,4 +1,4 @@
-import type { useVirtualizer } from '@tanstack/react-virtual';
+import type { Virtualizer } from '@tanstack/react-virtual';
 import { type RefObject, type UIEvent, useCallback, useEffect, useRef } from 'react';
 import { useScrollPositionStore } from '../../../store/scrollPositionStore';
 
@@ -19,7 +19,7 @@ const MAX_RESTORE_ATTEMPTS = 30;
 interface UseScrollRestoreHandlerArgs {
   targetQueryId: string | null;
   scrollerRef: RefObject<HTMLDivElement | null>;
-  rowVirtualizer: ReturnType<typeof useVirtualizer>;
+  rowVirtualizer: Virtualizer<HTMLDivElement, Element>;
   rowsLength: number;
 }
 

--- a/frontend/src/components/grid/hooks/useScrollRestoreHandler.ts
+++ b/frontend/src/components/grid/hooks/useScrollRestoreHandler.ts
@@ -1,0 +1,134 @@
+import type { useVirtualizer } from '@tanstack/react-virtual';
+import { type RefObject, type UIEvent, useCallback, useEffect, useRef } from 'react';
+import { useScrollPositionStore } from '../../../store/scrollPositionStore';
+
+/**
+ * Tab 切替時の grid scroll 位置保存/復元 (操作層).
+ *
+ * - onScroll で現在の queryId に top/left を常時保存 (closure 経由で旧 queryId 汚染を防止)
+ * - queryId 切替の過渡期 (programmatic scroll や clamp-scroll) は suppress フラグで保存抑止
+ * - rows 描画後に rAF ループで container サイズが整うのを待ってから 1 回だけ復元
+ * - unmount (tab 非表示化) 時は最後の queryId に対して最終保存
+ *
+ * 背景 (#366, scrollPersistence test 参照):
+ *   useEffect cleanup での保存方式は ref=null や誤 queryId 問題を起こすため
+ *   onScroll closure による保存方式に統一されている。
+ */
+const MAX_RESTORE_ATTEMPTS = 30;
+
+interface UseScrollRestoreHandlerArgs {
+  targetQueryId: string | null;
+  scrollerRef: RefObject<HTMLDivElement | null>;
+  rowVirtualizer: ReturnType<typeof useVirtualizer>;
+  rowsLength: number;
+}
+
+export interface UseScrollRestoreHandlerResult {
+  handleScroll: (e: UIEvent<HTMLDivElement>) => void;
+}
+
+export function useScrollRestoreHandler({
+  targetQueryId,
+  scrollerRef,
+  rowVirtualizer,
+  rowsLength,
+}: UseScrollRestoreHandlerArgs): UseScrollRestoreHandlerResult {
+  const prevQueryIdRef = useRef<string | null>(null);
+  const scrollRestoredForQueryRef = useRef<string | null>(null);
+  // 過渡期 (queryId 変化 → 復元完了まで) の scroll event を抑止するフラグ。
+  // programmatic scroll や DOM height 変化による clamp-scroll が新 queryId の
+  // store に旧値を書き込むのを防ぐ。
+  const suppressScrollSaveRef = useRef(false);
+
+  // 1. queryId 切替: 過渡期抑止 ON + 復元 1-shot フラグ初期化
+  useEffect(() => {
+    suppressScrollSaveRef.current = true;
+    prevQueryIdRef.current = targetQueryId;
+    scrollRestoredForQueryRef.current = null;
+  }, [targetQueryId]);
+
+  // 2. onScroll: 現在の targetQueryId に紐付け保存 (closure)
+  const handleScroll = useCallback(
+    (e: UIEvent<HTMLDivElement>) => {
+      if (!targetQueryId) return;
+      if (suppressScrollSaveRef.current) return;
+      const el = e.currentTarget;
+      useScrollPositionStore
+        .getState()
+        .savePosition(targetQueryId, { top: el.scrollTop, left: el.scrollLeft });
+    },
+    [targetQueryId]
+  );
+
+  // 3. 復元: rows 描画 + container 実サイズ確定後に rAF ループで 1 回だけ実施
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll restore is a one-shot per queryId
+  useEffect(() => {
+    if (!targetQueryId) return;
+    if (scrollRestoredForQueryRef.current === targetQueryId) return;
+    if (rowsLength === 0) return;
+
+    let cancelled = false;
+    let attempts = 0;
+
+    const tryRestore = () => {
+      if (cancelled) return;
+      if (scrollRestoredForQueryRef.current === targetQueryId) return;
+
+      const el = scrollerRef.current;
+      if (!el || el.clientHeight === 0) {
+        if (attempts++ < MAX_RESTORE_ATTEMPTS) {
+          requestAnimationFrame(tryRestore);
+        } else {
+          // 限界超過 — 復元諦めて抑止解除 (user scroll 保存を許可)
+          suppressScrollSaveRef.current = false;
+        }
+        return;
+      }
+
+      rowVirtualizer.measure();
+      const totalSize = rowVirtualizer.getTotalSize();
+      if (totalSize === 0) {
+        if (attempts++ < MAX_RESTORE_ATTEMPTS) {
+          requestAnimationFrame(tryRestore);
+        } else {
+          suppressScrollSaveRef.current = false;
+        }
+        return;
+      }
+
+      const saved = useScrollPositionStore.getState().getPosition(targetQueryId);
+      if (saved) {
+        rowVirtualizer.scrollToOffset(saved.top);
+        el.scrollLeft = saved.left;
+      }
+      scrollRestoredForQueryRef.current = targetQueryId;
+      // 復元 programmatic scroll 完了後に抑止解除。scroll event は同期発火または
+      // 次 microtask で発火するため rAF 2 回待ち (1 回目: event 発火、2 回目: 解除)。
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          suppressScrollSaveRef.current = false;
+        });
+      });
+    };
+
+    requestAnimationFrame(tryRestore);
+    return () => {
+      cancelled = true;
+    };
+  }, [targetQueryId, rowsLength]);
+
+  // 4. unmount (tab が grid 以外に切替) 時に最終保存
+  useEffect(() => {
+    return () => {
+      const el = scrollerRef.current;
+      const qid = prevQueryIdRef.current;
+      if (qid && el) {
+        useScrollPositionStore
+          .getState()
+          .savePosition(qid, { top: el.scrollTop, left: el.scrollLeft });
+      }
+    };
+  }, [scrollerRef]);
+
+  return { handleScroll };
+}

--- a/frontend/src/tests/grid/useScrollRestoreHandler.test.tsx
+++ b/frontend/src/tests/grid/useScrollRestoreHandler.test.tsx
@@ -1,0 +1,208 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { fireEvent, render } from '@testing-library/react';
+import { type RefObject, useRef } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useScrollRestoreHandler } from '../../components/grid/hooks/useScrollRestoreHandler';
+import { useScrollPositionStore } from '../../store/scrollPositionStore';
+
+/**
+ * useScrollRestoreHandler の不変条件テスト。
+ *
+ * scope:
+ * - onScroll closure による現 queryId への保存
+ * - queryId 切替過渡期 (suppress) の保存抑止
+ * - rows=0 / queryId=null での復元短絡
+ * - 復元 1-shot 性 (同一 queryId での重複 scrollToOffset 呼出なし)
+ *
+ * 既存 ResultGrid.scrollPersistence.test.tsx は再現ハーネスでの不変条件検証だが、
+ * 本テストは抽出 hook 自体の API/挙動をピンポイントで検証する。
+ */
+
+interface HarnessProps {
+  queryId: string | null;
+  rowsLength: number;
+  height?: number;
+  totalSize?: number;
+  onVirtualizer?: (v: ReturnType<typeof useVirtualizer>) => void;
+}
+
+function Harness({
+  queryId,
+  rowsLength,
+  height = 200,
+  totalSize = 1000,
+  onVirtualizer,
+}: HarnessProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: rowsLength,
+    getScrollElement: () => ref.current,
+    estimateSize: () => 32,
+    initialRect: { width: 0, height },
+  });
+
+  // jsdom は layout 計算しないため getTotalSize/measure をスタブ
+  vi.spyOn(rowVirtualizer, 'getTotalSize').mockReturnValue(totalSize);
+  vi.spyOn(rowVirtualizer, 'measure').mockImplementation(() => {});
+  if (onVirtualizer) onVirtualizer(rowVirtualizer);
+
+  const { handleScroll } = useScrollRestoreHandler({
+    targetQueryId: queryId,
+    scrollerRef: ref as RefObject<HTMLDivElement | null>,
+    rowVirtualizer,
+    rowsLength,
+  });
+
+  return (
+    <div
+      data-testid="scroller"
+      ref={ref}
+      onScroll={handleScroll}
+      style={{ height, overflow: 'auto' }}
+    >
+      <div style={{ height: 5000 }} />
+    </div>
+  );
+}
+
+function setScroll(el: HTMLElement, top: number, left = 0) {
+  Object.defineProperty(el, 'scrollTop', { value: top, writable: true, configurable: true });
+  Object.defineProperty(el, 'scrollLeft', { value: left, writable: true, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: 200, writable: true, configurable: true });
+}
+
+describe('useScrollRestoreHandler', () => {
+  beforeEach(() => {
+    useScrollPositionStore.setState({ positions: {} });
+    // requestAnimationFrame を即時実行に置換 (rAF ループ内の処理を同期化)
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('onScroll 保存', () => {
+    it('queryId が null のときは保存しない', () => {
+      const { getByTestId } = render(<Harness queryId={null} rowsLength={0} />);
+      const el = getByTestId('scroller');
+      setScroll(el, 1000);
+      fireEvent.scroll(el);
+      expect(useScrollPositionStore.getState().positions).toEqual({});
+    });
+
+    it('過渡期 (suppress=true) は保存しない', () => {
+      // queryId 切替直後は suppress=true。復元実行前 (rowsLength=0) では false に戻らない。
+      const { getByTestId } = render(<Harness queryId="q1" rowsLength={0} />);
+      const el = getByTestId('scroller');
+      setScroll(el, 1234);
+      fireEvent.scroll(el);
+      expect(useScrollPositionStore.getState().getPosition('q1')).toBeUndefined();
+    });
+
+    it('復元完了後はユーザー scroll が現 queryId に保存される', () => {
+      // rowsLength>0 + container 実サイズあり → 復元 → suppress 解除 (rAF 2 回経由)
+      const { getByTestId } = render(<Harness queryId="q1" rowsLength={10} />);
+      const el = getByTestId('scroller');
+      // 復元 path が clientHeight を要求するため事前設定が必要
+      Object.defineProperty(el, 'clientHeight', { value: 200, configurable: true });
+
+      setScroll(el, 7247, 50);
+      fireEvent.scroll(el);
+
+      expect(useScrollPositionStore.getState().getPosition('q1')).toEqual({ top: 7247, left: 50 });
+    });
+  });
+
+  describe('復元', () => {
+    it('rowsLength=0 では復元 scrollToOffset を呼ばない', () => {
+      let virt: ReturnType<typeof useVirtualizer> | undefined;
+      useScrollPositionStore.getState().savePosition('q1', { top: 500, left: 0 });
+      render(
+        <Harness
+          queryId="q1"
+          rowsLength={0}
+          onVirtualizer={(v) => {
+            virt = v;
+          }}
+        />
+      );
+      expect(virt).toBeDefined();
+      if (!virt) throw new Error('virtualizer not captured');
+      const spy = vi.spyOn(virt, 'scrollToOffset');
+      // rerender なしで rowsLength は 0 のまま — scrollToOffset 呼ばれない
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('saved 値が container にセットされる', () => {
+      useScrollPositionStore.getState().savePosition('q1', { top: 500, left: 30 });
+      let virt: ReturnType<typeof useVirtualizer> | undefined;
+      const { getByTestId } = render(
+        <Harness
+          queryId="q1"
+          rowsLength={10}
+          onVirtualizer={(v) => {
+            virt = v;
+          }}
+        />
+      );
+      const el = getByTestId('scroller');
+      // 復元 path の clientHeight チェック通過用
+      Object.defineProperty(el, 'clientHeight', { value: 200, configurable: true });
+
+      // hook 内 useEffect は render 後に同期実行される。requestAnimationFrame は即時化済。
+      expect(virt?.scrollToOffset).toBeDefined();
+    });
+
+    it('saved が無いときは scrollToOffset を呼ばない (1-shot フラグはセットされる)', () => {
+      let virt: ReturnType<typeof useVirtualizer> | undefined;
+      const { getByTestId } = render(
+        <Harness
+          queryId="q-no-save"
+          rowsLength={10}
+          onVirtualizer={(v) => {
+            virt = v;
+          }}
+        />
+      );
+      const el = getByTestId('scroller');
+      Object.defineProperty(el, 'clientHeight', { value: 200, configurable: true });
+
+      if (!virt) throw new Error('virtualizer not captured');
+      const spy = vi.spyOn(virt, 'scrollToOffset');
+      // この時点で復元 path は走り、saved=undefined なので scrollToOffset は呼ばれない
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('queryId 切替', () => {
+    it('queryId が変わると新 queryId に独立して保存される', () => {
+      const { getByTestId, rerender } = render(<Harness queryId="A" rowsLength={10} />);
+      const el = getByTestId('scroller');
+      Object.defineProperty(el, 'clientHeight', { value: 200, configurable: true });
+
+      setScroll(el, 100);
+      fireEvent.scroll(el);
+      expect(useScrollPositionStore.getState().getPosition('A')).toEqual({ top: 100, left: 0 });
+
+      rerender(<Harness queryId="B" rowsLength={10} />);
+      Object.defineProperty(el, 'clientHeight', { value: 200, configurable: true });
+
+      setScroll(el, 500);
+      fireEvent.scroll(el);
+      expect(useScrollPositionStore.getState().getPosition('A')).toEqual({ top: 100, left: 0 });
+      expect(useScrollPositionStore.getState().getPosition('B')).toEqual({ top: 500, left: 0 });
+    });
+  });
+
+  describe('unmount', () => {
+    it('unmount してもエラーを投げない (cleanup 安全性)', () => {
+      const { unmount } = render(<Harness queryId="A" rowsLength={10} />);
+      expect(() => unmount()).not.toThrow();
+    });
+  });
+});

--- a/frontend/src/tests/grid/useScrollRestoreHandler.test.tsx
+++ b/frontend/src/tests/grid/useScrollRestoreHandler.test.tsx
@@ -1,4 +1,4 @@
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { useVirtualizer, type Virtualizer } from '@tanstack/react-virtual';
 import { fireEvent, render } from '@testing-library/react';
 import { type RefObject, useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -23,7 +23,7 @@ interface HarnessProps {
   rowsLength: number;
   height?: number;
   totalSize?: number;
-  onVirtualizer?: (v: ReturnType<typeof useVirtualizer>) => void;
+  onVirtualizer?: (v: Virtualizer<HTMLDivElement, Element>) => void;
 }
 
 function Harness({
@@ -120,7 +120,7 @@ describe('useScrollRestoreHandler', () => {
 
   describe('復元', () => {
     it('rowsLength=0 では復元 scrollToOffset を呼ばない', () => {
-      let virt: ReturnType<typeof useVirtualizer> | undefined;
+      let virt: Virtualizer<HTMLDivElement, Element> | undefined;
       useScrollPositionStore.getState().savePosition('q1', { top: 500, left: 0 });
       render(
         <Harness
@@ -140,7 +140,7 @@ describe('useScrollRestoreHandler', () => {
 
     it('saved 値が container にセットされる', () => {
       useScrollPositionStore.getState().savePosition('q1', { top: 500, left: 30 });
-      let virt: ReturnType<typeof useVirtualizer> | undefined;
+      let virt: Virtualizer<HTMLDivElement, Element> | undefined;
       const { getByTestId } = render(
         <Harness
           queryId="q1"
@@ -159,7 +159,7 @@ describe('useScrollRestoreHandler', () => {
     });
 
     it('saved が無いときは scrollToOffset を呼ばない (1-shot フラグはセットされる)', () => {
-      let virt: ReturnType<typeof useVirtualizer> | undefined;
+      let virt: Virtualizer<HTMLDivElement, Element> | undefined;
       const { getByTestId } = render(
         <Harness
           queryId="q-no-save"


### PR DESCRIPTION
ResultGrid.tsx (846行) から queryId 切替時の scroll save/restore ロジック (~115行) を hook に分離

- 抽出: scroll 保存抑止フラグ / onScroll closure / rAF 復元ループ / unmount 最終保存
- 残置: per-tab UI state reset (sort/filter/selection) は ResultGrid 側に維持
- 新規 unit test 8 ケース、既存 scrollPersistence test 7 ケース PASS"
- 振る舞い不変 (handleScroll signature・副作用順序・rAF 2 回待ち抑止解除いずれも温存)

Closes #461