### PR TITLE
refactor(frontend): sqlIdentifier の quote プリミティブを utils/sql/quoting.ts (Platform) に分離 (#465)

### DIFF
--- a/frontend/src/components/export/exporters/sqlExporter.ts
+++ b/frontend/src/components/export/exporters/sqlExporter.ts
@@ -1,5 +1,5 @@
 import type { ResultSet } from '../../../types';
-import { quoteIdentifier, quoteLiteral } from '../../../utils/sqlIdentifier';
+import { quoteIdentifier, quoteLiteral } from '../../../utils/sql/quoting';
 import type { Exportable, ExportOptions } from './types';
 
 export const sqlExporter: Exportable = {

--- a/frontend/src/hooks/useColumnActions.ts
+++ b/frontend/src/hooks/useColumnActions.ts
@@ -2,12 +2,12 @@ import { type Dispatch, type SetStateAction, useCallback, useState } from 'react
 import { bridge } from '../api/bridge';
 import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
 import { log } from '../utils/logger';
+import { quoteIdentifier } from '../utils/sql/quoting';
 import {
   buildAlterViewSql,
   buildDropColumnSql,
   buildRenameColumnSql,
   fetchViewDefinition,
-  quoteIdentifier,
 } from '../utils/sqlIdentifier';
 import { updateNodeChildren } from '../utils/treeNode';
 

--- a/frontend/src/tests/utils/sql/quoting.test.ts
+++ b/frontend/src/tests/utils/sql/quoting.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { escapeSingleQuotes, quoteIdentifier, quoteLiteral } from '../../../utils/sql/quoting';
+
+describe('escapeSingleQuotes', () => {
+  it('シングルクォートなしはそのまま', () => {
+    expect(escapeSingleQuotes('hello')).toBe('hello');
+  });
+
+  it('単一シングルクォートを 2 重化', () => {
+    expect(escapeSingleQuotes("O'Brien")).toBe("O''Brien");
+  });
+
+  it('複数のシングルクォートを全て 2 重化', () => {
+    expect(escapeSingleQuotes("a'b'c")).toBe("a''b''c");
+  });
+
+  it('空文字列はそのまま', () => {
+    expect(escapeSingleQuotes('')).toBe('');
+  });
+});
+
+describe('quoteIdentifier', () => {
+  it('SQL Server (default): 角括弧でクォート', () => {
+    expect(quoteIdentifier('Users', 'sqlserver')).toBe('[Users]');
+  });
+
+  it('SQL Server: dbType 未指定時も角括弧', () => {
+    expect(quoteIdentifier('Users')).toBe('[Users]');
+  });
+
+  it('SQL Server: 内部の ] を ]] にエスケープ', () => {
+    expect(quoteIdentifier('a]b', 'sqlserver')).toBe('[a]]b]');
+  });
+
+  it('PostgreSQL: ダブルクォート', () => {
+    expect(quoteIdentifier('users', 'postgresql')).toBe('"users"');
+  });
+
+  it('PostgreSQL: 内部の " を "" にエスケープ', () => {
+    expect(quoteIdentifier('a"b', 'postgresql')).toBe('"a""b"');
+  });
+
+  it('MySQL: バッククォート', () => {
+    expect(quoteIdentifier('users', 'mysql')).toBe('`users`');
+  });
+
+  it('MySQL: 内部の ` を `` にエスケープ', () => {
+    expect(quoteIdentifier('a`b', 'mysql')).toBe('`a``b`');
+  });
+});
+
+describe('quoteLiteral', () => {
+  it('SQL Server (default): N プレフィックス付きシングルクォート', () => {
+    expect(quoteLiteral('hello', 'sqlserver')).toBe("N'hello'");
+  });
+
+  it('SQL Server: dbType 未指定時も N プレフィックス', () => {
+    expect(quoteLiteral('hello')).toBe("N'hello'");
+  });
+
+  it('SQL Server: シングルクォートを 2 重化してエスケープ', () => {
+    expect(quoteLiteral("O'Brien", 'sqlserver')).toBe("N'O''Brien'");
+  });
+
+  it('PostgreSQL: シングルクォートのみ (N プレフィックスなし)', () => {
+    expect(quoteLiteral('hello', 'postgresql')).toBe("'hello'");
+  });
+
+  it('PostgreSQL: シングルクォートを 2 重化', () => {
+    expect(quoteLiteral("O'Brien", 'postgresql')).toBe("'O''Brien'");
+  });
+
+  it('MySQL: シングルクォートのみ', () => {
+    expect(quoteLiteral('hello', 'mysql')).toBe("'hello'");
+  });
+
+  it('MySQL: シングルクォートを 2 重化', () => {
+    expect(quoteLiteral("O'Brien", 'mysql')).toBe("'O''Brien'");
+  });
+});

--- a/frontend/src/utils/sql/quoting.ts
+++ b/frontend/src/utils/sql/quoting.ts
@@ -1,0 +1,30 @@
+import type { DatabaseType } from '../../types';
+
+/** SQL リテラル内のシングルクォートを 2 重化エスケープ */
+export function escapeSingleQuotes(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/** DB種別に応じたリテラルクォート */
+export function quoteLiteral(value: string, dbType?: DatabaseType): string {
+  const escaped = escapeSingleQuotes(value);
+  switch (dbType) {
+    case 'postgresql':
+    case 'mysql':
+      return `'${escaped}'`;
+    default:
+      return `N'${escaped}'`;
+  }
+}
+
+/** DB種別に応じた識別子クォート */
+export function quoteIdentifier(name: string, dbType?: DatabaseType): string {
+  switch (dbType) {
+    case 'postgresql':
+      return `"${name.replace(/"/g, '""')}"`;
+    case 'mysql':
+      return `\`${name.replace(/`/g, '``')}\``;
+    default:
+      return `[${name.replace(/]/g, ']]')}]`;
+  }
+}

--- a/frontend/src/utils/sqlIdentifier.ts
+++ b/frontend/src/utils/sqlIdentifier.ts
@@ -1,33 +1,5 @@
 import type { DatabaseType } from '../types';
-
-/** sp_rename等のリテラル文字列用エスケープ (シングルクォート) */
-function escapeSqlLiteral(value: string): string {
-  return value.replace(/'/g, "''");
-}
-
-/** DB種別に応じたリテラルクォート */
-export function quoteLiteral(value: string, dbType?: DatabaseType): string {
-  const escaped = value.replace(/'/g, "''");
-  switch (dbType) {
-    case 'postgresql':
-    case 'mysql':
-      return `'${escaped}'`;
-    default:
-      return `N'${escaped}'`;
-  }
-}
-
-/** DB種別に応じた識別子クォート */
-export function quoteIdentifier(name: string, dbType?: DatabaseType): string {
-  switch (dbType) {
-    case 'postgresql':
-      return `"${name.replace(/"/g, '""')}"`;
-    case 'mysql':
-      return `\`${name.replace(/`/g, '``')}\``;
-    default:
-      return `[${name.replace(/]/g, ']]')}]`;
-  }
-}
+import { escapeSingleQuotes, quoteIdentifier } from './sql/quoting';
 
 /** ALTER TABLE ... RENAME COLUMN SQL生成 */
 export function buildRenameColumnSql(
@@ -45,7 +17,7 @@ export function buildRenameColumnSql(
     case 'mysql':
       return `ALTER TABLE ${q(table)} RENAME COLUMN ${q(oldName)} TO ${q(newName)}`;
     default:
-      return `EXEC sp_rename '${escapeSqlLiteral(schema)}.${escapeSqlLiteral(table)}.${escapeSqlLiteral(oldName)}', '${escapeSqlLiteral(newName)}', 'COLUMN'`;
+      return `EXEC sp_rename '${escapeSingleQuotes(schema)}.${escapeSingleQuotes(table)}.${escapeSingleQuotes(oldName)}', '${escapeSingleQuotes(newName)}', 'COLUMN'`;
   }
 }
 
@@ -359,8 +331,8 @@ export function buildGetViewDefinitionSql(
   viewName: string,
   dbType?: DatabaseType
 ): string {
-  const s = escapeSqlLiteral(schema);
-  const v = escapeSqlLiteral(viewName);
+  const s = escapeSingleQuotes(schema);
+  const v = escapeSingleQuotes(viewName);
 
   switch (dbType) {
     case 'postgresql':


### PR DESCRIPTION
- quoteIdentifier / quoteLiteral / escapeSingleQuotes を utils/sql/quoting.ts に集約
- sqlIdentifier 内ローカルの escapeSqlLiteral を escapeSingleQuotes に統合 (DRY)
- consumer (useColumnActions / sqlExporter) を Platform 層に直接 import
- Platform 層への片方向依存に統一し横参照を排除
- 新規 unit test 18 件追加 (quoteIdentifier / quoteLiteral / escapeSingleQuotes)

Closes #465