### PR TITLE
refactor(frontend): ResultGrid の dialog state を useGridDialogState (管理層) に抽出 (#463)

### DIFF
--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -10,7 +10,6 @@ import {
 } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { memo, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useEphemeralOpen } from '../../hooks/useEphemeralOpen';
 import { useConnectionStore } from '../../store/connectionStore';
 import {
   useIsActiveDataView,
@@ -37,6 +36,7 @@ import { GridToolbar } from './GridToolbar';
 import { useClampedActiveIndex } from './hooks/useClampedActiveIndex';
 import { useColumnAutoSize } from './hooks/useColumnAutoSize';
 import { useElapsedTimer } from './hooks/useElapsedTimer';
+import { useGridDialogState } from './hooks/useGridDialogState';
 import { useGridEdit } from './hooks/useGridEdit';
 import { useGridKeyboard } from './hooks/useGridKeyboard';
 import { useGridSelection } from './hooks/useGridSelection';
@@ -101,27 +101,26 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
   } = useQueryActions();
 
   // --- Local state ---
-  const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
   const rowsLengthRef = useRef(0);
   const columnOrderRef = useRef<string[]>([]);
   const viewRowsRef = useRef<Row<RowData>[]>([]);
-  const [valueEditorState, setValueEditorState] = useState<{
-    isOpen: boolean;
-    rowIndex: number;
-    columnName: string;
-    value: string | null;
-  }>({ isOpen: false, rowIndex: 0, columnName: '', value: null });
   const [viewMode, setViewMode] = useState<GridViewMode>('table');
   const [transposeRowIndex, setTransposeRowIndex] = useState(0);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [showColumnFilters, setShowColumnFilters] = useState(false);
-  // エラーダイアログの表示制御: error 到来で自動 open、ユーザーが閉じられる、再 open 可
+  // Dialog state は管理層 hook に集約 (#463): error / export / value-editor の 3 系統
   const {
-    isOpen: isErrorDialogOpen,
-    dismiss: dismissErrorDialog,
-    reopen: reopenErrorDialog,
-  } = useEphemeralOpen(error);
+    isErrorDialogOpen,
+    dismissErrorDialog,
+    reopenErrorDialog,
+    isExportDialogOpen,
+    openExportDialog,
+    closeExportDialog,
+    valueEditor,
+    openValueEditor,
+    closeValueEditor,
+  } = useGridDialogState({ error });
   const tableContainerRef = useRef<HTMLDivElement>(null);
   const elapsedSeconds = useElapsedTimer(isExecuting);
 
@@ -307,20 +306,13 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     [rowData, navigateToRelatedRow]
   );
 
-  const openValueEditor = useCallback(
-    (rowIndex: number, columnName: string, currentValue: string | null) => {
-      setValueEditorState({ isOpen: true, rowIndex, columnName, value: currentValue });
-    },
-    []
-  );
-
   const saveValueEditor = useCallback(
     (newValue: string | null) => {
-      const { rowIndex, columnName, value: oldValue } = valueEditorState;
+      const { rowIndex, columnName, value: oldValue } = valueEditor;
       if (oldValue !== newValue) updateCell(rowIndex, columnName, oldValue, newValue);
-      setValueEditorState((prev) => ({ ...prev, isOpen: false }));
+      closeValueEditor();
     },
-    [valueEditorState, updateCell]
+    [valueEditor, updateCell, closeValueEditor]
   );
 
   const getRowByViewIndex = useCallback(
@@ -517,8 +509,6 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     });
   }, []);
 
