### PR TITLE
refactor(frontend): ConnectionTreeSection の context menu 項目生成を useContextMenuItems (提供層) に抽出

### DIFF
--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -1,18 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useColumnActions } from '../../hooks/useColumnActions';
+import { useContextMenuItems } from '../../hooks/useContextMenuItems';
 import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
 import { useTableActions } from '../../hooks/useTableActions';
 import { useConnectionStore } from '../../store/connectionStore';
 import { useToastStore } from '../../store/toastStore';
-import type { Connection, DatabaseObject, MenuItem } from '../../types';
+import type { Connection, DatabaseObject } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
 import { log } from '../../utils/logger';
-import { buildInsertTemplateSql, buildSelectSql } from '../../utils/sqlIdentifier';
 import {
   type ExpandableType,
-  extractBareTableName,
-  isExpandableType,
   parseTableNodeId,
   shouldLoadColumns,
   updateNodeChildren,
@@ -306,129 +304,22 @@ export function ConnectionTreeSection({
     setContextMenu(null);
   }, []);
 
-  const getMenuItems = useCallback(
-    (node: DatabaseObject): MenuItem[] => {
-      const items: MenuItem[] = [];
+  const addToast = useToastStore((s) => s.addToast);
+  const removeConnection = useConnectionStore((s) => s.removeConnection);
 
-      if (node.type === 'table' || node.type === 'view') {
-        // SELECT文をコピー
-        items.push({
-          label: 'SELECT文をコピー',
-          action: async () => {
-            await navigator.clipboard.writeText(buildSelectSql(node.name, connection.dbType));
-          },
-        });
-
-        // INSERT文をコピー (table のみ、view 除外)
-        if (node.type === 'table') {
-          items.push({
-            label: 'INSERT文をコピー',
-            action: async () => {
-              try {
-                const columns = await bridge.getColumns(
-                  connection.id,
-                  extractBareTableName(node.name)
-                );
-                const sql = buildInsertTemplateSql(
-                  node.name,
-                  columns.map((c) => c.name),
-                  connection.dbType
-                );
-                await copyToClipboard(sql, 'INSERT文をコピーしました');
-              } catch (error) {
-                log.error(`Failed to build INSERT template: ${error}`);
-                useToastStore.getState().addToast('INSERT文の生成に失敗しました', 'error');
-              }
-            },
-          });
-        }
-
-        // テーブルを開く
-        items.push({
-          label: 'データを開く',
-          action: () => {
-            if (onTableOpen && isExpandableType(node.type)) {
-              onTableOpen(node.name, node.type, connection.id);
-            }
-          },
-        });
-
-        items.push({ label: '', action: () => {}, divider: true });
-
-        // カラム一覧をコピー
-        items.push({
-          label: 'カラム一覧をコピー',
-          action: async () => {
-            try {
-              const columns = await bridge.getColumns(
-                connection.id,
-                extractBareTableName(node.name)
-              );
-              const columnList = columns.map((c) => c.name).join(', ');
-              await navigator.clipboard.writeText(columnList);
-            } catch (error) {
-              log.error(`Failed to get columns: ${error}`);
-            }
-          },
-        });
-
-        // テーブル操作 (table のみ、view 除外)
-        const tableItems = getTableMenuItems(node);
-        if (tableItems.length > 0) {
-          items.push({ label: '', action: () => {}, divider: true });
-          items.push(...tableItems);
-        }
-      }
-
-      if (node.type === 'database') {
-        items.push({
-          label: 'リフレッシュ',
-          action: async () => {
-            // Re-load tables
-            setLoadingNodes((prev) => new Set(prev).add(connection.id));
-            const children = await loadTables();
-            setTreeData((prev) => {
-              return prev.map((n) => {
-                if (n.id === connection.id) {
-                  return { ...n, children };
-                }
-                return n;
-              });
-            });
-            setLoadingNodes((prev) => {
-              const next = new Set(prev);
-              next.delete(connection.id);
-              return next;
-            });
-          },
-        });
-
-        items.push({ label: '', action: () => {}, divider: true });
-
-        items.push({
-          label: '接続を閉じる',
-          action: async () => {
-            await useConnectionStore.getState().removeConnection(connection.id);
-          },
-        });
-      }
-
-      if (node.type === 'column') {
-        items.push(...getColumnMenuItems(node));
-      }
-
-      return items;
-    },
-    [
-      connection.id,
-      connection.dbType,
-      onTableOpen,
-      loadTables,
-      getColumnMenuItems,
-      getTableMenuItems,
-      copyToClipboard,
-    ]
-  );
+  const { getMenuItems } = useContextMenuItems({
+    connectionId: connection.id,
+    dbType: connection.dbType,
+    onTableOpen,
+    loadTables,
+    setTreeData,
+    setLoadingNodes,
+    getColumnMenuItems,
+    getTableMenuItems,
+    copyToClipboard,
+    addToast,
+    closeConnection: removeConnection,
+  });
 
   const connColor = useMemo(
     () => connectionColor(connection.server, connection.database),

--- a/frontend/src/hooks/useContextMenuItems.ts
+++ b/frontend/src/hooks/useContextMenuItems.ts
@@ -1,0 +1,149 @@
+import { type Dispatch, type SetStateAction, useCallback } from 'react';
+import { bridge } from '../api/bridge';
+import type { ToastType } from '../store/toastStore';
+import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
+import { log } from '../utils/logger';
+import { buildInsertTemplateSql, buildSelectSql } from '../utils/sqlIdentifier';
+import { type ExpandableType, extractBareTableName, isExpandableType } from '../utils/treeNode';
+
+interface UseContextMenuItemsParams {
+  connectionId: string;
+  dbType?: DatabaseType;
+  onTableOpen?: (tableName: string, tableType: ExpandableType, connectionId?: string) => void;
+  loadTables: () => Promise<DatabaseObject[]>;
+  setTreeData: Dispatch<SetStateAction<DatabaseObject[]>>;
+  setLoadingNodes: Dispatch<SetStateAction<Set<string>>>;
+  getColumnMenuItems: (node: DatabaseObject) => MenuItem[];
+  getTableMenuItems: (node: DatabaseObject) => MenuItem[];
+  copyToClipboard: (text: string, successMessage: string) => Promise<void>;
+  addToast: (message: string, type: ToastType) => void;
+  closeConnection: (connectionId: string) => Promise<void>;
+}
+
+const DIVIDER: MenuItem = { label: '', action: () => {}, divider: true };
+
+export function useContextMenuItems({
+  connectionId,
+  dbType,
+  onTableOpen,
+  loadTables,
+  setTreeData,
+  setLoadingNodes,
+  getColumnMenuItems,
+  getTableMenuItems,
+  copyToClipboard,
+  addToast,
+  closeConnection,
+}: UseContextMenuItemsParams) {
+  const buildTableOrViewItems = useCallback(
+    (node: DatabaseObject): MenuItem[] => {
+      const items: MenuItem[] = [];
+
+      items.push({
+        label: 'SELECT文をコピー',
+        action: async () => {
+          await navigator.clipboard.writeText(buildSelectSql(node.name, dbType));
+        },
+      });
+
+      if (node.type === 'table') {
+        items.push({
+          label: 'INSERT文をコピー',
+          action: async () => {
+            try {
+              const columns = await bridge.getColumns(
+                connectionId,
+                extractBareTableName(node.name)
+              );
+              const sql = buildInsertTemplateSql(
+                node.name,
+                columns.map((c) => c.name),
+                dbType
+              );
+              await copyToClipboard(sql, 'INSERT文をコピーしました');
+            } catch (error) {
+              log.error(`Failed to build INSERT template: ${error}`);
+              addToast('INSERT文の生成に失敗しました', 'error');
+            }
+          },
+        });
+      }
+
+      items.push({
+        label: 'データを開く',
+        action: () => {
+          if (onTableOpen && isExpandableType(node.type)) {
+            onTableOpen(node.name, node.type, connectionId);
+          }
+        },
+      });
+
+      items.push(DIVIDER);
+
+      items.push({
+        label: 'カラム一覧をコピー',
+        action: async () => {
+          try {
+            const columns = await bridge.getColumns(connectionId, extractBareTableName(node.name));
+            const columnList = columns.map((c) => c.name).join(', ');
+            await navigator.clipboard.writeText(columnList);
+          } catch (error) {
+            log.error(`Failed to get columns: ${error}`);
+          }
+        },
+      });
+
+      const tableItems = getTableMenuItems(node);
+      if (tableItems.length > 0) {
+        items.push(DIVIDER);
+        items.push(...tableItems);
+      }
+
+      return items;
+    },
+    [connectionId, dbType, onTableOpen, copyToClipboard, getTableMenuItems, addToast]
+  );
+
+  const buildDatabaseItems = useCallback((): MenuItem[] => {
+    return [
+      {
+        label: 'リフレッシュ',
+        action: async () => {
+          setLoadingNodes((prev) => new Set(prev).add(connectionId));
+          const children = await loadTables();
+          setTreeData((prev) => prev.map((n) => (n.id === connectionId ? { ...n, children } : n)));
+          setLoadingNodes((prev) => {
+            const next = new Set(prev);
+            next.delete(connectionId);
+            return next;
+          });
+        },
+      },
+      DIVIDER,
+      {
+        label: '接続を閉じる',
+        action: async () => {
+          await closeConnection(connectionId);
+        },
+      },
+    ];
+  }, [connectionId, loadTables, setTreeData, setLoadingNodes, closeConnection]);
+
+  const getMenuItems = useCallback(
+    (node: DatabaseObject): MenuItem[] => {
+      if (node.type === 'table' || node.type === 'view') {
+        return buildTableOrViewItems(node);
+      }
+      if (node.type === 'database') {
+        return buildDatabaseItems();
+      }
+      if (node.type === 'column') {
+        return getColumnMenuItems(node);
+      }
+      return [];
+    },
+    [buildTableOrViewItems, buildDatabaseItems, getColumnMenuItems]
+  );
+
+  return { getMenuItems };
+}

--- a/frontend/src/tests/hooks/useContextMenuItems.test.ts
+++ b/frontend/src/tests/hooks/useContextMenuItems.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DatabaseObject, MenuItem } from '../../types';
+
+vi.mock('../../api/bridge', () => ({
+  bridge: {
+    getColumns: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  log: { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
+}));
+
+import { act, renderHook } from '@testing-library/react';
+import { bridge } from '../../api/bridge';
+import { useContextMenuItems } from '../../hooks/useContextMenuItems';
+
+function makeNode(overrides: Partial<DatabaseObject> = {}): DatabaseObject {
+  return {
+    id: 'c1-dbo-Users',
+    name: 'dbo.Users',
+    type: 'table',
+    metadata: { schema: 'dbo' },
+    ...overrides,
+  };
+}
+
+function createParams(overrides: Partial<Parameters<typeof useContextMenuItems>[0]> = {}) {
+  return {
+    connectionId: 'c1',
+    dbType: 'sqlserver' as const,
+    onTableOpen: vi.fn(),
+    loadTables: vi.fn().mockResolvedValue([]),
+    setTreeData: vi.fn(),
+    setLoadingNodes: vi.fn(),
+    getColumnMenuItems: vi.fn().mockReturnValue([] as MenuItem[]),
+    getTableMenuItems: vi.fn().mockReturnValue([] as MenuItem[]),
+    copyToClipboard: vi.fn().mockResolvedValue(undefined),
+    addToast: vi.fn(),
+    closeConnection: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+describe('useContextMenuItems', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('table ノード', () => {
+    it('SELECT/INSERT/データを開く/カラム一覧をコピーが含まれる', () => {
+      const { result } = renderHook(() => useContextMenuItems(createParams()));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+      const labels = items.map((i) => i.label);
+
+      expect(labels).toContain('SELECT文をコピー');
+      expect(labels).toContain('INSERT文をコピー');
+      expect(labels).toContain('データを開く');
+      expect(labels).toContain('カラム一覧をコピー');
+    });
+
+    it('getTableMenuItems の項目が末尾に divider 付きで合成される', () => {
+      const tableMenuItems: MenuItem[] = [{ label: 'テーブルを削除', action: vi.fn() }];
+      const params = createParams({ getTableMenuItems: vi.fn().mockReturnValue(tableMenuItems) });
+      const { result } = renderHook(() => useContextMenuItems(params));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+
+      const dropIdx = items.findIndex((i) => i.label === 'テーブルを削除');
+      expect(dropIdx).toBeGreaterThan(0);
+      expect(items[dropIdx - 1].divider).toBe(true);
+    });
+
+    it('getTableMenuItems が空配列のとき末尾 divider は付与されない', () => {
+      const { result } = renderHook(() => useContextMenuItems(createParams()));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+
+      expect(items[items.length - 1].divider).toBeFalsy();
+      expect(items[items.length - 1].label).toBe('カラム一覧をコピー');
+    });
+  });
+
+  describe('view ノード', () => {
+    it('INSERT文をコピー が含まれない (SELECT文は含まれる)', () => {
+      const { result } = renderHook(() => useContextMenuItems(createParams()));
+      const items = result.current.getMenuItems(makeNode({ type: 'view', name: 'dbo.vw_Users' }));
+      const labels = items.map((i) => i.label);
+
+      expect(labels).toContain('SELECT文をコピー');
+      expect(labels).not.toContain('INSERT文をコピー');
+    });
+
+    it('view では getTableMenuItems の結果は反映されない (空)', () => {
+      const tableMenuItems: MenuItem[] = [{ label: 'テーブルを削除', action: vi.fn() }];
+      const getTableMenuItems = vi.fn((n: DatabaseObject) =>
+        n.type === 'table' ? tableMenuItems : []
+      );
+      const { result } = renderHook(() => useContextMenuItems(createParams({ getTableMenuItems })));
+      const items = result.current.getMenuItems(makeNode({ type: 'view', name: 'dbo.vw_Users' }));
+
+      expect(items.find((i) => i.label === 'テーブルを削除')).toBeUndefined();
+    });
+  });
+
+  describe('database ノード', () => {
+    it('リフレッシュ + 接続を閉じる が含まれる', () => {
+      const { result } = renderHook(() => useContextMenuItems(createParams()));
+      const items = result.current.getMenuItems(makeNode({ type: 'database', name: 'srv/db' }));
+      const labels = items.map((i) => i.label);
+
+      expect(labels).toContain('リフレッシュ');
+      expect(labels).toContain('接続を閉じる');
+    });
+
+    it('リフレッシュ実行 → setLoadingNodes/loadTables/setTreeData の順で呼ばれる', async () => {
+      const params = createParams();
+      vi.mocked(params.loadTables).mockResolvedValueOnce([{ id: 'x', name: 'x', type: 'folder' }]);
+      const { result } = renderHook(() => useContextMenuItems(params));
+      const items = result.current.getMenuItems(makeNode({ type: 'database' }));
+      const refresh = items.find((i) => i.label === 'リフレッシュ');
+
+      await act(async () => {
+        await refresh?.action();
+      });
+
+      const lnOrder = vi.mocked(params.setLoadingNodes).mock.invocationCallOrder[0];
+      const ltOrder = vi.mocked(params.loadTables).mock.invocationCallOrder[0];
+      const tdOrder = vi.mocked(params.setTreeData).mock.invocationCallOrder[0];
+      expect(lnOrder).toBeLessThan(ltOrder);
+      expect(ltOrder).toBeLessThan(tdOrder);
+    });
+
+    it('接続を閉じる → 注入された closeConnection(connectionId) が呼ばれる', async () => {
+      const params = createParams();
+      const { result } = renderHook(() => useContextMenuItems(params));
+      const items = result.current.getMenuItems(makeNode({ type: 'database' }));
+      const close = items.find((i) => i.label === '接続を閉じる');
+
+      await act(async () => {
+        await close?.action();
+      });
+
+      expect(params.closeConnection).toHaveBeenCalledWith('c1');
+    });
+  });
+
+  describe('column ノード', () => {
+    it('getColumnMenuItems の結果がそのまま返る', () => {
+      const columnItems: MenuItem[] = [{ label: '列名変更', action: vi.fn() }];
+      const params = createParams({ getColumnMenuItems: vi.fn().mockReturnValue(columnItems) });
+      const { result } = renderHook(() => useContextMenuItems(params));
+      const items = result.current.getMenuItems(makeNode({ type: 'column', name: 'id' }));
+
+      expect(items).toEqual(columnItems);
+    });
+  });
+
+  describe('action 動作', () => {
+    it('SELECT文をコピー → navigator.clipboard.writeText に SELECT SQL が渡る', async () => {
+      const { result } = renderHook(() => useContextMenuItems(createParams()));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+      const select = items.find((i) => i.label === 'SELECT文をコピー');
+
+      await act(async () => {
+        await select?.action();
+      });
+
+      expect(writeTextMock).toHaveBeenCalled();
+      expect(writeTextMock.mock.calls[0][0]).toMatch(/SELECT/i);
+    });
+
+    it('INSERT文をコピー成功 → copyToClipboard に INSERT SQL とメッセージが渡る', async () => {
+      vi.mocked(bridge.getColumns).mockResolvedValueOnce([
+        { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+      ]);
+      const params = createParams();
+      const { result } = renderHook(() => useContextMenuItems(params));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+      const insert = items.find((i) => i.label === 'INSERT文をコピー');
+
+      await act(async () => {
+        await insert?.action();
+      });
+
+      const copyMock = vi.mocked(params.copyToClipboard);
+      expect(copyMock).toHaveBeenCalled();
+      expect(copyMock.mock.calls[0][0]).toMatch(/INSERT/i);
+      expect(copyMock.mock.calls[0][1]).toBe('INSERT文をコピーしました');
+    });
+
+    it('INSERT文をコピー失敗 → toast にエラー通知', async () => {
+      vi.mocked(bridge.getColumns).mockRejectedValueOnce(new Error('boom'));
+      const params = createParams();
+      const { result } = renderHook(() => useContextMenuItems(params));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+      const insert = items.find((i) => i.label === 'INSERT文をコピー');
+
+      await act(async () => {
+        await insert?.action();
+      });
+
+      expect(params.addToast).toHaveBeenCalledWith('INSERT文の生成に失敗しました', 'error');
+    });
+
+    it('データを開く → onTableOpen(name, type, connectionId)', () => {
+      const params = createParams();
+      const { result } = renderHook(() => useContextMenuItems(params));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+      const open = items.find((i) => i.label === 'データを開く');
+
+      act(() => {
+        open?.action();
+      });
+
+      expect(params.onTableOpen).toHaveBeenCalledWith('dbo.Users', 'table', 'c1');
+    });
+
+    it('カラム一覧をコピー → カラム名カンマ連結を clipboard に書く', async () => {
+      vi.mocked(bridge.getColumns).mockResolvedValueOnce([
+        { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+        { name: 'name', type: 'varchar', size: 100, nullable: true, isPrimaryKey: false },
+      ]);
+      const { result } = renderHook(() => useContextMenuItems(createParams()));
+      const items = result.current.getMenuItems(makeNode({ type: 'table' }));
+      const copy = items.find((i) => i.label === 'カラム一覧をコピー');
+
+      await act(async () => {
+        await copy?.action();
+      });
+
+      expect(writeTextMock).toHaveBeenCalledWith('id, name');
+    });
+  });
+
+  it('未対応 type (folder) → 空配列', () => {
+    const { result } = renderHook(() => useContextMenuItems(createParams()));
+    const items = result.current.getMenuItems(makeNode({ type: 'folder', name: 'Tables' }));
+    expect(items).toEqual([]);
+  });
+});


### PR DESCRIPTION
- 100+ 行の getMenuItems を useContextMenuItems hook (提供層) に分離
- 親コンポーネント: 481 → 367 行
- DI 化: addToast / closeConnection を引数注入 (store 直アクセス排除)
- 新規テスト 15 件追加

Closes #464