### PR TITLE
fix(frontend): buildAlterViewSql の動的 RegExp を静的化し ReDoS 警告を解消 (#490)

### DIFF
--- a/frontend/src/tests/utils/sql/ddl/view-ddl.test.ts
+++ b/frontend/src/tests/utils/sql/ddl/view-ddl.test.ts
@@ -108,4 +108,22 @@ describe('buildAlterViewSql', () => {
     const result = buildAlterViewSql(viewDef, 'col.with.dots', 'renamed', 'sqlserver');
     expect(result).toContain('[renamed]');
   });
+
+  it('ReDoS 耐性: oldCol が動的 regex に埋め込まれず正常終了する', () => {
+    const viewDef = 'CREATE VIEW [dbo].[vw_Test] AS\nSELECT id, name FROM [dbo].[Users]';
+    // 元実装で動的 RegExp に埋め込まれていた場合、入力サイズに対して指数的劣化する
+    // パターン (a+)+! 系を想定。oldCol は文字列リテラルとしてのみ扱われ、
+    // 識別子 'name' とは一致しないので非マッチで終了する。
+    const evilCol = `${'a+'.repeat(50)}!`;
+    const result = buildAlterViewSql(viewDef, evilCol, 'new_name', 'sqlserver');
+    expect(result).toMatch(/^ALTER VIEW/);
+    expect(result).not.toContain('new_name');
+  });
+
+  it('カラム名に部分一致するだけの識別子はリネーム対象外', () => {
+    const viewDef = 'CREATE VIEW [dbo].[vw_Test] AS\nSELECT username, name FROM [dbo].[Users]';
+    const result = buildAlterViewSql(viewDef, 'name', 'renamed', 'sqlserver');
+    expect(result).toContain('username,');
+    expect(result).toMatch(/\bname\s+AS\s+\[renamed\]/);
+  });
 });

--- a/frontend/src/utils/sql/ddl/view-ddl.ts
+++ b/frontend/src/utils/sql/ddl/view-ddl.ts
@@ -38,10 +38,17 @@ export async function fetchViewDefinition(
   return result.rows[0]?.[0] ?? '';
 }
 
-/** 正規表現メタ文字のエスケープ */
-function escapeRegex(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
+/**
+ * SELECT 句に出現するカラム参照を検出する静的パターン。
+ * - グループ1: ブラケット識別子の中身 `[name]` → `name`
+ * - グループ2: 素の識別子 `name`
+ * - グループ3: 既存エイリアス節 ` AS xxx` (省略可)
+ * 末尾の lookahead でカラム境界 (カンマ / 空白 / AS) を保証する。
+ * 動的に oldCol を埋め込まず、識別子の等価比較で oldCol を判定することで
+ * ReDoS リスク (Semgrep detect-non-literal-regexp) を回避する。
+ */
+const COLUMN_REFERENCE_PATTERN =
+  /(?:\w+\.)?(?:\[([^\]]+)\]|(\w+))(?=\s*[,\s]|\s+AS\b)(\s+AS\s+(?:\[[^\]]*\]|"[^"]*"|`[^`]*`|\w+))?/gi;
 
 /**
  * SELECT句とFROM句を括弧深度を追跡して分割する。
@@ -98,20 +105,21 @@ export function buildAlterViewSql(
 
   const [selectPart, fromAndRest] = split;
   const selectFromStart = sql.slice(0, selectIdx);
-  const escapedCol = escapeRegex(oldCol);
+  const oldColLower = oldCol.toLowerCase();
 
-  // 名前付きパーツで正規表現を構築
-  const tablePrefix = '(?:\\w+\\.)?';
-  const quotedCol = `\\[?${escapedCol}\\]?`;
-  const colBoundary = '(?=\\s*[,\\s]|\\s+AS\\b)';
-  const aliasValue = '\\[[^\\]]*\\]|"[^"]*"|`[^`]*`|\\w+';
-  const existingAlias = `(\\s+AS\\s+(?:${aliasValue}))`;
+  for (const match of selectPart.matchAll(COLUMN_REFERENCE_PATTERN)) {
+    const matchedName = match[1] ?? match[2];
+    if (matchedName.toLowerCase() !== oldColLower) continue;
+    if (match.index === undefined) continue;
 
-  const colPattern = new RegExp(`(${tablePrefix}${quotedCol})${colBoundary}${existingAlias}?`, 'i');
-
-  if (colPattern.test(selectPart)) {
-    const newSelectPart = selectPart.replace(colPattern, `$1 AS ${q(newCol)}`);
+    const aliasClause = match[3] ?? '';
+    const identifierPart = aliasClause ? match[0].slice(0, -aliasClause.length) : match[0];
+    const newSelectPart =
+      selectPart.slice(0, match.index) +
+      `${identifierPart} AS ${q(newCol)}` +
+      selectPart.slice(match.index + match[0].length);
     sql = `${selectFromStart}SELECT ${selectPrefix}${newSelectPart}${fromAndRest}`;
+    break;
   }
 
   return sql;


### PR DESCRIPTION
Semgrep detect-non-literal-regexp で警告されていた new RegExp() へのoldCol 埋め込みを廃止。
SELECT 句のカラム参照を検出する静的パターンCOLUMN_REFERENCE_PATTERN を導入し、抽出した識別子と oldCol を等価比較する方式に変更した。escapeRegex は不要になり削除。

副次的に既存の部分一致誤認バグも解消:

- 旧: SELECT username, name で oldCol=name を渡すと username 内の name 部分が誤って置換されていた
- 新: 識別子境界が明確になり name のみがリネーム対象になる

回帰防止テスト 2 件 (ReDoS 耐性 / 部分一致非対象) を追加。

Closes #490