-  const openExportDialog = useCallback(() => setIsExportDialogOpen(true), []);
-
   const changeViewMode = useCallback(
     (mode: GridViewMode) => {
       if (mode === 'transpose' && selectedRows.size > 0) {
@@ -702,17 +692,17 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
       <Suspense fallback={null}>
         <ExportDialog
           isOpen={isExportDialogOpen}
-          onClose={() => setIsExportDialogOpen(false)}
+          onClose={closeExportDialog}
           resultSet={resultSet}
         />
       </Suspense>
 
       <ValueEditorDialog
-        isOpen={valueEditorState.isOpen}
-        columnName={valueEditorState.columnName}
-        initialValue={valueEditorState.value}
+        isOpen={valueEditor.isOpen}
+        columnName={valueEditor.columnName}
+        initialValue={valueEditor.value}
         onSave={saveValueEditor}
-        onCancel={() => setValueEditorState((prev) => ({ ...prev, isOpen: false }))}
+        onCancel={closeValueEditor}
       />
 
       <Suspense fallback={null}>

--- a/frontend/src/components/grid/hooks/useGridDialogState.ts
+++ b/frontend/src/components/grid/hooks/useGridDialogState.ts
@@ -1,0 +1,80 @@
+import { useCallback, useState } from 'react';
+import { useEphemeralOpen } from '../../../hooks/useEphemeralOpen';
+
+export interface ValueEditorState {
+  isOpen: boolean;
+  rowIndex: number;
+  columnName: string;
+  value: string | null;
+}
+
+export interface UseGridDialogStateArgs {
+  error: string | null;
+}
+
+export interface UseGridDialogStateResult {
+  isErrorDialogOpen: boolean;
+  dismissErrorDialog: () => void;
+  reopenErrorDialog: () => void;
+
+  isExportDialogOpen: boolean;
+  openExportDialog: () => void;
+  closeExportDialog: () => void;
+
+  valueEditor: ValueEditorState;
+  openValueEditor: (rowIndex: number, columnName: string, value: string | null) => void;
+  closeValueEditor: () => void;
+}
+
+const VALUE_EDITOR_INITIAL: ValueEditorState = {
+  isOpen: false,
+  rowIndex: 0,
+  columnName: '',
+  value: null,
+};
+
+/**
+ * ResultGrid の dialog open/close state を集約する管理層 hook。
+ * Error / Export / ValueEditor の 3 系統を保持。
+ *
+ * 運用ルール: callback (e.g. saveValueEditor) はビジネスロジックとの結合点のため
+ * 本 hook には含めず、呼び出し側 (ResultGrid) で組み立てる。
+ *
+ * DML preview dialog は useGridEdit 側で既に管理されているため対象外。
+ */
+export function useGridDialogState({ error }: UseGridDialogStateArgs): UseGridDialogStateResult {
+  const {
+    isOpen: isErrorDialogOpen,
+    dismiss: dismissErrorDialog,
+    reopen: reopenErrorDialog,
+  } = useEphemeralOpen(error);
+
+  const [isExportDialogOpen, setIsExportDialogOpen] = useState(false);
+  const [valueEditor, setValueEditor] = useState<ValueEditorState>(VALUE_EDITOR_INITIAL);
+
+  const openExportDialog = useCallback(() => setIsExportDialogOpen(true), []);
+  const closeExportDialog = useCallback(() => setIsExportDialogOpen(false), []);
+
+  const openValueEditor = useCallback(
+    (rowIndex: number, columnName: string, value: string | null) => {
+      setValueEditor({ isOpen: true, rowIndex, columnName, value });
+    },
+    []
+  );
+  const closeValueEditor = useCallback(
+    () => setValueEditor((prev) => ({ ...prev, isOpen: false })),
+    []
+  );
+
+  return {
+    isErrorDialogOpen,
+    dismissErrorDialog,
+    reopenErrorDialog,
+    isExportDialogOpen,
+    openExportDialog,
+    closeExportDialog,
+    valueEditor,
+    openValueEditor,
+    closeValueEditor,
+  };
+}

--- a/frontend/src/tests/grid/useGridDialogState.test.ts
+++ b/frontend/src/tests/grid/useGridDialogState.test.ts
@@ -1,0 +1,179 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useGridDialogState } from '../../components/grid/hooks/useGridDialogState';
+
+describe('useGridDialogState', () => {
+  describe('初期状態', () => {
+    it('error=null で全 dialog が閉じている', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      expect(result.current.isErrorDialogOpen).toBe(false);
+      expect(result.current.isExportDialogOpen).toBe(false);
+      expect(result.current.valueEditor).toEqual({
+        isOpen: false,
+        rowIndex: 0,
+        columnName: '',
+        value: null,
+      });
+    });
+  });
+
+  describe('error dialog (useEphemeralOpen 委譲)', () => {
+    it('error=truthy で isErrorDialogOpen=true', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: 'syntax error' }));
+
+      expect(result.current.isErrorDialogOpen).toBe(true);
+    });
+
+    it('dismissErrorDialog → 同 trigger では isErrorDialogOpen=false', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: 'syntax error' }));
+
+      act(() => {
+        result.current.dismissErrorDialog();
+      });
+
+      expect(result.current.isErrorDialogOpen).toBe(false);
+    });
+
+    it('dismiss 後に reopen → 再度 isErrorDialogOpen=true', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: 'syntax error' }));
+
+      act(() => {
+        result.current.dismissErrorDialog();
+      });
+      act(() => {
+        result.current.reopenErrorDialog();
+      });
+
+      expect(result.current.isErrorDialogOpen).toBe(true);
+    });
+
+    it('error が新しい値に変化すると dismiss 状態がリセットされ自動再 open', () => {
+      const { result, rerender } = renderHook(
+        ({ error }: { error: string | null }) => useGridDialogState({ error }),
+        { initialProps: { error: 'first error' } }
+      );
+
+      act(() => {
+        result.current.dismissErrorDialog();
+      });
+      expect(result.current.isErrorDialogOpen).toBe(false);
+
+      rerender({ error: 'second error' });
+      expect(result.current.isErrorDialogOpen).toBe(true);
+    });
+  });
+
+  describe('export dialog', () => {
+    it('openExportDialog → isExportDialogOpen=true', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      act(() => {
+        result.current.openExportDialog();
+      });
+
+      expect(result.current.isExportDialogOpen).toBe(true);
+    });
+
+    it('closeExportDialog → isExportDialogOpen=false', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      act(() => {
+        result.current.openExportDialog();
+      });
+      act(() => {
+        result.current.closeExportDialog();
+      });
+
+      expect(result.current.isExportDialogOpen).toBe(false);
+    });
+  });
+
+  describe('value editor dialog', () => {
+    it('openValueEditor → isOpen=true で payload が反映される', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      act(() => {
+        result.current.openValueEditor(3, 'name', 'Alice');
+      });
+
+      expect(result.current.valueEditor).toEqual({
+        isOpen: true,
+        rowIndex: 3,
+        columnName: 'name',
+        value: 'Alice',
+      });
+    });
+
+    it('value=null を扱える (NULL 値編集)', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      act(() => {
+        result.current.openValueEditor(0, 'description', null);
+      });
+
+      expect(result.current.valueEditor.value).toBeNull();
+      expect(result.current.valueEditor.isOpen).toBe(true);
+    });
+
+    it('closeValueEditor → isOpen=false に戻り payload は維持', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      act(() => {
+        result.current.openValueEditor(5, 'email', 'a@b.com');
+      });
+      act(() => {
+        result.current.closeValueEditor();
+      });
+
+      expect(result.current.valueEditor).toEqual({
+        isOpen: false,
+        rowIndex: 5,
+        columnName: 'email',
+        value: 'a@b.com',
+      });
+    });
+
+    it('close 後に異なる payload で再 open → 完全置換 (前 payload は残らない)', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      act(() => {
+        result.current.openValueEditor(1, 'name', 'Alice');
+      });
+      act(() => {
+        result.current.closeValueEditor();
+      });
+      act(() => {
+        result.current.openValueEditor(2, 'email', 'b@c.com');
+      });
+
+      expect(result.current.valueEditor).toEqual({
+        isOpen: true,
+        rowIndex: 2,
+        columnName: 'email',
+        value: 'b@c.com',
+      });
+    });
+  });
+
+  describe('独立性', () => {
+    it('export と value-editor は独立に open/close できる', () => {
+      const { result } = renderHook(() => useGridDialogState({ error: null }));
+
+      act(() => {
+        result.current.openExportDialog();
+        result.current.openValueEditor(1, 'col', 'v');
+      });
+
+      expect(result.current.isExportDialogOpen).toBe(true);
+      expect(result.current.valueEditor.isOpen).toBe(true);
+
+      act(() => {
+        result.current.closeExportDialog();
+      });
+
+      expect(result.current.isExportDialogOpen).toBe(false);
+      expect(result.current.valueEditor.isOpen).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
inline で散在していた error / export / value-editor の 3 系統 dialog state を管理層 hook `useGridDialogState` に集約。
`useEphemeralOpen(error)` を hook 内包し、ResultGrid からは unified API (isOpen / dismiss / reopen / open*/ close*) のみ使用。

- 新規: components/grid/hooks/useGridDialogState.ts (78 行)
- 新規: tests/grid/useGridDialogState.test.ts (12 tests)
- ResultGrid.tsx: -30/+20、useEphemeralOpen import 削除、3 useState 削除

DML preview state は useGridEdit 内で edit lifecycle と密結合済みのため対象外。

premise-questioning: skipped (理由: parent #457 で方針確定、姉妹 #458 でパターン採用済み)

Closes #463