### PR TITLE
refactor(frontend): sqlIdentifier の statement type detection を utils/sql/statement-type.ts (操作層) に分離

### DIFF
--- a/frontend/src/components/grid/GridStatusBar.tsx
+++ b/frontend/src/components/grid/GridStatusBar.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import type { PaginationState } from '../../store/query/types';
 import type { ResultSet } from '../../types';
 import type { GridViewMode } from '../../types/grid';
-import type { StatementType } from '../../utils/sqlIdentifier';
+import type { StatementType } from '../../utils/sql/statement-type';
 import styles from './ResultGrid.module.css';
 
 interface GridStatusBarProps {

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -27,7 +27,7 @@ import { type ColumnMeta, type GridViewMode, isNumericType, type RowData } from 
 import { parseErrorMessage } from '../../utils/errorParser';
 import { lazyWithRetry } from '../../utils/lazyWithRetry';
 import { log } from '../../utils/logger';
-import { getStatementType } from '../../utils/sqlIdentifier';
+import { getStatementType } from '../../utils/sql/statement-type';
 import { QueryConfirmDialog } from '../dialogs/QueryConfirmDialog';
 import { GridFilterBar } from './GridFilterBar';
 import { GridStatusBar } from './GridStatusBar';

--- a/frontend/src/tests/utils/sql/statement-type.test.ts
+++ b/frontend/src/tests/utils/sql/statement-type.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { getStatementType } from '../../../utils/sql/statement-type';
+
+describe('getStatementType', () => {
+  it('SELECT 文', () => {
+    expect(getStatementType('SELECT * FROM users')).toBe('SELECT');
+  });
+
+  it('小文字 select', () => {
+    expect(getStatementType('select id from t')).toBe('SELECT');
+  });
+
+  it('INSERT 文', () => {
+    expect(getStatementType('INSERT INTO t (id) VALUES (1)')).toBe('INSERT');
+  });
+
+  it('UPDATE 文', () => {
+    expect(getStatementType('UPDATE t SET x = 1 WHERE id = 2')).toBe('UPDATE');
+  });
+
+  it('DELETE 文', () => {
+    expect(getStatementType('DELETE FROM t WHERE id = 1')).toBe('DELETE');
+  });
+
+  it('TRUNCATE 文', () => {
+    expect(getStatementType('TRUNCATE TABLE t')).toBe('TRUNCATE');
+  });
+
+  it('DROP 文', () => {
+    expect(getStatementType('DROP TABLE t')).toBe('DROP');
+  });
+
+  it('CREATE 文', () => {
+    expect(getStatementType('CREATE TABLE t (id INT)')).toBe('CREATE');
+  });
+
+  it('ALTER 文', () => {
+    expect(getStatementType('ALTER TABLE t ADD c INT')).toBe('ALTER');
+  });
+
+  it('先頭空白', () => {
+    expect(getStatementType('   \n\t  UPDATE t SET x=1')).toBe('UPDATE');
+  });
+
+  it('単一行コメント剥離', () => {
+    expect(getStatementType('-- comment\nDELETE FROM t')).toBe('DELETE');
+  });
+
+  it('複数単一行コメント連続', () => {
+    expect(getStatementType('-- one\n-- two\nINSERT INTO t VALUES (1)')).toBe('INSERT');
+  });
+
+  it('ブロックコメント剥離', () => {
+    expect(getStatementType('/* leading */ TRUNCATE TABLE t')).toBe('TRUNCATE');
+  });
+
+  it('複数行ブロックコメント', () => {
+    expect(getStatementType('/* one\ntwo\nthree */ UPDATE t SET x=1')).toBe('UPDATE');
+  });
+
+  it('WITH (CTE) → SELECT', () => {
+    expect(getStatementType('WITH cte AS (SELECT 1) SELECT * FROM cte')).toBe('SELECT');
+  });
+
+  it('WITH (CTE) → INSERT', () => {
+    expect(getStatementType('WITH cte AS (SELECT 1) INSERT INTO t SELECT * FROM cte')).toBe(
+      'INSERT'
+    );
+  });
+
+  it('WITH (CTE) → UPDATE', () => {
+    expect(
+      getStatementType('WITH cte AS (SELECT id FROM s) UPDATE t SET x=1 FROM cte WHERE t.id=cte.id')
+    ).toBe('UPDATE');
+  });
+
+  it('WITH (CTE) → DELETE', () => {
+    expect(
+      getStatementType(
+        'WITH cte AS (SELECT id FROM s) DELETE FROM t WHERE id IN (SELECT id FROM cte)'
+      )
+    ).toBe('DELETE');
+  });
+
+  it('WITH ネスト CTE', () => {
+    expect(getStatementType('WITH a AS (SELECT 1), b AS (SELECT * FROM a) SELECT * FROM b')).toBe(
+      'SELECT'
+    );
+  });
+
+  it('CTE カラムリスト (a, b) を skipCteDefinitions で消費して主動詞へ到達', () => {
+    expect(getStatementType('WITH cte (a, b) AS (SELECT 1, 2) SELECT * FROM cte')).toBe('SELECT');
+  });
+
+  it('CTE サブクエリ内の入れ子括弧を skipBalancedParens の深度追跡で踏破', () => {
+    expect(
+      getStatementType('WITH cte AS (SELECT (SELECT MAX(x) FROM s) AS m) SELECT * FROM cte')
+    ).toBe('SELECT');
+  });
+
+  it('未知の動詞は OTHER', () => {
+    expect(getStatementType('EXPLAIN SELECT 1')).toBe('OTHER');
+  });
+
+  it('空文字列は OTHER', () => {
+    expect(getStatementType('')).toBe('OTHER');
+  });
+
+  it('空白のみは OTHER', () => {
+    expect(getStatementType('   \n\n  ')).toBe('OTHER');
+  });
+
+  it('コメントのみは OTHER', () => {
+    expect(getStatementType('-- only a comment')).toBe('OTHER');
+  });
+});

--- a/frontend/src/tests/utils/sqlIdentifier.test.ts
+++ b/frontend/src/tests/utils/sqlIdentifier.test.ts
@@ -5,7 +5,6 @@ import {
   buildGetViewDefinitionSql,
   buildInsertTemplateSql,
   buildTruncateTableSql,
-  getStatementType,
   parseDropOrTruncate,
   type ReferencingFK,
 } from '../../utils/sqlIdentifier';
@@ -371,109 +370,5 @@ describe('buildInsertTemplateSql', () => {
   it('カラム空: 空のプレースホルダ (呼び出し側が防ぐべき入力を明示的に契約化)', () => {
     const sql = buildInsertTemplateSql('dbo.Empty', [], 'sqlserver');
     expect(sql).toBe('INSERT INTO [dbo].[Empty] () VALUES ();');
-  });
-});
-
-describe('getStatementType', () => {
-  it('SELECT 文', () => {
-    expect(getStatementType('SELECT * FROM users')).toBe('SELECT');
-  });
-
-  it('小文字 select', () => {
-    expect(getStatementType('select id from t')).toBe('SELECT');
-  });
-
-  it('INSERT 文', () => {
-    expect(getStatementType('INSERT INTO t (id) VALUES (1)')).toBe('INSERT');
-  });
-
-  it('UPDATE 文', () => {
-    expect(getStatementType('UPDATE t SET x = 1 WHERE id = 2')).toBe('UPDATE');
-  });
-
-  it('DELETE 文', () => {
-    expect(getStatementType('DELETE FROM t WHERE id = 1')).toBe('DELETE');
-  });
-
-  it('TRUNCATE 文', () => {
-    expect(getStatementType('TRUNCATE TABLE t')).toBe('TRUNCATE');
-  });
-
-  it('DROP 文', () => {
-    expect(getStatementType('DROP TABLE t')).toBe('DROP');
-  });
-
-  it('CREATE 文', () => {
-    expect(getStatementType('CREATE TABLE t (id INT)')).toBe('CREATE');
-  });
-
-  it('ALTER 文', () => {
-    expect(getStatementType('ALTER TABLE t ADD c INT')).toBe('ALTER');
-  });
-
-  it('先頭空白', () => {
-    expect(getStatementType('   \n\t  UPDATE t SET x=1')).toBe('UPDATE');
-  });
-
-  it('単一行コメント剥離', () => {
-    expect(getStatementType('-- comment\nDELETE FROM t')).toBe('DELETE');
-  });
-
-  it('複数単一行コメント連続', () => {
-    expect(getStatementType('-- one\n-- two\nINSERT INTO t VALUES (1)')).toBe('INSERT');
-  });
-
-  it('ブロックコメント剥離', () => {
-    expect(getStatementType('/* leading */ TRUNCATE TABLE t')).toBe('TRUNCATE');
-  });
-
-  it('複数行ブロックコメント', () => {
-    expect(getStatementType('/* one\ntwo\nthree */ UPDATE t SET x=1')).toBe('UPDATE');
-  });
-
-  it('WITH (CTE) → SELECT', () => {
-    expect(getStatementType('WITH cte AS (SELECT 1) SELECT * FROM cte')).toBe('SELECT');
-  });
-
-  it('WITH (CTE) → INSERT', () => {
-    expect(getStatementType('WITH cte AS (SELECT 1) INSERT INTO t SELECT * FROM cte')).toBe(
-      'INSERT'
-    );
-  });
-
-  it('WITH (CTE) → UPDATE', () => {
-    expect(
-      getStatementType('WITH cte AS (SELECT id FROM s) UPDATE t SET x=1 FROM cte WHERE t.id=cte.id')
-    ).toBe('UPDATE');
-  });
-
-  it('WITH (CTE) → DELETE', () => {
-    expect(
-      getStatementType(
-        'WITH cte AS (SELECT id FROM s) DELETE FROM t WHERE id IN (SELECT id FROM cte)'
-      )
-    ).toBe('DELETE');
-  });
-
-  it('WITH ネスト CTE', () => {
-    expect(getStatementType('WITH a AS (SELECT 1), b AS (SELECT * FROM a) SELECT * FROM b')).toBe(
-      'SELECT'
-    );
-  });
-
-  it('未知の動詞は OTHER', () => {
-    expect(getStatementType('EXPLAIN SELECT 1')).toBe('OTHER');
-  });
-
-  it('空文字列は OTHER', () => {
-    expect(getStatementType('')).toBe('OTHER');
-  });
-
-  it('空白のみは OTHER', () => {
-    expect(getStatementType('   \n\n  ')).toBe('OTHER');
-  });
-
-  it('コメントのみは OTHER', () => {
-    expect(getStatementType('-- only a comment')).toBe('OTHER');
   });
 });

--- a/frontend/src/utils/sql/statement-type.ts
+++ b/frontend/src/utils/sql/statement-type.ts
@@ -1,0 +1,110 @@
+// SQL ステートメント種別判定 (操作層)。
+// SQL 文字列を解析し、先頭の主動詞からステートメント種別を返す。
+// CTE (WITH 句) は配下の主動詞を返す。コメント・先頭空白は剥離する。
+
+export type StatementType =
+  | 'SELECT'
+  | 'INSERT'
+  | 'UPDATE'
+  | 'DELETE'
+  | 'TRUNCATE'
+  | 'DROP'
+  | 'CREATE'
+  | 'ALTER'
+  | 'OTHER';
+
+const STATEMENT_VERBS: ReadonlySet<StatementType> = new Set([
+  'SELECT',
+  'INSERT',
+  'UPDATE',
+  'DELETE',
+  'TRUNCATE',
+  'DROP',
+  'CREATE',
+  'ALTER',
+]);
+
+function stripLeadingComments(sql: string): string {
+  let s = sql;
+  for (;;) {
+    const before = s.length;
+    s = s.replace(/^\s+/, '');
+    s = s.replace(/^--[^\n]*\n?/, '');
+    s = s.replace(/^\/\*[\s\S]*?\*\//, '');
+    if (s.length === before) return s;
+  }
+}
+
+/**
+ * SQL 文の先頭動詞からステートメント種別を判定する。
+ * WITH (CTE) は配下の主動詞を返す。コメント・先頭空白は剥離。
+ */
+export function getStatementType(sql: string): StatementType {
+  let body = stripLeadingComments(sql);
+  if (body.length === 0) return 'OTHER';
+
+  // CTE 配下に現れる動詞は WITH 自身ではなく後続の主動詞を返す。
+  // (`WITH cte AS (SELECT 1) UPDATE t ...` → UPDATE)
+  // カッコ深度を追跡して CTE 定義群を飛ばし、主動詞を探す。
+  if (/^WITH\b/i.test(body)) {
+    body = skipCteDefinitions(body);
+  }
+
+  const m = body.match(/^[A-Za-z]+/);
+  if (!m) return 'OTHER';
+  const verb = m[0].toUpperCase() as StatementType;
+  return STATEMENT_VERBS.has(verb) ? verb : 'OTHER';
+}
+
+// 各 CTE 定義は `name [(cols)] AS (subquery)` の形。複数 CTE は `,` 区切り。
+// この関数は WITH 直後から始め、CTE 群を全て読み飛ばし、主動詞 (UPDATE/DELETE/SELECT 等) の
+// 直前まで s を進めて返す。途中で形式が崩れたらその時点の s を返し、呼び出し側で OTHER fallback。
+function skipCteDefinitions(body: string): string {
+  let s = body.replace(/^WITH\b\s*/i, '');
+  for (;;) {
+    // (1) CTE 名 (識別子) を消費
+    s = stripLeadingComments(s);
+    const nameMatch = s.match(/^(?:\[[^\]]+\]|"[^"]+"|`[^`]+`|\w+)\s*/);
+    if (!nameMatch) return s;
+    s = s.slice(nameMatch[0].length);
+
+    // (2) 任意の (col, ...) を消費
+    s = stripLeadingComments(s);
+    if (s.startsWith('(')) {
+      const after = skipBalancedParens(s);
+      if (after === null) return s;
+      s = after;
+    }
+
+    // (3) AS キーワードを消費
+    s = stripLeadingComments(s);
+    if (!/^AS\b/i.test(s)) return s;
+    s = s.slice(2);
+
+    // (4) (subquery) を消費
+    s = stripLeadingComments(s);
+    if (!s.startsWith('(')) return s;
+    const afterSub = skipBalancedParens(s);
+    if (afterSub === null) return s;
+    s = afterSub;
+
+    // (5) `,` があれば次 CTE、なければ主動詞へ
+    s = stripLeadingComments(s);
+    if (!s.startsWith(',')) return s;
+    s = s.slice(1);
+  }
+}
+
+function skipBalancedParens(s: string): string | null {
+  if (!s.startsWith('(')) return null;
+  let depth = 0;
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return s.slice(i + 1);
+    }
+  }
+  return null;
+}

