### PR TITLE
fix(frontend): a11y lint 残 25 件を修正 (biome check 0 件達成)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ indent_size = 4
 
 [*.{cpp,cc,cxx,c,h,hpp,hxx}]
 indent_size = 4
+end_of_line = crlf
 
 [*.{cmake,cmake.in}]
 indent_size = 2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,14 +76,14 @@ ruff check scripts/ && ruff format --check scripts/
 
 ### IPC通信フロー
 
-```
+```text
 Frontend → window.invoke(JSON) → Backend ipc_handler.cpp → providers/ → database/ → JSON応答
 Frontend ← api/bridge.ts (Promiseラップ) ←────────────────────────────────────────────────┘
 ```
 
 ### Backend 構造 (C++)
 
-```
+```text
 backend/
 ├── ipc_handler.cpp           # IPCルーティング (m_routes にルート登録)
 ├── interfaces/               # ISP準拠インターフェース (*able.h)
@@ -108,7 +108,7 @@ backend/
 
 ### Frontend 構造 (React)
 
-```
+```text
 frontend/
 ├── src/
 │   ├── api/bridge.ts         # IPC通信 (Backend全メソッドのPromiseラッパー)
@@ -155,7 +155,7 @@ frontend/
 ## ドキュメント参照
 
 | ファイル | 内容 |
-|----------|------|
+| ---------- | ------ |
 | `docs/ARCHITECTURE.md` | レイヤー構造、コンポーネント対応表 |
 | `docs/TROUBLESHOOTING.md` | トラブルシューティング |
 | `docs/VISUAL_STUDIO_SETUP.md` | VS2022 でのデバッグ手順 |

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,79 +1,80 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "correctness": {
-        "useExhaustiveDependencies": "warn",
-        "useHookAtTopLevel": "error",
-        "noUnusedImports": "error",
-        "noUnusedVariables": "error",
-        "noUnknownPseudoElement": "off"
-      },
-      "suspicious": {
-        "noExplicitAny": "warn",
-        "noArrayIndexKey": "warn"
-      },
-      "style": {
-        "noNonNullAssertion": "warn",
-        "useConst": "error",
-        "useTemplate": "error"
-      },
-      "complexity": {
-        "noForEach": "off"
-      },
-      "a11y": {
-        "recommended": false
-      }
-    }
-  },
-  "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineWidth": 100,
-    "lineEnding": "lf"
-  },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "single",
-      "semicolons": "always",
-      "trailingCommas": "es5",
-      "arrowParentheses": "always"
-    }
-  },
-  "json": {
-    "formatter": {
-      "indentWidth": 2
-    }
-  },
-  "css": {
-    "parser": {
-      "cssModules": true
-    },
-    "formatter": {
-      "enabled": true
-    },
-    "linter": {
-      "enabled": true
-    }
-  },
-  "files": {
-    "includes": [
-      "**",
-      "!**/dist",
-      "!**/node_modules",
-      "!**/*.min.js",
-      "!**/coverage",
-      "!**/.claude"
-    ]
-  },
-  "vcs": {
-    "enabled": true,
-    "clientKind": "git",
-    "useIgnoreFile": false,
-    "root": ".."
-  }
+	"$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"correctness": {
+				"useExhaustiveDependencies": "warn",
+				"useHookAtTopLevel": "error",
+				"noUnusedImports": "error",
+				"noUnusedVariables": "error",
+				"noUnknownPseudoElement": "off"
+			},
+			"suspicious": {
+				"noExplicitAny": "warn",
+				"noArrayIndexKey": "warn"
+			},
+			"style": {
+				"noNonNullAssertion": "warn",
+				"useConst": "error",
+				"useTemplate": "error"
+			},
+			"complexity": {
+				"noForEach": "off"
+			},
+			"a11y": {
+				"recommended": true
+			}
+		}
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "space",
+		"indentWidth": 2,
+		"lineWidth": 100,
+		"lineEnding": "lf",
+		"useEditorconfig": true
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "single",
+			"semicolons": "always",
+			"trailingCommas": "es5",
+			"arrowParentheses": "always"
+		}
+	},
+	"json": {
+		"formatter": {
+			"indentWidth": 2
+		}
+	},
+	"css": {
+		"parser": {
+			"cssModules": true
+		},
+		"formatter": {
+			"enabled": true
+		},
+		"linter": {
+			"enabled": true
+		}
+	},
+	"files": {
+		"includes": [
+			"**",
+			"!**/dist",
+			"!**/node_modules",
+			"!**/*.min.js",
+			"!**/coverage",
+			"!**/.claude"
+		]
+	},
+	"vcs": {
+		"enabled": true,
+		"clientKind": "git",
+		"useIgnoreFile": false,
+		"root": ".."
+	}
 }

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,80 +1,80 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"correctness": {
-				"useExhaustiveDependencies": "warn",
-				"useHookAtTopLevel": "error",
-				"noUnusedImports": "error",
-				"noUnusedVariables": "error",
-				"noUnknownPseudoElement": "off"
-			},
-			"suspicious": {
-				"noExplicitAny": "warn",
-				"noArrayIndexKey": "warn"
-			},
-			"style": {
-				"noNonNullAssertion": "warn",
-				"useConst": "error",
-				"useTemplate": "error"
-			},
-			"complexity": {
-				"noForEach": "off"
-			},
-			"a11y": {
-				"recommended": true
-			}
-		}
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "space",
-		"indentWidth": 2,
-		"lineWidth": 100,
-		"lineEnding": "lf",
-		"useEditorconfig": true
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "single",
-			"semicolons": "always",
-			"trailingCommas": "es5",
-			"arrowParentheses": "always"
-		}
-	},
-	"json": {
-		"formatter": {
-			"indentWidth": 2
-		}
-	},
-	"css": {
-		"parser": {
-			"cssModules": true
-		},
-		"formatter": {
-			"enabled": true
-		},
-		"linter": {
-			"enabled": true
-		}
-	},
-	"files": {
-		"includes": [
-			"**",
-			"!**/dist",
-			"!**/node_modules",
-			"!**/*.min.js",
-			"!**/coverage",
-			"!**/.claude"
-		]
-	},
-	"vcs": {
-		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": false,
-		"root": ".."
-	}
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "useExhaustiveDependencies": "warn",
+        "useHookAtTopLevel": "error",
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error",
+        "noUnknownPseudoElement": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noArrayIndexKey": "warn"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "useConst": "error",
+        "useTemplate": "error"
+      },
+      "complexity": {
+        "noForEach": "off"
+      },
+      "a11y": {
+        "recommended": true
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf",
+    "useEditorconfig": true
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "es5",
+      "arrowParentheses": "always"
+    }
+  },
+  "json": {
+    "formatter": {
+      "indentWidth": 2
+    }
+  },
+  "css": {
+    "parser": {
+      "cssModules": true
+    },
+    "formatter": {
+      "enabled": true
+    },
+    "linter": {
+      "enabled": true
+    }
+  },
+  "files": {
+    "includes": [
+      "**",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/*.min.js",
+      "!**/coverage",
+      "!**/.claude"
+    ]
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": false,
+    "root": ".."
+  }
 }

--- a/frontend/src/components/common/ContextMenu.tsx
+++ b/frontend/src/components/common/ContextMenu.tsx
@@ -91,6 +91,7 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
           <div key={getItemKey(item, index)} className={styles.separator} />
         ) : (
           <button
+            type="button"
             key={getItemKey(item, index)}
             className={`${styles.item} ${item.disabled ? styles.disabled : ''}`}
             onClick={() => handleItemClick(item)}

--- a/frontend/src/components/common/DialogOverlay.tsx
+++ b/frontend/src/components/common/DialogOverlay.tsx
@@ -1,0 +1,63 @@
+import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+
+interface DialogOverlayProps {
+  onClose: () => void;
+  children: ReactNode;
+  overlayClassName?: string;
+  dialogClassName?: string;
+  ariaLabelledBy?: string;
+  overlayStyle?: CSSProperties;
+  dialogStyle?: CSSProperties;
+  /** overlay クリックでの閉じるを抑止 (実行中など) */
+  disableOverlayClose?: boolean;
+}
+
+// overlay 背景クリックでの閉じるは意図的 UX。ESC は useDialogKeyboard が window レベルで
+// 共通処理するため、a11y/useKeyWithClickEvents は冗長。a11y/noStaticElementInteractions は
+// role="presentation"/"dialog" 付与済だが biome は static 扱いするため抑止。
+export function DialogOverlay({
+  onClose,
+  children,
+  overlayClassName,
+  dialogClassName,
+  ariaLabelledBy,
+  overlayStyle,
+  dialogStyle,
+  disableOverlayClose = false,
+}: DialogOverlayProps) {
+  const handleOverlayClick = () => {
+    if (!disableOverlayClose) onClose();
+  };
+  const handleOverlayKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape' && !disableOverlayClose) {
+      e.stopPropagation();
+      onClose();
+    }
+  };
+  const stopPropagation = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    e.stopPropagation();
+  };
+
+  return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: overlay backdrop は意図的 click-to-close。ESC は handleOverlayKeyDown と useDialogKeyboard 双方で対応
+    <div
+      className={overlayClassName}
+      style={overlayStyle}
+      onClick={handleOverlayClick}
+      onKeyDown={handleOverlayKeyDown}
+      role="presentation"
+    >
+      <div
+        className={dialogClassName}
+        style={dialogStyle}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={stopPropagation}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={ariaLabelledBy}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/dialogs/ConnectionDialog.tsx
+++ b/frontend/src/components/dialogs/ConnectionDialog.tsx
@@ -128,7 +128,7 @@ export function ConnectionDialog({
         tabIndex={-1}
         aria-label="ダイアログを閉じる"
       />
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+      <div className={styles.dialog}>
         <div className={styles.header}>
           <h2>DB接続</h2>
           <button type="button" className={styles.closeButton} onClick={onClose}>

--- a/frontend/src/components/dialogs/DmlPreviewDialog.tsx
+++ b/frontend/src/components/dialogs/DmlPreviewDialog.tsx
@@ -1,4 +1,5 @@
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './DmlPreviewDialog.module.css';
 
 interface DmlPreviewDialogProps {
@@ -21,25 +22,38 @@ export function DmlPreviewDialog({
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={isExecuting ? undefined : onCancel}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <span className={styles.icon}>!</span>
-          <h3>変更プレビュー</h3>
-        </div>
-        <div className={styles.content}>
-          <p className={styles.summary}>{statements.length}件のSQL文を実行します</p>
-          <pre className={styles.sqlBlock}>{statements.join('\n\n')}</pre>
-        </div>
-        <div className={styles.footer}>
-          <button className={styles.cancelButton} onClick={onCancel} disabled={isExecuting}>
-            キャンセル
-          </button>
-          <button className={styles.executeButton} onClick={onExecute} disabled={isExecuting}>
-            {isExecuting ? '実行中...' : '実行'}
-          </button>
-        </div>
+    <DialogOverlay
+      onClose={onCancel}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+      disableOverlayClose={isExecuting}
+    >
+      <div className={styles.header}>
+        <span className={styles.icon}>!</span>
+        <h3>変更プレビュー</h3>
       </div>
-    </div>
+      <div className={styles.content}>
+        <p className={styles.summary}>{statements.length}件のSQL文を実行します</p>
+        <pre className={styles.sqlBlock}>{statements.join('\n\n')}</pre>
+      </div>
+      <div className={styles.footer}>
+        <button
+          type="button"
+          className={styles.cancelButton}
+          onClick={onCancel}
+          disabled={isExecuting}
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          className={styles.executeButton}
+          onClick={onExecute}
+          disabled={isExecuting}
+        >
+          {isExecuting ? '実行中...' : '実行'}
+        </button>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/dialogs/ERImportDialog.tsx
+++ b/frontend/src/components/dialogs/ERImportDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { bridge, toERDiagramModel } from '../../api/bridge';
 import type { ERDiagramModel } from '../../utils/erDiagramParser';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './ERImportDialog.module.css';
 
 interface ERImportDialogProps {
@@ -55,113 +56,94 @@ export function ERImportDialog({ isOpen, onClose, onImport }: ERImportDialogProp
   if (!isOpen) return null;
 
   return (
-    <div
-      className={styles.overlay}
-      onClick={onClose}
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') {
-          e.stopPropagation();
-          onClose();
-        }
-      }}
-      role="presentation"
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+      ariaLabelledBy="er-import-dialog-title"
     >
-      <div
-        className={styles.dialog}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') {
-            e.stopPropagation();
-            onClose();
-          }
-        }}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="er-import-dialog-title"
-      >
-        <div className={styles.header}>
-          <h2 id="er-import-dialog-title">ER図ファイルをインポート</h2>
-          <button type="button" className={styles.closeButton} onClick={onClose}>
-            {'\u2715'}
-          </button>
+      <div className={styles.header}>
+        <h2 id="er-import-dialog-title">ER図ファイルをインポート</h2>
+        <button type="button" className={styles.closeButton} onClick={onClose}>
+          {'\u2715'}
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.fileSection}>
+          <span className={styles.fileLabel}>ER図ファイルを選択</span>
+          <div className={styles.fileRow}>
+            <button
+              type="button"
+              className={styles.fileBrowseButton}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              ファイルを選択
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".a5er,.xml"
+              onChange={handleFileSelect}
+              className={styles.fileHidden}
+            />
+            {fileName && <span className={styles.fileName}>{fileName}</span>}
+          </div>
         </div>
 
-        <div className={styles.content}>
-          <div className={styles.fileSection}>
-            <span className={styles.fileLabel}>ER図ファイルを選択</span>
-            <div className={styles.fileRow}>
-              <button
-                type="button"
-                className={styles.fileBrowseButton}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                ファイルを選択
-              </button>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".a5er,.xml"
-                onChange={handleFileSelect}
-                className={styles.fileHidden}
-              />
-              {fileName && <span className={styles.fileName}>{fileName}</span>}
+        {error && <div className={styles.error}>{error}</div>}
+
+        {parsedModel && parsedModel.tables.length > 0 && (
+          <div className={styles.summary}>
+            <h3>解析結果</h3>
+            <p>
+              {parsedModel.tables.length} テーブル, {parsedModel.relations.length} リレーション
+            </p>
+
+            <div className={styles.tableList}>
+              {parsedModel.tables.map((table) => (
+                <div key={table.name} className={styles.tableItem}>
+                  <span className={styles.tableName}>
+                    {table.logicalName ? `${table.name} (${table.logicalName})` : table.name}
+                  </span>
+                  <span className={styles.columnCount}>{table.columns.length} カラム</span>
+                </div>
+              ))}
             </div>
           </div>
+        )}
 
-          {error && <div className={styles.error}>{error}</div>}
-
-          {parsedModel && parsedModel.tables.length > 0 && (
-            <div className={styles.summary}>
-              <h3>解析結果</h3>
-              <p>
-                {parsedModel.tables.length} テーブル, {parsedModel.relations.length} リレーション
-              </p>
-
-              <div className={styles.tableList}>
-                {parsedModel.tables.map((table) => (
-                  <div key={table.name} className={styles.tableItem}>
-                    <span className={styles.tableName}>
-                      {table.logicalName ? `${table.name} (${table.logicalName})` : table.name}
-                    </span>
-                    <span className={styles.columnCount}>{table.columns.length} カラム</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {parsedModel && (
-            <div className={styles.ddlSection}>
-              <div className={styles.ddlHeader}>
-                <h3>生成されたDDL</h3>
-                <button type="button" onClick={() => setShowDDL(!showDDL)}>
-                  {showDDL ? '非表示' : '表示'}
+        {parsedModel && (
+          <div className={styles.ddlSection}>
+            <div className={styles.ddlHeader}>
+              <h3>生成されたDDL</h3>
+              <button type="button" onClick={() => setShowDDL(!showDDL)}>
+                {showDDL ? '非表示' : '表示'}
+              </button>
+              {generatedDDL && (
+                <button type="button" onClick={handleCopyDDL}>
+                  コピー
                 </button>
-                {generatedDDL && (
-                  <button type="button" onClick={handleCopyDDL}>
-                    コピー
-                  </button>
-                )}
-              </div>
-              {showDDL && generatedDDL && <pre className={styles.ddlContent}>{generatedDDL}</pre>}
+              )}
             </div>
-          )}
-        </div>
-
-        <div className={styles.footer}>
-          <button type="button" className={styles.cancelButton} onClick={onClose}>
-            キャンセル
-          </button>
-          <button
-            type="button"
-            onClick={handleImport}
-            disabled={!parsedModel || parsedModel.tables.length === 0}
-            className={styles.importButton}
-          >
-            ER図にインポート
-          </button>
-        </div>
+            {showDDL && generatedDDL && <pre className={styles.ddlContent}>{generatedDDL}</pre>}
+          </div>
+        )}
       </div>
-    </div>
+
+      <div className={styles.footer}>
+        <button type="button" className={styles.cancelButton} onClick={onClose}>
+          キャンセル
+        </button>
+        <button
+          type="button"
+          onClick={handleImport}
+          disabled={!parsedModel || parsedModel.tables.length === 0}
+          className={styles.importButton}
+        >
+          ER図にインポート
+        </button>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/dialogs/ErrorDetailDialog.tsx
+++ b/frontend/src/components/dialogs/ErrorDetailDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import { parseErrorMessage } from '../../utils/errorParser';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './ErrorDetailDialog.module.css';
 
 interface ErrorDetailDialogProps {
@@ -25,25 +26,27 @@ export function ErrorDetailDialog({ isOpen, errorMessage, onClose }: ErrorDetail
   const parsed = parseErrorMessage(errorMessage);
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <span className={styles.icon}>!</span>
-          <h3>クエリエラー</h3>
-        </div>
-        <div className={styles.content}>
-          <p className={styles.summary}>{parsed.summary}</p>
-          <pre className={styles.detail}>{parsed.detail}</pre>
-        </div>
-        <div className={styles.footer}>
-          <button className={styles.copyButton} onClick={copyToClipboard}>
-            コピー
-          </button>
-          <button className={styles.closeButton} onClick={onClose}>
-            閉じる
-          </button>
-        </div>
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.header}>
+        <span className={styles.icon}>!</span>
+        <h3>クエリエラー</h3>
       </div>
-    </div>
+      <div className={styles.content}>
+        <p className={styles.summary}>{parsed.summary}</p>
+        <pre className={styles.detail}>{parsed.detail}</pre>
+      </div>
+      <div className={styles.footer}>
+        <button type="button" className={styles.copyButton} onClick={copyToClipboard}>
+          コピー
+        </button>
+        <button type="button" className={styles.closeButton} onClick={onClose}>
+          閉じる
+        </button>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/dialogs/ExecutionPlanDialog.module.css
+++ b/frontend/src/components/dialogs/ExecutionPlanDialog.module.css
@@ -78,7 +78,7 @@
   margin-bottom: 16px;
 }
 
-.sqlPreview label {
+.sqlPreview .fieldLabel {
   display: block;
   margin-bottom: 4px;
   color: var(--text-secondary);
@@ -102,7 +102,7 @@
   flex: 1;
 }
 
-.planContainer label {
+.planContainer .fieldLabel {
   display: block;
   margin-bottom: 8px;
   color: var(--text-secondary);

--- a/frontend/src/components/dialogs/ExecutionPlanDialog.tsx
+++ b/frontend/src/components/dialogs/ExecutionPlanDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import { useConnectionStore } from '../../store/connectionStore';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './ExecutionPlanDialog.module.css';
 
 interface ExecutionPlanDialogProps {
@@ -59,61 +60,67 @@ export function ExecutionPlanDialog({ isOpen, onClose, sql }: ExecutionPlanDialo
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <h2>実行計画</h2>
-          <button className={styles.closeButton} onClick={onClose}>
-            {'\u2715'}
-          </button>
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.header}>
+        <h2>実行計画</h2>
+        <button type="button" className={styles.closeButton} onClick={onClose}>
+          {'✕'}
+        </button>
+      </div>
+
+      <div className={styles.toolbar}>
+        <button
+          type="button"
+          onClick={handleGetPlan}
+          disabled={isLoading || !activeConnectionId}
+          className={!showActual ? styles.active : ''}
+        >
+          推定プラン
+        </button>
+        <button
+          type="button"
+          onClick={handleGetActualPlan}
+          disabled={isLoading || !activeConnectionId}
+          className={showActual ? styles.active : ''}
+        >
+          実際のプラン
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.sqlPreview}>
+          <span className={styles.fieldLabel}>クエリ:</span>
+          <pre>{sql}</pre>
         </div>
 
-        <div className={styles.toolbar}>
-          <button
-            onClick={handleGetPlan}
-            disabled={isLoading || !activeConnectionId}
-            className={!showActual ? styles.active : ''}
-          >
-            推定プラン
-          </button>
-          <button
-            onClick={handleGetActualPlan}
-            disabled={isLoading || !activeConnectionId}
-            className={showActual ? styles.active : ''}
-          >
-            実際のプラン
-          </button>
-        </div>
-
-        <div className={styles.content}>
-          <div className={styles.sqlPreview}>
-            <label>クエリ:</label>
-            <pre>{sql}</pre>
-          </div>
-
-          <div className={styles.planContainer}>
-            <label>実行計画:</label>
-            {isLoading ? (
-              <div className={styles.loading}>実行計画を読み込み中...</div>
-            ) : error ? (
-              <div className={styles.error}>{error}</div>
-            ) : planText ? (
-              <pre className={styles.planText}>{planText}</pre>
-            ) : (
-              <div className={styles.placeholder}>
-                「推定プラン」または「実際のプラン」をクリックして実行計画を生成
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className={styles.footer}>
-          <span className={styles.hint}>
-            ヒント: 実際のプランはクエリを実行します。推定プランは実行しません。
-          </span>
-          <button onClick={onClose}>閉じる</button>
+        <div className={styles.planContainer}>
+          <span className={styles.fieldLabel}>実行計画:</span>
+          {isLoading ? (
+            <div className={styles.loading}>実行計画を読み込み中...</div>
+          ) : error ? (
+            <div className={styles.error}>{error}</div>
+          ) : planText ? (
+            <pre className={styles.planText}>{planText}</pre>
+          ) : (
+            <div className={styles.placeholder}>
+              「推定プラン」または「実際のプラン」をクリックして実行計画を生成
+            </div>
+          )}
         </div>
       </div>
-    </div>
+
+      <div className={styles.footer}>
+        <span className={styles.hint}>
+          ヒント: 実際のプランはクエリを実行します。推定プランは実行しません。
+        </span>
+        <button type="button" onClick={onClose}>
+          閉じる
+        </button>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/dialogs/InputDialog.tsx
+++ b/frontend/src/components/dialogs/InputDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './InputDialog.module.css';
 
 interface InputDialogProps {
@@ -68,37 +69,44 @@ export function InputDialog({
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={onCancel}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <span className={styles.icon}>?</span>
-          <h3>{title}</h3>
-        </div>
-        <div className={styles.content}>
-          <p className={styles.message}>{message}</p>
-          <input
-            ref={inputRef}
-            className={styles.input}
-            type="text"
-            value={value}
-            placeholder={placeholder}
-            onChange={(e) => {
-              setValue(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={handleKeyDown}
-          />
-          {error && <p className={styles.error}>{error}</p>}
-        </div>
-        <div className={styles.footer}>
-          <button className={styles.cancelButton} onClick={onCancel}>
-            {cancelLabel}
-          </button>
-          <button className={styles.confirmButton} onClick={tryConfirm} disabled={!value.trim()}>
-            {confirmLabel}
-          </button>
-        </div>
+    <DialogOverlay
+      onClose={onCancel}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.header}>
+        <span className={styles.icon}>?</span>
+        <h3>{title}</h3>
       </div>
-    </div>
+      <div className={styles.content}>
+        <p className={styles.message}>{message}</p>
+        <input
+          ref={inputRef}
+          className={styles.input}
+          type="text"
+          value={value}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setError(null);
+          }}
+          onKeyDown={handleKeyDown}
+        />
+        {error && <p className={styles.error}>{error}</p>}
+      </div>
+      <div className={styles.footer}>
+        <button type="button" className={styles.cancelButton} onClick={onCancel}>
+          {cancelLabel}
+        </button>
+        <button
+          type="button"
+          className={styles.confirmButton}
+          onClick={tryConfirm}
+          disabled={!value.trim()}
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/dialogs/QueryConfirmDialog.tsx
+++ b/frontend/src/components/dialogs/QueryConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './QueryConfirmDialog.module.css';
 
 interface QueryConfirmDialogProps {
@@ -29,30 +30,33 @@ export function QueryConfirmDialog({
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={onCancel}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <span className={`${styles.icon} ${isDestructive ? styles.warning : ''}`}>
-            {isDestructive ? '!' : '?'}
-          </span>
-          <h3>{title}</h3>
-        </div>
-        <div className={styles.content}>
-          <p className={styles.message}>{message}</p>
-          {details && <pre className={styles.details}>{details}</pre>}
-        </div>
-        <div className={styles.footer}>
-          <button className={styles.cancelButton} onClick={onCancel}>
-            {cancelLabel}
-          </button>
-          <button
-            className={`${styles.confirmButton} ${isDestructive ? styles.destructive : ''}`}
-            onClick={onConfirm}
-          >
-            {confirmLabel}
-          </button>
-        </div>
+    <DialogOverlay
+      onClose={onCancel}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.header}>
+        <span className={`${styles.icon} ${isDestructive ? styles.warning : ''}`}>
+          {isDestructive ? '!' : '?'}
+        </span>
+        <h3>{title}</h3>
       </div>
-    </div>
+      <div className={styles.content}>
+        <p className={styles.message}>{message}</p>
+        {details && <pre className={styles.details}>{details}</pre>}
+      </div>
+      <div className={styles.footer}>
+        <button type="button" className={styles.cancelButton} onClick={onCancel}>
+          {cancelLabel}
+        </button>
+        <button
+          type="button"
+          className={`${styles.confirmButton} ${isDestructive ? styles.destructive : ''}`}
+          onClick={onConfirm}
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/dialogs/SearchDialog.module.css
+++ b/frontend/src/components/dialogs/SearchDialog.module.css
@@ -72,6 +72,12 @@
   gap: 12px;
   padding: 10px 16px;
   cursor: pointer;
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
 }
 
 .resultItem:hover,

--- a/frontend/src/components/dialogs/SearchDialog.tsx
+++ b/frontend/src/components/dialogs/SearchDialog.tsx
@@ -132,7 +132,8 @@ export function SearchDialog({ isOpen, onClose, onResultSelect }: SearchDialogPr
           </div>
         ) : (
           results.map((result, index) => (
-            <div
+            <button
+              type="button"
               key={`${result.type}-${result.schema}-${result.name}`}
               className={`${styles.resultItem} ${index === selectedIndex ? styles.selected : ''}`}
               onClick={() => handleResultClick(result)}
@@ -148,7 +149,7 @@ export function SearchDialog({ isOpen, onClose, onResultSelect }: SearchDialogPr
                   {result.schema}.{result.type}
                 </span>
               </div>
-            </div>
+            </button>
           ))
         )}
       </div>

--- a/frontend/src/components/dialogs/SearchDialog.tsx
+++ b/frontend/src/components/dialogs/SearchDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useDeferredValue, useEffect, useRef, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useConnectionStore } from '../../store/connectionStore';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './SearchDialog.module.css';
 
 interface SearchDialogProps {
@@ -103,60 +104,62 @@ export function SearchDialog({ isOpen, onClose, onResultSelect }: SearchDialogPr
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.searchContainer}>
-          <span className={styles.searchIcon}>{'\uD83D\uDD0D'}</span>
-          <input
-            ref={inputRef}
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="テーブル、ビュー、プロシージャを検索..."
-            className={styles.searchInput}
-          />
-          {(isSearching || isStale) && <span className={styles.spinner}>{'\u23F3'}</span>}
-        </div>
-
-        <div className={styles.results}>
-          {!activeConnectionId ? (
-            <div className={styles.noConnection}>検索するにはデータベースに接続してください</div>
-          ) : results.length === 0 && searchQuery.trim() ? (
-            <div className={styles.noResults}>
-              {isSearching || isStale ? '検索中...' : '結果が見つかりません'}
-            </div>
-          ) : (
-            results.map((result, index) => (
-              <div
-                key={`${result.type}-${result.schema}-${result.name}`}
-                className={`${styles.resultItem} ${index === selectedIndex ? styles.selected : ''}`}
-                onClick={() => handleResultClick(result)}
-                onMouseEnter={() => setSelectedIndex(index)}
-              >
-                <span className={styles.resultIcon}>{getIcon(result.type)}</span>
-                <div className={styles.resultInfo}>
-                  <span className={styles.resultName}>
-                    {result.parentName ? `${result.parentName}.` : ''}
-                    {result.name}
-                  </span>
-                  <span className={styles.resultMeta}>
-                    {result.schema}.{result.type}
-                  </span>
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-
-        <div className={styles.footer}>
-          <span className={styles.hint}>↑↓ 移動, Enter 選択, Esc 閉じる</span>
-          {activeConnection && (
-            <span className={styles.connectionInfo}>{activeConnection.database}</span>
-          )}
-        </div>
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.searchContainer}>
+        <span className={styles.searchIcon}>{'\uD83D\uDD0D'}</span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="テーブル、ビュー、プロシージャを検索..."
+          className={styles.searchInput}
+        />
+        {(isSearching || isStale) && <span className={styles.spinner}>{'\u23F3'}</span>}
       </div>
-    </div>
+
+      <div className={styles.results}>
+        {!activeConnectionId ? (
+          <div className={styles.noConnection}>検索するにはデータベースに接続してください</div>
+        ) : results.length === 0 && searchQuery.trim() ? (
+          <div className={styles.noResults}>
+            {isSearching || isStale ? '検索中...' : '結果が見つかりません'}
+          </div>
+        ) : (
+          results.map((result, index) => (
+            <div
+              key={`${result.type}-${result.schema}-${result.name}`}
+              className={`${styles.resultItem} ${index === selectedIndex ? styles.selected : ''}`}
+              onClick={() => handleResultClick(result)}
+              onMouseEnter={() => setSelectedIndex(index)}
+            >
+              <span className={styles.resultIcon}>{getIcon(result.type)}</span>
+              <div className={styles.resultInfo}>
+                <span className={styles.resultName}>
+                  {result.parentName ? `${result.parentName}.` : ''}
+                  {result.name}
+                </span>
+                <span className={styles.resultMeta}>
+                  {result.schema}.{result.type}
+                </span>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        <span className={styles.hint}>↑↓ 移動, Enter 選択, Esc 閉じる</span>
+        {activeConnection && (
+          <span className={styles.connectionInfo}>{activeConnection.database}</span>
+        )}
+      </div>
+    </DialogOverlay>
   );
 }
 

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../api/bridge';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './SettingsDialog.module.css';
 import {
   type AppSettings,
@@ -82,187 +83,198 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <h2>設定</h2>
-          <button className={styles.closeButton} onClick={onClose}>
-            {'\u2715'}
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.header}>
+        <h2>設定</h2>
+        <button type="button" className={styles.closeButton} onClick={onClose}>
+          {'\u2715'}
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.tabs}>
+          <button
+            type="button"
+            className={`${styles.tab} ${activeTab === 'editor' ? styles.active : ''}`}
+            onClick={() => setActiveTab('editor')}
+          >
+            エディタ
+          </button>
+          <button
+            type="button"
+            className={`${styles.tab} ${activeTab === 'query' ? styles.active : ''}`}
+            onClick={() => setActiveTab('query')}
+          >
+            クエリ
+          </button>
+          <button
+            type="button"
+            className={`${styles.tab} ${activeTab === 'appearance' ? styles.active : ''}`}
+            onClick={() => setActiveTab('appearance')}
+          >
+            外観
+          </button>
+          <button
+            type="button"
+            className={`${styles.tab} ${activeTab === 'shortcuts' ? styles.active : ''}`}
+            onClick={() => setActiveTab('shortcuts')}
+          >
+            ショートカット
           </button>
         </div>
 
-        <div className={styles.content}>
-          <div className={styles.tabs}>
-            <button
-              className={`${styles.tab} ${activeTab === 'editor' ? styles.active : ''}`}
-              onClick={() => setActiveTab('editor')}
-            >
-              エディタ
-            </button>
-            <button
-              className={`${styles.tab} ${activeTab === 'query' ? styles.active : ''}`}
-              onClick={() => setActiveTab('query')}
-            >
-              クエリ
-            </button>
-            <button
-              className={`${styles.tab} ${activeTab === 'appearance' ? styles.active : ''}`}
-              onClick={() => setActiveTab('appearance')}
-            >
-              外観
-            </button>
-            <button
-              className={`${styles.tab} ${activeTab === 'shortcuts' ? styles.active : ''}`}
-              onClick={() => setActiveTab('shortcuts')}
-            >
-              ショートカット
-            </button>
-          </div>
-
-          <div className={styles.tabContent}>
-            {activeTab === 'editor' && (
-              <div className={styles.settingsGroup}>
-                <div className={styles.setting}>
-                  <label>フォントサイズ</label>
-                  <input
-                    type="number"
-                    value={settings.editor.fontSize}
-                    onChange={(e) =>
-                      updateSetting('editor', 'fontSize', Number.parseInt(e.target.value, 10) || 14)
-                    }
-                    min={8}
-                    max={32}
-                  />
-                </div>
-                <div className={styles.setting}>
-                  <label>タブサイズ</label>
-                  <select
-                    value={settings.editor.tabSize}
-                    onChange={(e) =>
-                      updateSetting('editor', 'tabSize', Number.parseInt(e.target.value, 10))
-                    }
-                  >
-                    <option value={2}>2スペース</option>
-                    <option value={4}>4スペース</option>
-                    <option value={8}>8スペース</option>
-                  </select>
-                </div>
-                <div className={styles.setting}>
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={settings.editor.wordWrap}
-                      onChange={(e) => updateSetting('editor', 'wordWrap', e.target.checked)}
-                    />
-                    折り返し
-                  </label>
-                </div>
-                <div className={styles.setting}>
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={settings.editor.minimap}
-                      onChange={(e) => updateSetting('editor', 'minimap', e.target.checked)}
-                    />
-                    ミニマップを表示
-                  </label>
-                </div>
+        <div className={styles.tabContent}>
+          {activeTab === 'editor' && (
+            <div className={styles.settingsGroup}>
+              <div className={styles.setting}>
+                <label htmlFor="setting-editor-font-size">フォントサイズ</label>
+                <input
+                  id="setting-editor-font-size"
+                  type="number"
+                  value={settings.editor.fontSize}
+                  onChange={(e) =>
+                    updateSetting('editor', 'fontSize', Number.parseInt(e.target.value, 10) || 14)
+                  }
+                  min={8}
+                  max={32}
+                />
               </div>
-            )}
-
-            {activeTab === 'query' && (
-              <div className={styles.settingsGroup}>
-                <div className={styles.setting}>
-                  <label>
-                    <input
-                      type="checkbox"
-                      checked={settings.query.autoCommit}
-                      onChange={(e) => updateSetting('query', 'autoCommit', e.target.checked)}
-                    />
-                    自動コミット
-                  </label>
-                </div>
-                <div className={styles.setting}>
-                  <label htmlFor="setting-query-timeout-sec">クエリタイムアウト (秒)</label>
-                  <input
-                    id="setting-query-timeout-sec"
-                    type="number"
-                    value={Math.round(settings.query.timeout / 1000)}
-                    onChange={(e) => {
-                      const parsed = Number.parseInt(e.target.value, 10);
-                      const sec = Number.isFinite(parsed) ? parsed : QUERY_TIMEOUT_DEFAULT_SEC;
-                      updateSetting('query', 'timeout', sec * 1000);
-                    }}
-                    min={QUERY_TIMEOUT_MIN_SEC}
-                    max={QUERY_TIMEOUT_MAX_SEC}
-                    step={60}
-                  />
-                </div>
-                <div className={styles.setting}>
-                  <label>最大行数</label>
-                  <input
-                    type="number"
-                    value={settings.query.maxRows}
-                    onChange={(e) =>
-                      updateSetting(
-                        'query',
-                        'maxRows',
-                        Number.parseInt(e.target.value, 10) || 10000
-                      )
-                    }
-                    min={100}
-                    max={1000000}
-                    step={1000}
-                  />
-                </div>
+              <div className={styles.setting}>
+                <label htmlFor="setting-editor-tab-size">タブサイズ</label>
+                <select
+                  id="setting-editor-tab-size"
+                  value={settings.editor.tabSize}
+                  onChange={(e) =>
+                    updateSetting('editor', 'tabSize', Number.parseInt(e.target.value, 10))
+                  }
+                >
+                  <option value={2}>2スペース</option>
+                  <option value={4}>4スペース</option>
+                  <option value={8}>8スペース</option>
+                </select>
               </div>
-            )}
-
-            {activeTab === 'appearance' && (
-              <div className={styles.settingsGroup}>
-                <div className={styles.setting}>
-                  <label>テーマ</label>
-                  <select
-                    value={settings.appearance.theme}
-                    onChange={(e) =>
-                      updateSetting('appearance', 'theme', e.target.value as 'dark' | 'light')
-                    }
-                  >
-                    <option value="dark">ダーク</option>
-                    <option value="light">ライト（準備中）</option>
-                  </select>
-                </div>
+              <div className={styles.setting}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={settings.editor.wordWrap}
+                    onChange={(e) => updateSetting('editor', 'wordWrap', e.target.checked)}
+                  />
+                  折り返し
+                </label>
               </div>
-            )}
+              <div className={styles.setting}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={settings.editor.minimap}
+                    onChange={(e) => updateSetting('editor', 'minimap', e.target.checked)}
+                  />
+                  ミニマップを表示
+                </label>
+              </div>
+            </div>
+          )}
 
-            {activeTab === 'shortcuts' && (
-              <div className={styles.settingsGroup}>
-                {SHORTCUT_DISPLAY.map(({ label, keys }) => (
+          {activeTab === 'query' && (
+            <div className={styles.settingsGroup}>
+              <div className={styles.setting}>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={settings.query.autoCommit}
+                    onChange={(e) => updateSetting('query', 'autoCommit', e.target.checked)}
+                  />
+                  自動コミット
+                </label>
+              </div>
+              <div className={styles.setting}>
+                <label htmlFor="setting-query-timeout-sec">クエリタイムアウト (秒)</label>
+                <input
+                  id="setting-query-timeout-sec"
+                  type="number"
+                  value={Math.round(settings.query.timeout / 1000)}
+                  onChange={(e) => {
+                    const parsed = Number.parseInt(e.target.value, 10);
+                    const sec = Number.isFinite(parsed) ? parsed : QUERY_TIMEOUT_DEFAULT_SEC;
+                    updateSetting('query', 'timeout', sec * 1000);
+                  }}
+                  min={QUERY_TIMEOUT_MIN_SEC}
+                  max={QUERY_TIMEOUT_MAX_SEC}
+                  step={60}
+                />
+              </div>
+              <div className={styles.setting}>
+                <label htmlFor="setting-query-max-rows">最大行数</label>
+                <input
+                  id="setting-query-max-rows"
+                  type="number"
+                  value={settings.query.maxRows}
+                  onChange={(e) =>
+                    updateSetting('query', 'maxRows', Number.parseInt(e.target.value, 10) || 10000)
+                  }
+                  min={100}
+                  max={1000000}
+                  step={1000}
+                />
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'appearance' && (
+            <div className={styles.settingsGroup}>
+              <div className={styles.setting}>
+                <label htmlFor="setting-appearance-theme">テーマ</label>
+                <select
+                  id="setting-appearance-theme"
+                  value={settings.appearance.theme}
+                  onChange={(e) =>
+                    updateSetting('appearance', 'theme', e.target.value as 'dark' | 'light')
+                  }
+                >
+                  <option value="dark">ダーク</option>
+                  <option value="light">ライト（準備中）</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'shortcuts' && (
+            <div className={styles.settingsGroup}>
+              {SHORTCUT_DISPLAY.map(({ label, keys }) => {
+                const inputId = `setting-shortcut-${label}`;
+                return (
                   <div key={label} className={styles.setting}>
-                    <label>{label}</label>
-                    <input type="text" value={keys} readOnly />
+                    <label htmlFor={inputId}>{label}</label>
+                    <input id={inputId} type="text" value={keys} readOnly />
                   </div>
-                ))}
-                <p className={styles.shortcutNote}>
-                  このバージョンではキーボードショートカットのカスタマイズはできません。
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-
-        <div className={styles.footer}>
-          <button onClick={handleReset} className={styles.resetButton}>
-            デフォルトに戻す
-          </button>
-          <div className={styles.actions}>
-            <button onClick={onClose}>キャンセル</button>
-            <button onClick={handleSave} className={styles.saveButton}>
-              保存
-            </button>
-          </div>
+                );
+              })}
+              <p className={styles.shortcutNote}>
+                このバージョンではキーボードショートカットのカスタマイズはできません。
+              </p>
+            </div>
+          )}
         </div>
       </div>
-    </div>
+
+      <div className={styles.footer}>
+        <button type="button" onClick={handleReset} className={styles.resetButton}>
+          デフォルトに戻す
+        </button>
+        <div className={styles.actions}>
+          <button type="button" onClick={onClose}>
+            キャンセル
+          </button>
+          <button type="button" onClick={handleSave} className={styles.saveButton}>
+            保存
+          </button>
+        </div>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/dialogs/sections/ConnectionFormSection.tsx
+++ b/frontend/src/components/dialogs/sections/ConnectionFormSection.tsx
@@ -32,13 +32,19 @@ export function ConnectionFormSection({
   return (
     <>
       <div className={styles.formGroup}>
-        <label>接続名</label>
-        <input type="text" value={config.name} onChange={(e) => onChange('name', e.target.value)} />
+        <label htmlFor="conn-name">接続名</label>
+        <input
+          id="conn-name"
+          type="text"
+          value={config.name}
+          onChange={(e) => onChange('name', e.target.value)}
+        />
       </div>
 
       <div className={styles.formGroup}>
-        <label>フォルダ (任意)</label>
+        <label htmlFor="conn-folder">フォルダ (任意)</label>
         <input
+          id="conn-folder"
           type="text"
           value={config.folderPath}
           onChange={(e) => onChange('folderPath', e.target.value)}
@@ -48,8 +54,9 @@ export function ConnectionFormSection({
 
       <div className={styles.formRow}>
         <div className={styles.formGroup}>
-          <label>サーバー</label>
+          <label htmlFor="conn-server">サーバー</label>
           <input
+            id="conn-server"
             type="text"
             value={config.server}
             onChange={(e) => onChange('server', e.target.value)}
@@ -58,8 +65,9 @@ export function ConnectionFormSection({
         </div>
 
         <div className={styles.formGroupSmall}>
-          <label>ポート</label>
+          <label htmlFor="conn-port">ポート</label>
           <input
+            id="conn-port"
             type="number"
             value={config.port}
             onChange={(e) =>
@@ -70,8 +78,9 @@ export function ConnectionFormSection({
       </div>
 
       <div className={styles.formGroup}>
-        <label>データベース</label>
+        <label htmlFor="conn-database">データベース</label>
         <input
+          id="conn-database"
           type="text"
           value={config.database}
           onChange={(e) => onChange('database', e.target.value)}
@@ -95,8 +104,9 @@ export function ConnectionFormSection({
       {!(dbType === 'sqlserver' && config.useWindowsAuth) && (
         <>
           <div className={styles.formGroup}>
-            <label>ユーザー名</label>
+            <label htmlFor="conn-username">ユーザー名</label>
             <input
+              id="conn-username"
               type="text"
               value={config.username}
               onChange={(e) => onChange('username', e.target.value)}
@@ -104,8 +114,9 @@ export function ConnectionFormSection({
           </div>
 
           <div className={styles.formGroup}>
-            <label>パスワード</label>
+            <label htmlFor="conn-password">パスワード</label>
             <input
+              id="conn-password"
               type="password"
               value={config.password}
               onChange={(e) => onChange('password', e.target.value)}

--- a/frontend/src/components/dialogs/sections/SshTunnelSection.tsx
+++ b/frontend/src/components/dialogs/sections/SshTunnelSection.tsx
@@ -27,8 +27,9 @@ export function SshTunnelSection({ ssh, onChange }: SshTunnelSectionProps) {
         <>
           <div className={styles.formRow}>
             <div className={styles.formGroup}>
-              <label>SSHホスト</label>
+              <label htmlFor="ssh-host">SSHホスト</label>
               <input
+                id="ssh-host"
                 type="text"
                 value={ssh.host}
                 onChange={(e) => onChange('host', e.target.value)}
@@ -36,8 +37,9 @@ export function SshTunnelSection({ ssh, onChange }: SshTunnelSectionProps) {
               />
             </div>
             <div className={styles.formGroupSmall}>
-              <label>SSHポート</label>
+              <label htmlFor="ssh-port">SSHポート</label>
               <input
+                id="ssh-port"
                 type="number"
                 value={ssh.port}
                 onChange={(e) => onChange('port', Number.parseInt(e.target.value, 10) || 22)}
@@ -45,16 +47,18 @@ export function SshTunnelSection({ ssh, onChange }: SshTunnelSectionProps) {
             </div>
           </div>
           <div className={styles.formGroup}>
-            <label>SSHユーザー名</label>
+            <label htmlFor="ssh-username">SSHユーザー名</label>
             <input
+              id="ssh-username"
               type="text"
               value={ssh.username}
               onChange={(e) => onChange('username', e.target.value)}
             />
           </div>
           <div className={styles.formGroup}>
-            <label>認証方式</label>
+            <label htmlFor="ssh-auth-type">認証方式</label>
             <select
+              id="ssh-auth-type"
               value={ssh.authType}
               onChange={(e) => {
                 if (isSshAuthType(e.target.value)) onChange('authType', e.target.value);
@@ -67,8 +71,9 @@ export function SshTunnelSection({ ssh, onChange }: SshTunnelSectionProps) {
           </div>
           {ssh.authType === 'password' && (
             <div className={styles.formGroup}>
-              <label>SSHパスワード</label>
+              <label htmlFor="ssh-password">SSHパスワード</label>
               <input
+                id="ssh-password"
                 type="password"
                 value={ssh.password}
                 onChange={(e) => onChange('password', e.target.value)}
@@ -78,9 +83,10 @@ export function SshTunnelSection({ ssh, onChange }: SshTunnelSectionProps) {
           {ssh.authType === 'privateKey' && (
             <>
               <div className={styles.formGroup}>
-                <label>秘密鍵のパス</label>
+                <label htmlFor="ssh-private-key-path">秘密鍵のパス</label>
                 <div className={styles.inputWithButton}>
                   <input
+                    id="ssh-private-key-path"
                     type="text"
                     value={ssh.privateKeyPath}
                     onChange={(e) => onChange('privateKeyPath', e.target.value)}
@@ -107,8 +113,9 @@ export function SshTunnelSection({ ssh, onChange }: SshTunnelSectionProps) {
                 </div>
               </div>
               <div className={styles.formGroup}>
-                <label>パスフレーズ（任意）</label>
+                <label htmlFor="ssh-key-passphrase">パスフレーズ（任意）</label>
                 <input
+                  id="ssh-key-passphrase"
                   type="password"
                   value={ssh.keyPassphrase}
                   onChange={(e) => onChange('keyPassphrase', e.target.value)}

--- a/frontend/src/components/export/ExportDialog.module.css
+++ b/frontend/src/components/export/ExportDialog.module.css
@@ -103,7 +103,7 @@
   margin-top: 16px;
 }
 
-.preview label {
+.preview .previewLabel {
   display: block;
   margin-bottom: 8px;
   color: var(--text-secondary);

--- a/frontend/src/components/export/ExportDialog.tsx
+++ b/frontend/src/components/export/ExportDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import { useConnectionStore } from '../../store/connectionStore';
 import type { ResultSet } from '../../types';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './ExportDialog.module.css';
 import { type ExportFormat, type ExportOptions, getExporter, isExportFormat } from './exporters';
 
@@ -88,108 +89,114 @@ export function ExportDialog({ isOpen, onClose, resultSet }: ExportDialogProps) 
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={onClose}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <h2>データエクスポート</h2>
-          <button className={styles.closeButton} onClick={onClose}>
-            {'\u2715'}
-          </button>
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.header}>
+        <h2>データエクスポート</h2>
+        <button type="button" className={styles.closeButton} onClick={onClose}>
+          {'✕'}
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.field}>
+          <label htmlFor="export-format">形式</label>
+          <select
+            id="export-format"
+            value={options.format}
+            onChange={(e) => {
+              if (!isExportFormat(e.target.value)) return;
+              setOptions({ ...options, format: e.target.value });
+            }}
+          >
+            <option value="csv">CSV</option>
+            <option value="json">JSON</option>
+            <option value="sql">SQL INSERT</option>
+            <option value="html">HTMLテーブル</option>
+            <option value="markdown">Markdown</option>
+          </select>
         </div>
 
-        <div className={styles.content}>
+        {options.format === 'csv' && (
           <div className={styles.field}>
-            <label>形式</label>
+            <label htmlFor="export-delimiter">区切り文字</label>
             <select
-              value={options.format}
-              onChange={(e) => {
-                if (!isExportFormat(e.target.value)) return;
-                setOptions({ ...options, format: e.target.value });
-              }}
+              id="export-delimiter"
+              value={options.delimiter}
+              onChange={(e) => setOptions({ ...options, delimiter: e.target.value })}
             >
-              <option value="csv">CSV</option>
-              <option value="json">JSON</option>
-              <option value="sql">SQL INSERT</option>
-              <option value="html">HTMLテーブル</option>
-              <option value="markdown">Markdown</option>
+              <option value=",">カンマ (,)</option>
+              <option value="	">タブ</option>
+              <option value=";">セミコロン (;)</option>
+              <option value="|">パイプ (|)</option>
             </select>
           </div>
+        )}
 
-          {options.format === 'csv' && (
-            <div className={styles.field}>
-              <label>区切り文字</label>
-              <select
-                value={options.delimiter}
-                onChange={(e) => setOptions({ ...options, delimiter: e.target.value })}
-              >
-                <option value=",">カンマ (,)</option>
-                <option value="	">タブ</option>
-                <option value=";">セミコロン (;)</option>
-                <option value="|">パイプ (|)</option>
-              </select>
-            </div>
-          )}
-
-          {(options.format === 'csv' ||
-            options.format === 'html' ||
-            options.format === 'markdown') && (
-            <div className={styles.field}>
-              <label>
-                <input
-                  type="checkbox"
-                  checked={options.includeHeaders}
-                  onChange={(e) => setOptions({ ...options, includeHeaders: e.target.checked })}
-                />
-                ヘッダーを含める
-              </label>
-            </div>
-          )}
-
-          {options.format === 'sql' && (
-            <div className={styles.field}>
-              <label>テーブル名</label>
-              <input
-                type="text"
-                value={options.tableName}
-                onChange={(e) => setOptions({ ...options, tableName: e.target.value })}
-              />
-            </div>
-          )}
-
+        {(options.format === 'csv' ||
+          options.format === 'html' ||
+          options.format === 'markdown') && (
           <div className={styles.field}>
-            <label>NULL値の表示</label>
+            <label>
+              <input
+                type="checkbox"
+                checked={options.includeHeaders}
+                onChange={(e) => setOptions({ ...options, includeHeaders: e.target.checked })}
+              />
+              ヘッダーを含める
+            </label>
+          </div>
+        )}
+
+        {options.format === 'sql' && (
+          <div className={styles.field}>
+            <label htmlFor="export-table-name">テーブル名</label>
             <input
+              id="export-table-name"
               type="text"
-              value={options.nullValue}
-              onChange={(e) => setOptions({ ...options, nullValue: e.target.value })}
+              value={options.tableName}
+              onChange={(e) => setOptions({ ...options, tableName: e.target.value })}
             />
           </div>
+        )}
 
-          <div className={styles.preview}>
-            <label>プレビュー</label>
-            <pre>
-              {(() => {
-                const text = generateExport();
-                return text.length > 1000 ? `${text.slice(0, 1000)}...` : text;
-              })()}
-            </pre>
-          </div>
+        <div className={styles.field}>
+          <label htmlFor="export-null-value">NULL値の表示</label>
+          <input
+            id="export-null-value"
+            type="text"
+            value={options.nullValue}
+            onChange={(e) => setOptions({ ...options, nullValue: e.target.value })}
+          />
         </div>
 
-        <div className={styles.footer}>
-          <span className={styles.rowCount}>
-            {resultSet ? `${resultSet.rows.length} 件` : 'データなし'}
-          </span>
-          <div className={styles.actions}>
-            <button onClick={handleCopy} className={styles.copyButton} title="Ctrl+C">
-              {copied ? 'コピーしました' : 'クリップボードにコピー'}
-            </button>
-            <button onClick={handleDownload} className={styles.downloadButton}>
-              ダウンロード
-            </button>
-          </div>
+        <div className={styles.preview}>
+          <span className={styles.previewLabel}>プレビュー</span>
+          <pre>
+            {(() => {
+              const text = generateExport();
+              return text.length > 1000 ? `${text.slice(0, 1000)}...` : text;
+            })()}
+          </pre>
         </div>
       </div>
-    </div>
+
+      <div className={styles.footer}>
+        <span className={styles.rowCount}>
+          {resultSet ? `${resultSet.rows.length} 件` : 'データなし'}
+        </span>
+        <div className={styles.actions}>
+          <button type="button" onClick={handleCopy} className={styles.copyButton} title="Ctrl+C">
+            {copied ? 'コピーしました' : 'クリップボードにコピー'}
+          </button>
+          <button type="button" onClick={handleDownload} className={styles.downloadButton}>
+            ダウンロード
+          </button>
+        </div>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/grid/ColumnResizer.tsx
+++ b/frontend/src/components/grid/ColumnResizer.tsx
@@ -84,6 +84,8 @@ function ColumnResizerInner({
   );
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: drag-resize handle; keyboard equivalent is column auto-fit via header double-click
+    // biome-ignore lint/a11y/useKeyWithClickEvents: stopClick only prevents bubbling on mouse drop; no semantic click action
     <div
       className={styles.columnResizer}
       onMouseDown={handleMouseDown}

--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -181,6 +181,7 @@ function GridTableInner({
   );
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: scroll/focus container for the inner table; keyboard navigation is handled at table-cell level
     <div
       ref={tableContainerRef}
       className={styles.tableContainer}
@@ -275,6 +276,7 @@ function GridTableInner({
             </tr>
           )}
         </thead>
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: cell-level keyboard navigation is handled by useKeyboardHandler at the container level */}
         <tbody
           className={styles.tbody}
           onClick={(e) => {

--- a/frontend/src/components/grid/GridTable.tsx
+++ b/frontend/src/components/grid/GridTable.tsx
@@ -380,12 +380,14 @@ function GridTableInner({
                     >
                       {isEditing ? (
                         <input
+                          ref={(el) => {
+                            el?.focus();
+                          }}
                           type="text"
                           className={styles.cellInput}
                           value={edit.editValue}
                           onChange={(e) => callbacks.onSetEditValue(e.target.value)}
                           onBlur={callbacks.onCommitEdit}
-                          autoFocus
                         />
                       ) : isNull ? (
                         'NULL'

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -552,7 +552,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
         )}
         <div className={progressClass} />
         {queryConnectionId && (
-          <button onClick={cancelCurrentQuery} className={styles.cancelButton}>
+          <button type="button" onClick={cancelCurrentQuery} className={styles.cancelButton}>
             キャンセル
           </button>
         )}
@@ -566,7 +566,7 @@ function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps =
     return (
       <div className={`${styles.message} ${styles.error}`}>
         <span>{parsed.summary}</span>
-        <button className={styles.errorDetailButton} onClick={reopenErrorDialog}>
+        <button type="button" className={styles.errorDetailButton} onClick={reopenErrorDialog}>
           詳細を表示
         </button>
         <Suspense fallback={null}>

--- a/frontend/src/components/grid/ResultTabs.tsx
+++ b/frontend/src/components/grid/ResultTabs.tsx
@@ -22,6 +22,7 @@ function ResultTabsInner({ results, activeIndex, onSelect }: ResultTabsProps) {
         const key = `${index}-${result.statement}`;
         return (
           <button
+            type="button"
             key={key}
             className={`${styles.resultTab} ${activeIndex === index ? styles.activeResultTab : ''}`}
             onClick={() => onSelect(index)}

--- a/frontend/src/components/grid/ValueEditorDialog.tsx
+++ b/frontend/src/components/grid/ValueEditorDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DialogOverlay } from '../common/DialogOverlay';
 import styles from './ValueEditorDialog.module.css';
 
 // JSON解析結果の型
@@ -75,54 +76,56 @@ export function ValueEditorDialog({
   if (!isOpen) return null;
 
   return (
-    <div className={styles.overlay} onClick={onCancel}>
-      <div className={styles.dialog} onClick={(e) => e.stopPropagation()}>
-        <div className={styles.header}>
-          <h2>{columnName}</h2>
-          <button type="button" className={styles.closeButton} onClick={onCancel}>
-            &times;
-          </button>
-        </div>
-        <div className={styles.content}>
-          <textarea
-            ref={textareaRef}
-            className={styles.textarea}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="値を入力..."
-            spellCheck={false}
-          />
-          <div className={styles.info}>
-            <span>{value.length} 文字</span>
-            {isValidJson && <span className={styles.jsonBadge}>JSON</span>}
-          </div>
-        </div>
-        <div className={styles.footer}>
-          <div className={styles.footerLeft}>
-            <button type="button" className={styles.button} onClick={handleSetNull}>
-              NULL
-            </button>
-            {isValidJson && (
-              <button type="button" className={styles.button} onClick={formatAsJson}>
-                JSON整形
-              </button>
-            )}
-          </div>
-          <div className={styles.footerRight}>
-            <button type="button" className={styles.button} onClick={onCancel}>
-              キャンセル
-            </button>
-            <button
-              type="button"
-              className={`${styles.button} ${styles.buttonPrimary}`}
-              onClick={handleSave}
-            >
-              保存 (Ctrl+Enter)
-            </button>
-          </div>
+    <DialogOverlay
+      onClose={onCancel}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+    >
+      <div className={styles.header}>
+        <h2>{columnName}</h2>
+        <button type="button" className={styles.closeButton} onClick={onCancel}>
+          &times;
+        </button>
+      </div>
+      <div className={styles.content}>
+        <textarea
+          ref={textareaRef}
+          className={styles.textarea}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="値を入力..."
+          spellCheck={false}
+        />
+        <div className={styles.info}>
+          <span>{value.length} 文字</span>
+          {isValidJson && <span className={styles.jsonBadge}>JSON</span>}
         </div>
       </div>
-    </div>
+      <div className={styles.footer}>
+        <div className={styles.footerLeft}>
+          <button type="button" className={styles.button} onClick={handleSetNull}>
+            NULL
+          </button>
+          {isValidJson && (
+            <button type="button" className={styles.button} onClick={formatAsJson}>
+              JSON整形
+            </button>
+          )}
+        </div>
+        <div className={styles.footerRight}>
+          <button type="button" className={styles.button} onClick={onCancel}>
+            キャンセル
+          </button>
+          <button
+            type="button"
+            className={`${styles.button} ${styles.buttonPrimary}`}
+            onClick={handleSave}
+          >
+            保存 (Ctrl+Enter)
+          </button>
+        </div>
+      </div>
+    </DialogOverlay>
   );
 }

--- a/frontend/src/components/history/HistoryItem.tsx
+++ b/frontend/src/components/history/HistoryItem.tsx
@@ -60,6 +60,7 @@ export const HistoryItem = memo(function HistoryItem({ item }: HistoryItemProps)
         <span className={styles.timestamp}>{formatTimestamp(item.timestamp)}</span>
         <span className={styles.duration}>{item.executionTimeMs.toFixed(0)}ms</span>
         <button
+          type="button"
           className={`${styles.favoriteButton} ${item.isFavorite ? styles.active : ''}`}
           onClick={(e) => {
             e.stopPropagation();
@@ -70,6 +71,7 @@ export const HistoryItem = memo(function HistoryItem({ item }: HistoryItemProps)
           {item.isFavorite ? '★' : '☆'}
         </button>
         <button
+          type="button"
           className={styles.deleteButton}
           onClick={(e) => {
             e.stopPropagation();

--- a/frontend/src/components/history/HistoryItem.tsx
+++ b/frontend/src/components/history/HistoryItem.tsx
@@ -49,11 +49,28 @@ export const HistoryItem = memo(function HistoryItem({ item }: HistoryItemProps)
     }
   }, [handleClick, executeQuery, item.connectionId]);
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleDoubleClick();
+      } else if (e.key === ' ') {
+        e.preventDefault();
+        handleClick();
+      }
+    },
+    [handleClick, handleDoubleClick]
+  );
+
   return (
+    // biome-ignore lint/a11y/useSemanticElements: contains nested favorite/delete buttons; cannot use a real <button>
     <div
       className={`${styles.container} ${item.success ? '' : styles.error}`}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
     >
       <div className={styles.header}>
         <span className={styles.status}>{item.success ? '✓' : '✗'}</span>

--- a/frontend/src/components/history/QueryHistory.tsx
+++ b/frontend/src/components/history/QueryHistory.tsx
@@ -46,6 +46,7 @@ export function QueryHistory() {
           className={styles.searchInput}
         />
         <button
+          type="button"
           onClick={clearHistory}
           className={styles.clearButton}
           title="履歴をクリア（お気に入りは保持）"

--- a/frontend/src/components/layout/BottomPanel.tsx
+++ b/frontend/src/components/layout/BottomPanel.tsx
@@ -35,19 +35,26 @@ export function BottomPanel({ height, onClose }: BottomPanelProps) {
     <div className={styles.container} style={{ height }}>
       <div className={styles.tabs}>
         <button
+          type="button"
           className={`${styles.tab} ${activeTab === 'results' ? styles.active : ''}`}
           onClick={() => setActiveTab('results')}
         >
           結果
         </button>
         <button
+          type="button"
           className={`${styles.tab} ${activeTab === 'history' ? styles.active : ''}`}
           onClick={() => setActiveTab('history')}
         >
           履歴
         </button>
         <div className={styles.tabSpacer} />
-        <button className={styles.closeButton} onClick={onClose} title="パネルを閉じる">
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={onClose}
+          title="パネルを閉じる"
+        >
           {'\u00D7'}
         </button>
       </div>

--- a/frontend/src/components/layout/LeftPanel.tsx
+++ b/frontend/src/components/layout/LeftPanel.tsx
@@ -17,7 +17,10 @@ const DatabaseIcon = (
     fill="none"
     stroke="currentColor"
     strokeWidth="1.5"
+    role="img"
+    aria-labelledby="left-panel-db-icon-title"
   >
+    <title id="left-panel-db-icon-title">データベース</title>
     <ellipse cx="8" cy="4" rx="6" ry="2.5" />
     <path d="M2 4v8c0 1.38 2.69 2.5 6 2.5s6-1.12 6-2.5V4" />
     <path d="M2 8c0 1.38 2.69 2.5 6 2.5s6-1.12 6-2.5" />

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -294,7 +294,7 @@ export function MainLayout() {
       <header className={styles.toolbar}>
         {/* Connection */}
         <div className={styles.toolbarGroup}>
-          <button onClick={openConnectionDialog} title="新規接続">
+          <button type="button" onClick={openConnectionDialog} title="新規接続">
             <ToolbarIcons.Database />
             <span>接続</span>
           </button>
@@ -304,6 +304,7 @@ export function MainLayout() {
 
         <div className={styles.toolbarGroup}>
           <button
+            type="button"
             onClick={isExecuting ? handleCancel : handleExecute}
             disabled={isRunButtonDisabled(activeQuery, activeQueryConnectionId)}
             title={isExecuting ? '停止 (Escape)' : '実行 (F9)'}
@@ -316,6 +317,7 @@ export function MainLayout() {
 
         <div className={styles.toolbarGroup}>
           <button
+            type="button"
             className={styles.iconButton}
             onClick={handleFormat}
             disabled={!activeQuery?.content || isDataView}
@@ -331,6 +333,7 @@ export function MainLayout() {
         {/* View toggles */}
         <div className={styles.toolbarGroup}>
           <button
+            type="button"
             className={styles.iconButton}
             onClick={() => setIsLeftPanelVisible(!isLeftPanelVisible)}
             title="データベースエクスプローラーを切り替え"
@@ -338,6 +341,7 @@ export function MainLayout() {
             <ToolbarIcons.Sidebar />
           </button>
           <button
+            type="button"
             className={styles.iconButton}
             onClick={() => setIsBottomPanelVisible(!isBottomPanelVisible)}
             disabled={isDataView}
@@ -352,13 +356,19 @@ export function MainLayout() {
         {/* Search and Settings */}
         <div className={styles.toolbarGroup}>
           <button
+            type="button"
             className={styles.iconButton}
             onClick={openSearchDialog}
             title="検索 (Ctrl+Shift+P)"
           >
             <ToolbarIcons.Search />
           </button>
-          <button className={styles.iconButton} onClick={openSettingsDialog} title="設定 (Ctrl+,)">
+          <button
+            type="button"
+            className={styles.iconButton}
+            onClick={openSettingsDialog}
+            title="設定 (Ctrl+,)"
+          >
             <ToolbarIcons.Settings />
           </button>
         </div>

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -378,6 +378,7 @@ export function MainLayout() {
         {isLeftPanelVisible && (
           <Suspense fallback={<LoadingFallback />}>
             <LeftPanel width={leftPanelWidth} />
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: drag-only resizer; keyboard panel sizing is not required */}
             <div
               className={styles.verticalResizer}
               onMouseDown={(e) => {
@@ -406,6 +407,7 @@ export function MainLayout() {
 
           {shouldShowBottomPanel && (
             <Suspense fallback={<LoadingFallback />}>
+              {/* biome-ignore lint/a11y/noStaticElementInteractions: drag-only resizer; keyboard panel sizing is not required */}
               <div
                 className={styles.horizontalResizer}
                 onMouseDown={(e) => {

--- a/frontend/src/components/table/TableViewer.tsx
+++ b/frontend/src/components/table/TableViewer.tsx
@@ -236,17 +236,33 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
       {/* Toolbar */}
       <div className={styles.toolbar}>
         <div className={styles.toolbarLeft}>
-          <button className={styles.toolbarButton} title="行を追加" disabled={activeTab !== 'data'}>
+          <button
+            type="button"
+            className={styles.toolbarButton}
+            title="行を追加"
+            disabled={activeTab !== 'data'}
+          >
             <span className={styles.icon}>+</span>
           </button>
-          <button className={styles.toolbarButton} title="行を削除" disabled={activeTab !== 'data'}>
+          <button
+            type="button"
+            className={styles.toolbarButton}
+            title="行を削除"
+            disabled={activeTab !== 'data'}
+          >
             <span className={styles.icon}>−</span>
           </button>
-          <button className={styles.toolbarButton} title="行を複製" disabled={activeTab !== 'data'}>
+          <button
+            type="button"
+            className={styles.toolbarButton}
+            title="行を複製"
+            disabled={activeTab !== 'data'}
+          >
             <span className={styles.icon}>⎘</span>
           </button>
           <div className={styles.toolbarDivider} />
           <button
+            type="button"
             className={`${styles.toolbarButton} ${showLogicalNames ? styles.active : ''}`}
             title="論理名を表示"
             onClick={() => setShowLogicalNames(!showLogicalNames)}
@@ -254,14 +270,14 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
             <span className={styles.icon}>A/あ</span>
           </button>
           <div className={styles.toolbarDivider} />
-          <button className={styles.toolbarButton} title="フィルタ">
+          <button type="button" className={styles.toolbarButton} title="フィルタ">
             <span className={styles.icon}>🔍</span>
           </button>
-          <button className={styles.toolbarButton} title="条件">
+          <button type="button" className={styles.toolbarButton} title="条件">
             <span className={styles.icon}>⚡</span>
           </button>
           <div className={styles.toolbarDivider} />
-          <button className={styles.toolbarButton} title="マーカー">
+          <button type="button" className={styles.toolbarButton} title="マーカー">
             <span className={styles.icon}>🔖</span>
           </button>
         </div>
@@ -270,7 +286,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
           {resultSet && (
             <span className={styles.rowCount}>{resultSet.rows.length.toLocaleString()} 件</span>
           )}
-          <button className={styles.toolbarButton} title="更新" onClick={loadData}>
+          <button type="button" className={styles.toolbarButton} title="更新" onClick={loadData}>
             <span className={styles.icon}>↻</span>
           </button>
         </div>
@@ -280,6 +296,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
       <div className={styles.tabBar}>
         {tabs.map((tab) => (
           <button
+            type="button"
             key={tab.id}
             className={`${styles.tab} ${activeTab === tab.id ? styles.activeTab : ''}`}
             onClick={() => setActiveTab(tab.id)}

--- a/frontend/src/components/table/tabs/SourceTab.tsx
+++ b/frontend/src/components/table/tabs/SourceTab.tsx
@@ -17,7 +17,7 @@ export function SourceTab({ ddl }: SourceTabProps) {
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <div className={styles.filterBar}>
-        <button className={styles.filterButton} onClick={handleCopy}>
+        <button type="button" className={styles.filterButton} onClick={handleCopy}>
           Copy DDL
         </button>
       </div>

--- a/frontend/src/components/tree/ContextMenu.tsx
+++ b/frontend/src/components/tree/ContextMenu.tsx
@@ -81,6 +81,7 @@ export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
           <div key={`divider-${index}`} className={styles.divider} />
         ) : (
           <button
+            type="button"
             key={item.label}
             className={`${styles.item} ${item.disabled ? styles.disabled : ''}`}
             onClick={() => handleItemClick(item)}

--- a/frontend/src/components/tree/FolderNode.tsx
+++ b/frontend/src/components/tree/FolderNode.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, memo, type ReactNode } from 'react';
+import { memo, type ReactNode } from 'react';
 import styles from './ObjectTree.module.css';
 
 interface FolderNodeProps {
@@ -17,21 +17,13 @@ function FolderNodeComponent({
   children,
 }: FolderNodeProps) {
   const toggle = () => onToggle(folderPath);
-  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      toggle();
-    }
-  };
 
   return (
     <div data-testid="folder-node" data-folder-path={folderPath}>
-      <div
+      <button
+        type="button"
         className={styles.folderHeader}
         onClick={toggle}
-        onKeyDown={onKeyDown}
-        role="button"
-        tabIndex={0}
         aria-expanded={expanded}
         title={folderPath}
       >
@@ -41,7 +33,7 @@ function FolderNodeComponent({
         <span className={styles.folderIcon}>📁</span>
         <span className={styles.folderName}>{folderPath}</span>
         <span className={styles.folderCount}>({profileCount})</span>
-      </div>
+      </button>
       {expanded && <div className={styles.folderBody}>{children}</div>}
     </div>
   );

--- a/frontend/src/components/tree/ObjectTree.module.css
+++ b/frontend/src/components/tree/ObjectTree.module.css
@@ -46,12 +46,16 @@
   display: flex;
   align-items: center;
   gap: 6px;
+  width: 100%;
   padding: 4px 10px;
   cursor: pointer;
   color: var(--text-secondary, #bbbbbb);
   font-size: 12px;
   font-weight: 500;
+  font-family: inherit;
+  text-align: left;
   background-color: var(--bg-secondary, #2b2b2b);
+  border: none;
   border-bottom: 1px solid var(--border-color, #3c3f41);
   user-select: none;
 }

--- a/frontend/src/components/tree/ObjectTree.module.css
+++ b/frontend/src/components/tree/ObjectTree.module.css
@@ -107,6 +107,10 @@
   border-bottom: 1px solid var(--border-color, #3c3f41);
   color: var(--text-secondary, #808080);
   font-size: 13px;
+  width: 100%;
+  background: none;
+  font-family: inherit;
+  text-align: left;
   /* off-screen スキップで大量プロファイル時のスクロール負荷を削減 */
   content-visibility: auto;
   contain-intrinsic-size: auto 30px;

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -254,10 +254,11 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
               </div>
             </div>
             <div className={styles.dialogActions}>
-              <button className={styles.cancelButton} onClick={handleCancel}>
+              <button type="button" className={styles.cancelButton} onClick={handleCancel}>
                 {isConnecting ? '接続中止' : 'キャンセル'}
               </button>
               <button
+                type="button"
                 className={`${styles.connectButton} ${confirmingProfile.isProduction ? styles.productionButton : ''}`}
                 onClick={handleConfirm}
                 disabled={isConnecting}

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -12,6 +12,7 @@ import {
 import { groupProfilesByFolder, type ProfileGroup } from '../../utils/groupProfilesByFolder';
 import { pruneCollapsedFolders } from '../../utils/pruneCollapsedFolders';
 import type { ExpandableType } from '../../utils/treeNode';
+import { DialogOverlay } from '../common/DialogOverlay';
 import { FolderNode } from './FolderNode';
 import styles from './ObjectTree.module.css';
 import { ProfileNode } from './ProfileNode';
@@ -227,51 +228,46 @@ export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
 
       {/* Connection confirmation dialog */}
       {confirmingProfile && (
-        <div className={styles.overlay} onClick={handleCancel}>
-          <div
-            className={`${styles.dialog} ${confirmingProfile.isProduction ? styles.productionDialog : ''}`}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className={styles.dialogHeader}>
-              {confirmingProfile.isProduction && <span className={styles.warningIcon}>⚠</span>}
-              <span>データベースに接続</span>
-            </div>
-            <div className={styles.dialogBody}>
-              {confirmingProfile.isProduction ? (
-                <p className={styles.warningText}>
-                  <strong>本番</strong>データベースに接続しようとしています。
-                  <br />
-                  続行しますか？
-                </p>
-              ) : (
-                <p>
-                  <strong>{confirmingProfile.name}</strong>に接続しますか？
-                </p>
-              )}
-              <div className={styles.profileDetails}>
-                <div>サーバー: {confirmingProfile.server}</div>
-                <div>データベース: {confirmingProfile.database}</div>
-              </div>
-            </div>
-            <div className={styles.dialogActions}>
-              <button type="button" className={styles.cancelButton} onClick={handleCancel}>
-                {isConnecting ? '接続中止' : 'キャンセル'}
-              </button>
-              <button
-                type="button"
-                className={`${styles.connectButton} ${confirmingProfile.isProduction ? styles.productionButton : ''}`}
-                onClick={handleConfirm}
-                disabled={isConnecting}
-              >
-                {isConnecting
-                  ? '接続中...'
-                  : confirmingProfile.isProduction
-                    ? '本番に接続'
-                    : '接続'}
-              </button>
+        <DialogOverlay
+          onClose={handleCancel}
+          overlayClassName={styles.overlay}
+          dialogClassName={`${styles.dialog} ${confirmingProfile.isProduction ? styles.productionDialog : ''}`}
+        >
+          <div className={styles.dialogHeader}>
+            {confirmingProfile.isProduction && <span className={styles.warningIcon}>⚠</span>}
+            <span>データベースに接続</span>
+          </div>
+          <div className={styles.dialogBody}>
+            {confirmingProfile.isProduction ? (
+              <p className={styles.warningText}>
+                <strong>本番</strong>データベースに接続しようとしています。
+                <br />
+                続行しますか？
+              </p>
+            ) : (
+              <p>
+                <strong>{confirmingProfile.name}</strong>に接続しますか？
+              </p>
+            )}
+            <div className={styles.profileDetails}>
+              <div>サーバー: {confirmingProfile.server}</div>
+              <div>データベース: {confirmingProfile.database}</div>
             </div>
           </div>
-        </div>
+          <div className={styles.dialogActions}>
+            <button type="button" className={styles.cancelButton} onClick={handleCancel}>
+              {isConnecting ? '接続中止' : 'キャンセル'}
+            </button>
+            <button
+              type="button"
+              className={`${styles.connectButton} ${confirmingProfile.isProduction ? styles.productionButton : ''}`}
+              onClick={handleConfirm}
+              disabled={isConnecting}
+            >
+              {isConnecting ? '接続中...' : confirmingProfile.isProduction ? '本番に接続' : '接続'}
+            </button>
+          </div>
+        </DialogOverlay>
       )}
     </div>
   );

--- a/frontend/src/components/tree/ProfileNode.tsx
+++ b/frontend/src/components/tree/ProfileNode.tsx
@@ -34,7 +34,8 @@ function ProfileNodeComponent({
   }
 
   return (
-    <div
+    <button
+      type="button"
       {...identityProps}
       className={`${styles.profileItem} ${profile.isProduction ? styles.production : ''}`}
       onClick={() => onProfileClick(profile)}
@@ -43,7 +44,7 @@ function ProfileNodeComponent({
       <span className={styles.profileIcon}>🗄</span>
       <span className={styles.profileName}>{profile.name}</span>
       <span className={styles.profileStatus}>未接続</span>
-    </div>
+    </button>
   );
 }
 

--- a/frontend/src/components/tree/TreeNode.module.css
+++ b/frontend/src/components/tree/TreeNode.module.css
@@ -39,9 +39,13 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  padding: 0;
   color: var(--text-secondary);
   font-size: 8px;
+  background: transparent;
+  border: none;
   border-radius: 3px;
+  cursor: pointer;
   transition: color 0.1s ease;
 }
 

--- a/frontend/src/components/tree/TreeNode.tsx
+++ b/frontend/src/components/tree/TreeNode.tsx
@@ -103,6 +103,13 @@ export const TreeNode = memo(function TreeNode({
     onContextMenu?.(e, node);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
   const nodeClasses = `${styles.node}${isLoading ? ` ${styles.loading}` : ''}${isSelected ? ` ${styles.selected}` : ''}`;
 
   const envClass = node.type === 'database' && environment ? ENV_NAME_CLASS[environment] : '';
@@ -123,6 +130,11 @@ export const TreeNode = memo(function TreeNode({
         style={nodeStyle}
         onClick={handleClick}
         onContextMenu={handleContextMenu}
+        onKeyDown={handleKeyDown}
+        role="treeitem"
+        aria-expanded={canExpand ? isExpanded : undefined}
+        aria-selected={isSelected}
+        tabIndex={0}
       >
         <button
           type="button"

--- a/frontend/src/components/tree/TreeNode.tsx
+++ b/frontend/src/components/tree/TreeNode.tsx
@@ -124,11 +124,12 @@ export const TreeNode = memo(function TreeNode({
         onClick={handleClick}
         onContextMenu={handleContextMenu}
       >
-        <span
+        <button
+          type="button"
           className={styles.expander}
           onClick={handleExpanderClick}
-          role="button"
           tabIndex={-1}
+          aria-label={isExpanded ? 'Collapse' : 'Expand'}
           style={canExpand ? EXPANDER_VISIBLE : EXPANDER_HIDDEN}
         >
           {isLoading ? (
@@ -138,7 +139,7 @@ export const TreeNode = memo(function TreeNode({
           ) : (
             <TreeIcons.ChevronRight />
           )}
-        </span>
+        </button>
         <span className={`${styles.icon} ${getIconClass(node.type)}`}>
           {getIcon(node.type, isExpanded)}
         </span>

--- a/frontend/src/tests/grid/ColumnResizer.test.tsx
+++ b/frontend/src/tests/grid/ColumnResizer.test.tsx
@@ -39,6 +39,7 @@ describe('ColumnResizer', () => {
   it('ダブルクリックイベントは親に伝播しない', () => {
     const parentDblClick = vi.fn();
     const { container } = render(
+      // biome-ignore lint/a11y/noStaticElementInteractions: test wrapper to capture event bubbling
       <div onDoubleClick={parentDblClick}>
         <ColumnResizer columnId="col_a" currentWidth={100} onResizeCommit={vi.fn()} />
       </div>
@@ -54,6 +55,8 @@ describe('ColumnResizer', () => {
   it('クリックイベントは親に伝播しない', () => {
     const parentClick = vi.fn();
     const { container } = render(
+      // biome-ignore lint/a11y/noStaticElementInteractions: test wrapper to capture event bubbling
+      // biome-ignore lint/a11y/useKeyWithClickEvents: test wrapper; only verifies click bubbling
       <div onClick={parentClick}>
         <ColumnResizer columnId="col_a" currentWidth={100} onResizeCommit={vi.fn()} />
       </div>


### PR DESCRIPTION
- SearchDialog: 検索結果 div を button 化 (CSS reset 同期)
- ProfileNode: div を button 化 (CSS reset 同期)
- HistoryItem: role="button" + onKeyDown (内部 nested button のため biome-ignore useSemanticElements)
- TreeNode: role="treeitem" + aria-expanded/aria-selected + tabIndex/onKeyDown (WAI-ARIA tree pattern)
- ValueEditorDialog: DialogOverlay 移行
- ObjectTree: 接続確認 dialog を DialogOverlay 移行
- ColumnResizer / GridTable / MainLayout (resizer): drag-only 用途で biome-ignore
- ColumnResizer.test: テストラッパー div に biome-ignore
- biome.json 修正

Closes #482