--- a/frontend/src/utils/sqlIdentifier.ts
+++ b/frontend/src/utils/sqlIdentifier.ts
@@ -1,3 +1,7 @@
+// SQL identifier ベースの builder 群 (操作層)。
+// 識別子クォート / リテラルエスケープは utils/sql/quoting.ts、
+// ステートメント種別判定は utils/sql/statement-type.ts に分離されている。
+
 import type { DatabaseType } from '../types';
 import { escapeSingleQuotes, quoteIdentifier } from './sql/quoting';
 
@@ -206,117 +210,6 @@ export function parseDropOrTruncate(
     if (!tableMatch) continue;
     const table = stripQuotes(tableMatch[1]);
     return { type, schema, table };
-  }
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Statement type detection (UPDATE/INSERT/DELETE/TRUNCATE/DROP/CREATE/ALTER 結果表示用)
-// ---------------------------------------------------------------------------
-
-export type StatementType =
-  | 'SELECT'
-  | 'INSERT'
-  | 'UPDATE'
-  | 'DELETE'
-  | 'TRUNCATE'
-  | 'DROP'
-  | 'CREATE'
-  | 'ALTER'
-  | 'OTHER';
-
-const STATEMENT_VERBS: ReadonlySet<StatementType> = new Set([
-  'SELECT',
-  'INSERT',
-  'UPDATE',
-  'DELETE',
-  'TRUNCATE',
-  'DROP',
-  'CREATE',
-  'ALTER',
-]);
-
-// CTE 配下に現れる動詞は WITH 自身ではなく後続の主動詞を返す。
-// (`WITH cte AS (SELECT 1) UPDATE t ...` → UPDATE)
-function stripLeadingComments(sql: string): string {
-  let s = sql;
-  for (;;) {
-    const before = s.length;
-    s = s.replace(/^\s+/, '');
-    s = s.replace(/^--[^\n]*\n?/, '');
-    s = s.replace(/^\/\*[\s\S]*?\*\//, '');
-    if (s.length === before) return s;
-  }
-}
-
-/**
- * SQL 文の先頭動詞からステートメント種別を判定する。
- * WITH (CTE) は配下の主動詞を返す。コメント・先頭空白は剥離。
- */
-export function getStatementType(sql: string): StatementType {
-  let body = stripLeadingComments(sql);
-  if (body.length === 0) return 'OTHER';
-
-  // WITH (CTE): カッコ深度を追跡して CTE 定義を飛ばし、主動詞を探す
-  if (/^WITH\b/i.test(body)) {
-    body = skipCteDefinitions(body);
-  }
-
-  const m = body.match(/^[A-Za-z]+/);
-  if (!m) return 'OTHER';
-  const verb = m[0].toUpperCase() as StatementType;
-  return STATEMENT_VERBS.has(verb) ? verb : 'OTHER';
-}
-
-// 各 CTE 定義は `name [(cols)] AS (subquery)` の形。複数 CTE は `,` 区切り。
-// この関数は WITH 直後から始め、CTE 群を全て読み飛ばし、主動詞 (UPDATE/DELETE/SELECT 等) の
-// 直前まで s を進めて返す。途中で形式が崩れたらその時点の s を返し、呼び出し側で OTHER fallback。
-function skipCteDefinitions(body: string): string {
-  let s = body.replace(/^WITH\b\s*/i, '');
-  for (;;) {
-    // (1) CTE 名 (識別子) を消費
-    s = stripLeadingComments(s);
-    const nameMatch = s.match(/^(?:\[[^\]]+\]|"[^"]+"|`[^`]+`|\w+)\s*/);
-    if (!nameMatch) return s;
-    s = s.slice(nameMatch[0].length);
-
-    // (2) 任意の (col, ...) を消費
-    s = stripLeadingComments(s);
-    if (s.startsWith('(')) {
-      const after = skipBalancedParens(s);
-      if (after === null) return s;
-      s = after;
-    }
-
-    // (3) AS キーワードを消費
-    s = stripLeadingComments(s);
-    if (!/^AS\b/i.test(s)) return s;
-    s = s.slice(2);
-
-    // (4) (subquery) を消費
-    s = stripLeadingComments(s);
-    if (!s.startsWith('(')) return s;
-    const afterSub = skipBalancedParens(s);
-    if (afterSub === null) return s;
-    s = afterSub;
-
-    // (5) `,` があれば次 CTE、なければ主動詞へ
-    s = stripLeadingComments(s);
-    if (!s.startsWith(',')) return s;
-    s = s.slice(1);
-  }
-}
-
-function skipBalancedParens(s: string): string | null {
-  if (!s.startsWith('(')) return null;
-  let depth = 0;
-  for (let i = 0; i < s.length; i++) {
-    const ch = s[i];
-    if (ch === '(') depth++;
-    else if (ch === ')') {
-      depth--;
-      if (depth === 0) return s.slice(i + 1);
-    }
   }
   return null;
 }


### PR DESCRIPTION
- StatementType 型 / getStatementType / 内部 helper (stripLeadingComments, skipCteDefinitions, skipBalancedParens) を統合し操作層に移動
- 消費側 (ResultGrid, GridStatusBar) の import 経路を更新
- テストを tests/utils/sql/statement-type.test.ts に分離 (CTE カラムリスト消費・サブクエリ深度追跡の独立ケースを追加, 計 25 ケース)
- sqlIdentifier.ts 冒頭にファイル責務 (SQL builder 群) を明記し、quoting.ts / statement-type.ts への分離関係を記述
- WITH 処理コメントを stripLeadingComments 直上から getStatementType 内の分岐直前へ移動し、説明対象との整合を回復

Closes #466