### PR TITLE
feat(frontend): ConnectionProvider + QueryProvider を bridge から抽出 (#518 #519)

### DIFF
--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -9,6 +9,8 @@ import type {
 import { DEFAULT_PAGE } from '../utils/erDiagramConstants';
 import type { ERDiagramModel } from '../utils/erDiagramParser';
 import { log } from '../utils/logger';
+import { connectionProvider, queryProvider } from './providers';
+import type { ConnectionInfo, TestConnectionInfo } from './providers/connection';
 import type { ConnectResultResponse } from './schemas';
 import * as S from './schemas';
 
@@ -140,6 +142,11 @@ function toCardinality(value: string): Cardinality {
   return '1:N';
 }
 
+// Bridge は個別 provider への委譲ラッパ (旧 import 互換用)。完全移行は #527 で本クラス削除予定。
+// - Connection methods (#518 で connectionProvider に移管)
+// - Query methods (#519 で queryProvider に移管: executeQuery / executeQueryPaginated / getRowCount /
+//   cancelQuery / lintSql / async query 5 件 / filterResultSet / getExecutionPlan)
+// - Schema / Transaction / Export / Settings / Search / IO / SQLBuilder: 未移管 (#520+)
 class Bridge {
   private async call<T>(
     method: string,
@@ -212,65 +219,30 @@ class Bridge {
     throw new Error('Backend not available');
   }
 
-  // Connection methods
-  async connectAsync(connectionInfo: {
-    server: string;
-    port?: number;
-    database: string;
-    username?: string;
-    password?: string;
-    useWindowsAuth: boolean;
-    connectionTimeout?: number;
-    dbType?: 'sqlserver' | 'postgresql' | 'mysql';
-    ssh?: {
-      enabled: boolean;
-      host: string;
-      port: number;
-      username: string;
-      authType: string;
-      password?: string;
-      privateKeyPath?: string;
-      keyPassphrase?: string;
-    };
-  }): Promise<{ requestId: string }> {
-    return this.call('connectAsync', connectionInfo, S.connectAsync);
+  // Connection methods (→ connectionProvider)
+  async connectAsync(connectionInfo: ConnectionInfo): Promise<{ requestId: string }> {
+    return connectionProvider.connectAsync(connectionInfo);
   }
 
   async getConnectResult(requestId: string): Promise<ConnectResultResponse> {
-    return this.call('getConnectResult', { requestId }, S.connectResult);
+    return connectionProvider.getConnectResult(requestId);
   }
 
   async cancelConnect(requestId: string): Promise<void> {
-    return this.call('cancelConnect', { requestId }, S.cancelConnect);
+    return connectionProvider.cancelConnect(requestId);
   }
 
   async disconnect(connectionId: string): Promise<void> {
-    return this.call('disconnect', { connectionId }, S.disconnect);
+    return connectionProvider.disconnect(connectionId);
   }
 
-  async testConnection(connectionInfo: {
-    server: string;
-    port?: number;
-    database: string;
-    username?: string;
-    password?: string;
-    useWindowsAuth: boolean;
-    dbType?: 'sqlserver' | 'postgresql' | 'mysql';
-    ssh?: {
-      enabled: boolean;
-      host: string;
-      port: number;
-      username: string;
-      authType: string;
-      password?: string;
-      privateKeyPath?: string;
-      keyPassphrase?: string;
-    };
-  }): Promise<{ success: boolean; message: string }> {
-    return this.call('testConnection', connectionInfo, S.testConnection);
+  async testConnection(
+    connectionInfo: TestConnectionInfo
+  ): Promise<{ success: boolean; message: string }> {
+    return connectionProvider.testConnection(connectionInfo);
   }
 
-  // Query methods
+  // Query methods (→ queryProvider)
   async executeQuery(
     connectionId: string,
     sql: string,
@@ -296,7 +268,7 @@ class Bridge {
         }[];
       }
   > {
-    return this.call('executeQuery', { connectionId, sql, useCache }, S.executeQuery);
+    return queryProvider.executeQuery(connectionId, sql, useCache);
   }
 
   async executeQueryPaginated(
@@ -311,25 +283,15 @@ class Bridge {
     affectedRows: number;
     executionTimeMs: number;
   }> {
-    return this.call(
-      'executeQueryPaginated',
-      {
-        connectionId,
-        sql,
-        startRow,
-        endRow,
-        sortModel,
-      },
-      S.executeQueryPaginated
-    );
+    return queryProvider.executeQueryPaginated(connectionId, sql, startRow, endRow, sortModel);
   }
 
   async getRowCount(connectionId: string, sql: string): Promise<{ rowCount: number }> {
-    return this.call('getRowCount', { connectionId, sql }, S.getRowCount);
+    return queryProvider.getRowCount(connectionId, sql);
   }
 
   async cancelQuery(connectionId: string): Promise<void> {
-    return this.call('cancelQuery', { connectionId }, S.cancelQuery);
+    return queryProvider.cancelQuery(connectionId);
   }
 
   async lintSql(
@@ -340,7 +302,7 @@ class Bridge {
     lintUnavailable?: boolean;
     reason?: string;
   }> {
-    return this.call('lintSql', { sql, dbType }, S.lintSql);
+    return queryProvider.lintSql(sql, dbType);
   }
 
   // Schema methods
@@ -497,13 +459,13 @@ class Bridge {
     return this.call('parseERDiagram', params, S.parseERDiagram);
   }
 
-  // Execution plan methods
+  // Execution plan methods (→ queryProvider)
   async getExecutionPlan(
     connectionId: string,
     sql: string,
     actual = false
   ): Promise<{ plan: string; actual: boolean }> {
-    return this.call('getExecutionPlan', { connectionId, sql, actual }, S.getExecutionPlan);
+    return queryProvider.getExecutionPlan(connectionId, sql, actual);
   }
 
   // Cache methods
@@ -523,28 +485,28 @@ class Bridge {
     return this.call('clearSchemaCache', {}, S.clearCache);
   }
 
-  // Async query methods
+  // Async query methods (→ queryProvider)
   async executeAsyncQuery(connectionId: string, sql: string): Promise<{ queryId: string }> {
-    return this.call('executeAsyncQuery', { connectionId, sql }, S.executeAsyncQuery);
+    return queryProvider.executeAsyncQuery(connectionId, sql);
   }
 
   async getAsyncQueryResult(queryId: string): Promise<AsyncQueryResultResponse> {
-    return this.call('getAsyncQueryResult', { queryId }, S.getAsyncQueryResult);
+    return queryProvider.getAsyncQueryResult(queryId);
   }
 
   async cancelAsyncQuery(queryId: string): Promise<{ cancelled: boolean }> {
-    return this.call('cancelAsyncQuery', { queryId }, S.cancelAsyncQuery);
+    return queryProvider.cancelAsyncQuery(queryId);
   }
 
   async removeAsyncQuery(queryId: string): Promise<{ removed: boolean }> {
-    return this.call('removeAsyncQuery', { queryId }, S.removeAsyncQuery);
+    return queryProvider.removeAsyncQuery(queryId);
   }
 
   async getActiveQueries(): Promise<string[]> {
-    return this.call('getActiveQueries', {}, S.getActiveQueries);
+    return queryProvider.getActiveQueries();
   }
 
-  // SIMD filter methods
+  // SIMD filter methods (→ queryProvider)
   async filterResultSet(
     connectionId: string,
     sql: string,
@@ -559,17 +521,13 @@ class Bridge {
     filteredRows: number;
     simdAvailable: boolean;
   }> {
-    return this.call(
-      'filterResultSet',
-      {
-        connectionId,
-        sql,
-        columnIndex,
-        filterType,
-        filterValue,
-        filterValueMax,
-      },
-      S.filterResultSet
+    return queryProvider.filterResultSet(
+      connectionId,
+      sql,
+      columnIndex,
+      filterType,
+      filterValue,
+      filterValueMax
     );
   }
 

--- a/frontend/src/api/providers/connection.ts
+++ b/frontend/src/api/providers/connection.ts
@@ -1,0 +1,86 @@
+import type { ConnectResultResponse } from '../schemas';
+import * as S from '../schemas';
+import type { BridgeLogger, IpcInvoker, ResponseValidator } from './types';
+
+interface SshConnectInfo {
+  enabled: boolean;
+  host: string;
+  port: number;
+  username: string;
+  authType: string;
+  password?: string;
+  privateKeyPath?: string;
+  keyPassphrase?: string;
+}
+
+export interface ConnectionInfo {
+  server: string;
+  port?: number;
+  database: string;
+  username?: string;
+  password?: string;
+  useWindowsAuth: boolean;
+  connectionTimeout?: number;
+  dbType?: 'sqlserver' | 'postgresql' | 'mysql';
+  ssh?: SshConnectInfo;
+}
+
+export type TestConnectionInfo = Omit<ConnectionInfo, 'connectionTimeout'>;
+
+export interface ConnectionProvider {
+  connectAsync(info: ConnectionInfo): Promise<{ requestId: string }>;
+  getConnectResult(requestId: string): Promise<ConnectResultResponse>;
+  cancelConnect(requestId: string): Promise<void>;
+  disconnect(connectionId: string): Promise<void>;
+  testConnection(info: TestConnectionInfo): Promise<{ success: boolean; message: string }>;
+}
+
+class ConnectionProviderImpl implements ConnectionProvider {
+  constructor(
+    private readonly invoker: IpcInvoker,
+    // 共通シグネチャ維持 (#517 軸③): 現状未使用だが #520+ で log.info 等を実利用するため
+    private readonly logger: BridgeLogger,
+    private readonly validator: ResponseValidator
+  ) {
+    void this.logger; // TS6138 抑制: 共通シグネチャ維持のため未使用受け取りを許可
+  }
+
+  async connectAsync(info: ConnectionInfo): Promise<{ requestId: string }> {
+    const raw = await this.invoker.invoke(
+      'connectAsync',
+      info as unknown as Record<string, unknown>
+    );
+    return this.validator.parse(S.connectAsync, raw);
+  }
+
+  async getConnectResult(requestId: string): Promise<ConnectResultResponse> {
+    const raw = await this.invoker.invoke('getConnectResult', { requestId });
+    return this.validator.parse(S.connectResult, raw);
+  }
+
+  async cancelConnect(requestId: string): Promise<void> {
+    // S.cancelConnect は z.any() で実質 noop のため parse を省略
+    await this.invoker.invoke('cancelConnect', { requestId });
+  }
+
+  async disconnect(connectionId: string): Promise<void> {
+    // S.disconnect は z.any() で実質 noop のため parse を省略
+    await this.invoker.invoke('disconnect', { connectionId });
+  }
+
+  async testConnection(info: TestConnectionInfo): Promise<{ success: boolean; message: string }> {
+    const raw = await this.invoker.invoke(
+      'testConnection',
+      info as unknown as Record<string, unknown>
+    );
+    return this.validator.parse(S.testConnection, raw);
+  }
+}
+
+export function createConnectionProvider(
+  invoker: IpcInvoker,
+  logger: BridgeLogger,
+  validator: ResponseValidator
+): ConnectionProvider {
+  return new ConnectionProviderImpl(invoker, logger, validator);
+}

--- a/frontend/src/api/providers/index.ts
+++ b/frontend/src/api/providers/index.ts
@@ -1,13 +1,48 @@
 import { log } from '../../utils/logger';
 import { type IpcInvoker, WindowIpcInvoker } from '../ipc/ipc-invoker';
+import { type ConnectionProvider, createConnectionProvider } from './connection';
+import { createQueryProvider, type QueryProvider } from './query';
+import type { BridgeLogger, ResponseValidator } from './types';
+import { createZodValidator } from './validator';
 
 let invokerInstance: IpcInvoker = new WindowIpcInvoker(log);
+const loggerInstance: BridgeLogger = log;
+const validatorInstance: ResponseValidator = createZodValidator();
 
-// loggerInstance / validatorInstance / 各 provider は #518-#526 で順次追加する。
+interface Providers {
+  connection: ConnectionProvider;
+  query: QueryProvider;
+}
+
+function buildProviders(): Providers {
+  return {
+    connection: createConnectionProvider(invokerInstance, loggerInstance, validatorInstance),
+    query: createQueryProvider(invokerInstance, loggerInstance, validatorInstance),
+  };
+}
+
+let providersRef = buildProviders();
+
+// 利用側は `xxxProvider.foo()` でメソッド参照を毎回最新の実体から引く。
+// テストで invoker を差し替えた際 (providersRef 再構築) も import 済みコードがそのまま動く。
+// メソッドを分割代入後に呼ぶケースでも this を失わないよう関数を実体に bind する。
+function makeProviderProxy<K extends keyof Providers>(key: K): Providers[K] {
+  return new Proxy({} as Providers[K], {
+    get: (_target, prop) => {
+      const target = providersRef[key];
+      const value = Reflect.get(target, prop);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
+export const connectionProvider: ConnectionProvider = makeProviderProxy('connection');
+export const queryProvider: QueryProvider = makeProviderProxy('query');
 
 /** テスト専用: invoker を差し替えて全 provider を再構築する */
 export function __setIpcInvokerForTest(invoker: IpcInvoker): void {
   invokerInstance = invoker;
+  providersRef = buildProviders();
 }
 
 /** テスト専用: 現在の invoker を取得する (DI 検証用) */

--- a/frontend/src/api/providers/query.ts
+++ b/frontend/src/api/providers/query.ts
@@ -1,0 +1,196 @@
+import type { AsyncQueryResultResponse, DatabaseType } from '../../types';
+import * as S from '../schemas';
+import type { BridgeLogger, IpcInvoker, ResponseValidator } from './types';
+
+type Column = { name: string; type: string; comment?: string };
+type AsyncColumn = { name: string; type: string };
+
+export type ExecuteQueryResult =
+  | {
+      columns: Column[];
+      rows: (string | null)[][];
+      affectedRows: number;
+      executionTimeMs: number;
+      cached: boolean;
+    }
+  | {
+      multipleResults: true;
+      results: {
+        statement: string;
+        data: {
+          columns: AsyncColumn[];
+          rows: (string | null)[][];
+          affectedRows: number;
+          executionTimeMs: number;
+        };
+      }[];
+    };
+
+export interface PaginatedQueryResult {
+  columns: AsyncColumn[];
+  rows: (string | null)[][];
+  affectedRows: number;
+  executionTimeMs: number;
+}
+
+export interface LintSqlResult {
+  diagnostics: { line: number; column: number; code: string; message: string }[];
+  lintUnavailable?: boolean;
+  reason?: string;
+}
+
+export interface FilterResultSet {
+  columns: AsyncColumn[];
+  rows: (string | null)[][];
+  totalRows: number;
+  filteredRows: number;
+  simdAvailable: boolean;
+}
+
+export type SortModel = Array<{ colId: string; sort: 'asc' | 'desc' }>;
+export type FilterType = 'equals' | 'contains' | 'range';
+
+export interface QueryProvider {
+  executeQuery(connectionId: string, sql: string, useCache?: boolean): Promise<ExecuteQueryResult>;
+  executeQueryPaginated(
+    connectionId: string,
+    sql: string,
+    startRow: number,
+    endRow: number,
+    sortModel?: SortModel
+  ): Promise<PaginatedQueryResult>;
+  getRowCount(connectionId: string, sql: string): Promise<{ rowCount: number }>;
+  cancelQuery(connectionId: string): Promise<void>;
+  lintSql(sql: string, dbType: DatabaseType): Promise<LintSqlResult>;
+  executeAsyncQuery(connectionId: string, sql: string): Promise<{ queryId: string }>;
+  getAsyncQueryResult(queryId: string): Promise<AsyncQueryResultResponse>;
+  cancelAsyncQuery(queryId: string): Promise<{ cancelled: boolean }>;
+  removeAsyncQuery(queryId: string): Promise<{ removed: boolean }>;
+  getActiveQueries(): Promise<string[]>;
+  filterResultSet(
+    connectionId: string,
+    sql: string,
+    columnIndex: number,
+    filterType: FilterType,
+    filterValue: string,
+    filterValueMax?: string
+  ): Promise<FilterResultSet>;
+  getExecutionPlan(
+    connectionId: string,
+    sql: string,
+    actual?: boolean
+  ): Promise<{ plan: string; actual: boolean }>;
+}
+
+class QueryProviderImpl implements QueryProvider {
+  constructor(
+    private readonly invoker: IpcInvoker,
+    // 共通シグネチャ維持 (#517 軸③): 現状未使用だが #520+ で log.info 等を実利用するため
+    private readonly logger: BridgeLogger,
+    private readonly validator: ResponseValidator
+  ) {
+    void this.logger; // TS6138 抑制: 共通シグネチャ維持のため未使用受け取りを許可
+  }
+
+  async executeQuery(
+    connectionId: string,
+    sql: string,
+    useCache = true
+  ): Promise<ExecuteQueryResult> {
+    const raw = await this.invoker.invoke('executeQuery', { connectionId, sql, useCache });
+    return this.validator.parse(S.executeQuery, raw);
+  }
+
+  async executeQueryPaginated(
+    connectionId: string,
+    sql: string,
+    startRow: number,
+    endRow: number,
+    sortModel?: SortModel
+  ): Promise<PaginatedQueryResult> {
+    const raw = await this.invoker.invoke('executeQueryPaginated', {
+      connectionId,
+      sql,
+      startRow,
+      endRow,
+      sortModel,
+    });
+    return this.validator.parse(S.executeQueryPaginated, raw);
+  }
+
+  async getRowCount(connectionId: string, sql: string): Promise<{ rowCount: number }> {
+    const raw = await this.invoker.invoke('getRowCount', { connectionId, sql });
+    return this.validator.parse(S.getRowCount, raw);
+  }
+
+  async cancelQuery(connectionId: string): Promise<void> {
+    // S.cancelQuery は z.any() で実質 noop のため parse を省略
+    await this.invoker.invoke('cancelQuery', { connectionId });
+  }
+
+  async lintSql(sql: string, dbType: DatabaseType): Promise<LintSqlResult> {
+    const raw = await this.invoker.invoke('lintSql', { sql, dbType });
+    return this.validator.parse(S.lintSql, raw);
+  }
+
+  async executeAsyncQuery(connectionId: string, sql: string): Promise<{ queryId: string }> {
+    const raw = await this.invoker.invoke('executeAsyncQuery', { connectionId, sql });
+    return this.validator.parse(S.executeAsyncQuery, raw);
+  }
+
+  async getAsyncQueryResult(queryId: string): Promise<AsyncQueryResultResponse> {
+    const raw = await this.invoker.invoke('getAsyncQueryResult', { queryId });
+    return this.validator.parse(S.getAsyncQueryResult, raw);
+  }
+
+  async cancelAsyncQuery(queryId: string): Promise<{ cancelled: boolean }> {
+    const raw = await this.invoker.invoke('cancelAsyncQuery', { queryId });
+    return this.validator.parse(S.cancelAsyncQuery, raw);
+  }
+
+  async removeAsyncQuery(queryId: string): Promise<{ removed: boolean }> {
+    const raw = await this.invoker.invoke('removeAsyncQuery', { queryId });
+    return this.validator.parse(S.removeAsyncQuery, raw);
+  }
+
+  async getActiveQueries(): Promise<string[]> {
+    const raw = await this.invoker.invoke('getActiveQueries', {});
+    return this.validator.parse(S.getActiveQueries, raw);
+  }
+
+  async filterResultSet(
+    connectionId: string,
+    sql: string,
+    columnIndex: number,
+    filterType: FilterType,
+    filterValue: string,
+    filterValueMax?: string
+  ): Promise<FilterResultSet> {
+    const raw = await this.invoker.invoke('filterResultSet', {
+      connectionId,
+      sql,
+      columnIndex,
+      filterType,
+      filterValue,
+      filterValueMax,
+    });
+    return this.validator.parse(S.filterResultSet, raw);
+  }
+
+  async getExecutionPlan(
+    connectionId: string,
+    sql: string,
+    actual = false
+  ): Promise<{ plan: string; actual: boolean }> {
+    const raw = await this.invoker.invoke('getExecutionPlan', { connectionId, sql, actual });
+    return this.validator.parse(S.getExecutionPlan, raw);
+  }
+}
+
+export function createQueryProvider(
+  invoker: IpcInvoker,
+  logger: BridgeLogger,
+  validator: ResponseValidator
+): QueryProvider {
+  return new QueryProviderImpl(invoker, logger, validator);
+}

--- a/frontend/src/components/dialogs/ConnectionDialog.tsx
+++ b/frontend/src/components/dialogs/ConnectionDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { bridge } from '../../api/bridge';
+import { connectionProvider } from '../../api/providers';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import type { ConnectionConfig, SshConfig } from '../../types/connectionForm';
 import { connectionColor } from '../../utils/colorContrast';
@@ -72,7 +72,7 @@ export function ConnectionDialog({
     setTestResult(null);
 
     try {
-      const response = await bridge.testConnection({
+      const response = await connectionProvider.testConnection({
         server: config.server,
         port: config.port,
         database: config.database,

--- a/frontend/src/components/dialogs/ExecutionPlanDialog.tsx
+++ b/frontend/src/components/dialogs/ExecutionPlanDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { bridge } from '../../api/bridge';
+import { queryProvider } from '../../api/providers';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import { useConnectionStore } from '../../store/connectionStore';
 import { DialogOverlay } from '../common/DialogOverlay';
@@ -32,7 +32,7 @@ export function ExecutionPlanDialog({ isOpen, onClose, sql }: ExecutionPlanDialo
           ? `SET STATISTICS XML ON;\n${sql}\nSET STATISTICS XML OFF;`
           : `SET SHOWPLAN_TEXT ON;\n${sql}\nSET SHOWPLAN_TEXT OFF;`;
 
-        const result = await bridge.executeQuery(activeConnectionId, planQuery);
+        const result = await queryProvider.executeQuery(activeConnectionId, planQuery);
 
         const allRows: (string | null)[][] =
           'multipleResults' in result ? result.results.flatMap((r) => r.data.rows) : result.rows;

--- a/frontend/src/components/grid/hooks/useGridEdit.ts
+++ b/frontend/src/components/grid/hooks/useGridEdit.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { bridge } from '../../../api/bridge';
+import { queryProvider } from '../../../api/providers';
 import { type CellChange, useEditStore } from '../../../store/editStore';
 import type { Query, ResultSet } from '../../../types';
 import { parseTableName, type RowData } from '../../../types/grid';
@@ -185,7 +186,7 @@ export function useGridEdit({
     setApplyError(null);
 
     try {
-      await bridge.executeQuery(activeConnectionId, previewStatements.join('\n'));
+      await queryProvider.executeQuery(activeConnectionId, previewStatements.join('\n'));
       revertAll();
       setPreviewStatements([]);
     } catch (err) {

--- a/frontend/src/components/table/TableViewer.tsx
+++ b/frontend/src/components/table/TableViewer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from 'react';
 import { bridge } from '../../api/bridge';
+import { queryProvider } from '../../api/providers';
 import { useConnectionStore } from '../../store/connectionStore';
 import { stripBrackets } from '../../utils/stringUtils';
 import { useTableDataState } from './hooks/useTableDataState';
@@ -72,7 +73,7 @@ export function TableViewer({ tableName, schemaName = 'dbo' }: TableViewerProps)
         sql += ` WHERE ${whereClause}`;
       }
 
-      const result = await bridge.executeQuery(activeConnectionId, sql, false);
+      const result = await queryProvider.executeQuery(activeConnectionId, sql, false);
       if ('multipleResults' in result) {
         setError('複数ステートメントの結果はテーブルビューアでは表示できません');
         return;

--- a/frontend/src/hooks/useColumnActions.ts
+++ b/frontend/src/hooks/useColumnActions.ts
@@ -1,5 +1,5 @@
 import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
-import { bridge } from '../api/bridge';
+import { queryProvider } from '../api/providers';
 import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
 import { log } from '../utils/logger';
 import { buildDropColumnSql, buildRenameColumnSql } from '../utils/sql/ddl/table-ddl';
@@ -75,7 +75,7 @@ export function useColumnActions({
   const executeDdl = useCallback(
     async (sql: string, schema: string, tableName: string) => {
       try {
-        await bridge.executeQuery(connectionId, sql);
+        await queryProvider.executeQuery(connectionId, sql);
         await refreshTableColumns(schema, tableName);
       } catch (error) {
         log.error(`[useColumnActions] DDL execution failed: ${error}`);

--- a/frontend/src/hooks/useTableActions.ts
+++ b/frontend/src/hooks/useTableActions.ts
@@ -1,5 +1,6 @@
 import { type Dispatch, type SetStateAction, useCallback, useState } from 'react';
 import { bridge } from '../api/bridge';
+import { queryProvider } from '../api/providers';
 import type { DatabaseObject, DatabaseType, MenuItem } from '../types';
 import { log } from '../utils/logger';
 import {
@@ -114,11 +115,11 @@ export function useTableActions({
       const hasTransaction = sqls[0] === SQL_BEGIN_TRANSACTION;
       try {
         for (const sql of sqls) {
-          await bridge.executeQuery(connectionId, sql, false);
+          await queryProvider.executeQuery(connectionId, sql, false);
         }
       } catch (error) {
         if (hasTransaction) {
-          await bridge.executeQuery(connectionId, 'ROLLBACK', false).catch(() => {});
+          await queryProvider.executeQuery(connectionId, 'ROLLBACK', false).catch(() => {});
         }
         throw error;
       }

--- a/frontend/src/store/connectionStore.ts
+++ b/frontend/src/store/connectionStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
-import { bridge } from '../api/bridge';
+import { connectionProvider } from '../api/providers';
 import type { Connection } from '../types';
 import { pollConnection } from './connection/helpers/connectionPolling';
 
@@ -39,7 +39,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ isConnecting: true, error: null, connectRequestId: null, connectCancelled: false });
 
     try {
-      const { requestId } = await bridge.connectAsync({
+      const { requestId } = await connectionProvider.connectAsync({
         server: connection.server,
         port: connection.port,
         database: connection.database,
@@ -63,7 +63,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
       // Check if cancelled while waiting for connectAsync IPC response
       if (get().connectCancelled) {
-        await bridge.cancelConnect(requestId).catch(() => {});
+        await connectionProvider.cancelConnect(requestId).catch(() => {});
         set({ isConnecting: false, connectRequestId: null, connectCancelled: false });
         return {};
       }
@@ -71,7 +71,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       set({ connectRequestId: requestId });
 
       const result = await pollConnection(
-        bridge,
+        connectionProvider,
         requestId,
         () => get().connectRequestId !== requestId
       );
@@ -97,7 +97,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const existing = get().connections.find(matchesExisting);
       const oldId = existing?.id;
       if (existing) {
-        await bridge.disconnect(existing.id).catch(() => {});
+        await connectionProvider.disconnect(existing.id).catch(() => {});
       }
 
       set((state) => ({
@@ -129,7 +129,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { connectRequestId } = get();
     if (connectRequestId) {
       set({ connectRequestId: null, connectCancelled: false });
-      await bridge.cancelConnect(connectRequestId).catch(() => {});
+      await connectionProvider.cancelConnect(connectRequestId).catch(() => {});
     } else {
       // Pre-IPC cancel: flag for addConnection to detect
       set({ connectCancelled: true });
@@ -141,7 +141,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { activeConnectionId } = get();
 
     try {
-      await bridge.disconnect(id);
+      await connectionProvider.disconnect(id);
     } catch {
       // Ignore disconnect errors
     }
@@ -168,7 +168,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ isConnecting: true, error: null });
 
     try {
-      const result = await bridge.testConnection({
+      const result = await connectionProvider.testConnection({
         server: connection.server,
         port: connection.port,
         database: connection.database,

--- a/frontend/src/tests/api/connectionProvider.test.ts
+++ b/frontend/src/tests/api/connectionProvider.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockIpcInvoker } from '../../api/ipc/mock-ipc-invoker';
+import { __setIpcInvokerForTest, connectionProvider } from '../../api/providers';
+
+describe('connectionProvider', () => {
+  let mock: MockIpcInvoker;
+
+  beforeEach(() => {
+    mock = new MockIpcInvoker();
+    __setIpcInvokerForTest(mock);
+  });
+
+  it('connectAsync は IPC を呼び出し schema parse 済みの値を返す', async () => {
+    mock.setResponse('connectAsync', { requestId: 'r-1' });
+
+    const result = await connectionProvider.connectAsync({
+      server: 'localhost',
+      database: 'db1',
+      useWindowsAuth: true,
+    });
+
+    expect(result).toEqual({ requestId: 'r-1' });
+    expect(mock.calls[0]?.method).toBe('connectAsync');
+    expect(mock.calls[0]?.params).toMatchObject({ server: 'localhost', database: 'db1' });
+  });
+
+  it('connectAsync が schema 不一致のレスポンスを受け取ると throw する', async () => {
+    mock.setResponse('connectAsync', { wrongField: 'oops' });
+
+    await expect(
+      connectionProvider.connectAsync({
+        server: 'localhost',
+        database: 'db1',
+        useWindowsAuth: true,
+      })
+    ).rejects.toThrow();
+  });
+
+  it('getConnectResult は requestId を渡し ConnectResultResponse を返す', async () => {
+    mock.setResponse('getConnectResult', { status: 'connected', connectionId: 'c-1' });
+
+    const result = await connectionProvider.getConnectResult('req-1');
+
+    expect(result).toEqual({ status: 'connected', connectionId: 'c-1' });
+    expect(mock.calls[0]).toEqual({ method: 'getConnectResult', params: { requestId: 'req-1' } });
+  });
+
+  it('cancelConnect は IPC を呼び出す', async () => {
+    mock.setResponse('cancelConnect', null);
+
+    await connectionProvider.cancelConnect('req-1');
+
+    expect(mock.calls[0]).toEqual({ method: 'cancelConnect', params: { requestId: 'req-1' } });
+  });
+
+  it('disconnect は connectionId を渡す', async () => {
+    mock.setResponse('disconnect', null);
+
+    await connectionProvider.disconnect('conn-1');
+
+    expect(mock.calls[0]).toEqual({ method: 'disconnect', params: { connectionId: 'conn-1' } });
+  });
+
+  it('testConnection は success/message を schema parse して返す', async () => {
+    mock.setResponse('testConnection', { success: true, message: 'ok' });
+
+    const result = await connectionProvider.testConnection({
+      server: 'localhost',
+      database: 'db1',
+      useWindowsAuth: true,
+    });
+
+    expect(result).toEqual({ success: true, message: 'ok' });
+    expect(mock.calls[0]?.method).toBe('testConnection');
+  });
+
+  it('メソッドを分割代入してから呼んでも this が失われない', async () => {
+    mock.setResponse('testConnection', { success: true, message: 'ok' });
+
+    const { testConnection } = connectionProvider;
+    const result = await testConnection({
+      server: 'localhost',
+      database: 'db1',
+      useWindowsAuth: true,
+    });
+
+    expect(result).toEqual({ success: true, message: 'ok' });
+  });
+
+  it('__setIpcInvokerForTest 後に再度差し替えると新しい invoker が使われる', async () => {
+    const first = new MockIpcInvoker();
+    first.setResponse('connectAsync', { requestId: 'first' });
+    __setIpcInvokerForTest(first);
+
+    const second = new MockIpcInvoker();
+    second.setResponse('connectAsync', { requestId: 'second' });
+    __setIpcInvokerForTest(second);
+
+    const result = await connectionProvider.connectAsync({
+      server: 's',
+      database: 'd',
+      useWindowsAuth: true,
+    });
+
+    expect(result.requestId).toBe('second');
+    expect(first.calls).toHaveLength(0);
+  });
+});

--- a/frontend/src/tests/api/queryProvider.test.ts
+++ b/frontend/src/tests/api/queryProvider.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockIpcInvoker } from '../../api/ipc/mock-ipc-invoker';
+import { __setIpcInvokerForTest, queryProvider } from '../../api/providers';
+
+describe('queryProvider', () => {
+  let mock: MockIpcInvoker;
+
+  beforeEach(() => {
+    mock = new MockIpcInvoker();
+    __setIpcInvokerForTest(mock);
+  });
+
+  it('executeQuery は connectionId/sql/useCache を渡し schema parse 済みの単一結果を返す', async () => {
+    mock.setResponse('executeQuery', {
+      columns: [{ name: 'id', type: 'int' }],
+      rows: [['1']],
+      affectedRows: 1,
+      executionTimeMs: 10,
+      cached: false,
+    });
+
+    const result = await queryProvider.executeQuery('conn1', 'SELECT 1', true);
+
+    expect('multipleResults' in result).toBe(false);
+    if (!('multipleResults' in result)) {
+      expect(result.columns).toEqual([{ name: 'id', type: 'int' }]);
+      expect(result.rows).toEqual([['1']]);
+    }
+    expect(mock.calls[0]).toEqual({
+      method: 'executeQuery',
+      params: { connectionId: 'conn1', sql: 'SELECT 1', useCache: true },
+    });
+  });
+
+  it('executeQuery は useCache を省略すると true を渡す', async () => {
+    mock.setResponse('executeQuery', {
+      columns: [],
+      rows: [],
+      affectedRows: 0,
+      executionTimeMs: 0,
+      cached: false,
+    });
+
+    await queryProvider.executeQuery('conn1', 'SELECT 1');
+
+    expect(mock.calls[0]?.params).toMatchObject({ useCache: true });
+  });
+
+  it('executeQueryPaginated は sortModel を含む全パラメータを渡す', async () => {
+    mock.setResponse('executeQueryPaginated', {
+      columns: [{ name: 'id', type: 'int' }],
+      rows: [['1']],
+      affectedRows: 0,
+      executionTimeMs: 5,
+    });
+
+    const sortModel = [{ colId: 'id', sort: 'asc' as const }];
+    await queryProvider.executeQueryPaginated('conn1', 'SELECT * FROM t', 0, 100, sortModel);
+
+    expect(mock.calls[0]).toEqual({
+      method: 'executeQueryPaginated',
+      params: {
+        connectionId: 'conn1',
+        sql: 'SELECT * FROM t',
+        startRow: 0,
+        endRow: 100,
+        sortModel,
+      },
+    });
+  });
+
+  it('getRowCount は rowCount を返す', async () => {
+    mock.setResponse('getRowCount', { rowCount: 42 });
+
+    const result = await queryProvider.getRowCount('conn1', 'SELECT * FROM t');
+
+    expect(result).toEqual({ rowCount: 42 });
+  });
+
+  it('cancelQuery は connectionId を渡し void を返す', async () => {
+    mock.setResponse('cancelQuery', null);
+
+    await queryProvider.cancelQuery('conn1');
+
+    expect(mock.calls[0]).toEqual({ method: 'cancelQuery', params: { connectionId: 'conn1' } });
+  });
+
+  it('lintSql は sql/dbType を渡し diagnostics を返す', async () => {
+    mock.setResponse('lintSql', {
+      diagnostics: [{ line: 1, column: 1, code: 'L1', message: 'm' }],
+    });
+
+    const result = await queryProvider.lintSql('SELECT 1', 'sqlserver');
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(mock.calls[0]?.params).toEqual({ sql: 'SELECT 1', dbType: 'sqlserver' });
+  });
+
+  it('executeAsyncQuery は queryId を返す', async () => {
+    mock.setResponse('executeAsyncQuery', { queryId: 'q-1' });
+
+    const result = await queryProvider.executeAsyncQuery('conn1', 'SELECT 1');
+
+    expect(result).toEqual({ queryId: 'q-1' });
+  });
+
+  it('getAsyncQueryResult は queryId を渡し AsyncQueryResultResponse を返す', async () => {
+    mock.setResponse('getAsyncQueryResult', { queryId: 'q-1', status: 'pending' });
+
+    const result = await queryProvider.getAsyncQueryResult('q-1');
+
+    expect(result).toEqual({ queryId: 'q-1', status: 'pending' });
+  });
+
+  it('getAsyncQueryResult schema は z.any() のため任意形状を素通しする (将来厳密化時の影響範囲を明文化)', async () => {
+    mock.setResponse('getAsyncQueryResult', { arbitrary: 'shape', not: 'validated' });
+
+    const result = await queryProvider.getAsyncQueryResult('q-1');
+
+    expect(result).toEqual({ arbitrary: 'shape', not: 'validated' });
+  });
+
+  it('cancelAsyncQuery は cancelled フラグを返す', async () => {
+    mock.setResponse('cancelAsyncQuery', { cancelled: true });
+
+    const result = await queryProvider.cancelAsyncQuery('q-1');
+
+    expect(result).toEqual({ cancelled: true });
+  });
+
+  it('removeAsyncQuery は removed フラグを返す', async () => {
+    mock.setResponse('removeAsyncQuery', { removed: true });
+
+    const result = await queryProvider.removeAsyncQuery('q-1');
+
+    expect(result).toEqual({ removed: true });
+  });
+
+  it('getActiveQueries は string 配列を返す', async () => {
+    mock.setResponse('getActiveQueries', ['q-1', 'q-2']);
+
+    const result = await queryProvider.getActiveQueries();
+
+    expect(result).toEqual(['q-1', 'q-2']);
+  });
+
+  it('filterResultSet は全パラメータを渡す', async () => {
+    mock.setResponse('filterResultSet', {
+      columns: [{ name: 'id', type: 'int' }],
+      rows: [['1']],
+      totalRows: 100,
+      filteredRows: 1,
+      simdAvailable: true,
+    });
+
+    await queryProvider.filterResultSet('conn1', 'SELECT * FROM t', 0, 'equals', '1', '10');
+
+    expect(mock.calls[0]).toEqual({
+      method: 'filterResultSet',
+      params: {
+        connectionId: 'conn1',
+        sql: 'SELECT * FROM t',
+        columnIndex: 0,
+        filterType: 'equals',
+        filterValue: '1',
+        filterValueMax: '10',
+      },
+    });
+  });
+
+  it('getExecutionPlan は actual を省略すると false を渡す', async () => {
+    mock.setResponse('getExecutionPlan', { plan: 'p', actual: false });
+
+    const result = await queryProvider.getExecutionPlan('conn1', 'SELECT 1');
+
+    expect(result).toEqual({ plan: 'p', actual: false });
+    expect(mock.calls[0]?.params).toMatchObject({ actual: false });
+  });
+
+  it('メソッドを分割代入してから呼んでも this が失われない', async () => {
+    mock.setResponse('cancelQuery', null);
+
+    const { cancelQuery } = queryProvider;
+    await cancelQuery('conn1');
+
+    expect(mock.calls[0]?.method).toBe('cancelQuery');
+  });
+
+  it('schema 不一致のレスポンスは throw する', async () => {
+    mock.setResponse('getRowCount', { wrong: 'field' });
+
+    await expect(queryProvider.getRowCount('conn1', 'SELECT 1')).rejects.toThrow();
+  });
+});

--- a/frontend/src/tests/dialogs/ConnectionDialog.test.tsx
+++ b/frontend/src/tests/dialogs/ConnectionDialog.test.tsx
@@ -8,10 +8,15 @@ import { useConnectionStore } from '../../store/connectionStore';
 vi.mock('../../api/bridge', () => ({
   bridge: {
     getConnectionProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
-    testConnection: vi.fn(),
     saveConnectionProfile: vi.fn(),
     deleteConnectionProfile: vi.fn(),
     getProfilePassword: vi.fn(),
+  },
+}));
+
+vi.mock('../../api/providers', () => ({
+  connectionProvider: {
+    testConnection: vi.fn(),
   },
 }));
 

--- a/frontend/src/tests/hooks/useTableActions.test.ts
+++ b/frontend/src/tests/hooks/useTableActions.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DatabaseObject } from '../../types';
 
-// Mock bridge
+// Mock bridge (Schema methods 用 — getReferencingForeignKeys は #520 で SchemaProvider に移管予定)
 vi.mock('../../api/bridge', () => ({
   bridge: {
-    executeQuery: vi.fn(),
     getReferencingForeignKeys: vi.fn(),
+  },
+}));
+
+// Mock providers (Query methods 用 — #519 で queryProvider に移管済み)
+vi.mock('../../api/providers', () => ({
+  queryProvider: {
+    executeQuery: vi.fn(),
   },
 }));
 
@@ -16,6 +22,7 @@ vi.mock('../../utils/logger', () => ({
 
 import { act, renderHook } from '@testing-library/react';
 import { bridge } from '../../api/bridge';
+import { queryProvider } from '../../api/providers';
 import { useTableActions } from '../../hooks/useTableActions';
 
 function makeTableNode(overrides: Partial<DatabaseObject> = {}): DatabaseObject {
@@ -153,7 +160,7 @@ describe('useTableActions', () => {
   // テスト19: confirmDrop → executeQuery実行 + コールバック
   it('confirmDrop: sqls を順にexecuteQuery実行 → 成功時loadTables+setTreeData呼び出し', async () => {
     vi.mocked(bridge.getReferencingForeignKeys).mockResolvedValueOnce([]);
-    vi.mocked(bridge.executeQuery).mockResolvedValue({
+    vi.mocked(queryProvider.executeQuery).mockResolvedValue({
       columns: [],
       rows: [],
       affectedRows: 0,
@@ -167,7 +174,11 @@ describe('useTableActions', () => {
     await act(() => result.current.requestDrop(makeTableNode()));
     await act(() => result.current.confirmDrop());
 
-    expect(bridge.executeQuery).toHaveBeenCalledWith('conn1', 'DROP TABLE [dbo].[Users]', false);
+    expect(queryProvider.executeQuery).toHaveBeenCalledWith(
+      'conn1',
+      'DROP TABLE [dbo].[Users]',
+      false
+    );
     expect(params.loadTables).toHaveBeenCalled();
     expect(params.setTreeData).toHaveBeenCalled();
     expect(result.current.tableAction).toBeNull();
@@ -176,7 +187,7 @@ describe('useTableActions', () => {
   // テスト20: confirmTruncate → executeQuery実行
   it('confirmTruncate: sqls を順にexecuteQuery実行', async () => {
     vi.mocked(bridge.getReferencingForeignKeys).mockResolvedValueOnce([]);
-    vi.mocked(bridge.executeQuery).mockResolvedValue({
+    vi.mocked(queryProvider.executeQuery).mockResolvedValue({
       columns: [],
       rows: [],
       affectedRows: 0,
@@ -188,7 +199,7 @@ describe('useTableActions', () => {
     await act(() => result.current.requestTruncate(makeTableNode()));
     await act(() => result.current.confirmTruncate());
 
-    expect(bridge.executeQuery).toHaveBeenCalledWith(
+    expect(queryProvider.executeQuery).toHaveBeenCalledWith(
       'conn1',
       'TRUNCATE TABLE [dbo].[Users]',
       false
@@ -200,7 +211,7 @@ describe('useTableActions', () => {
   it('confirmDrop: executeQuery失敗時 → onDdlErrorコールバック', async () => {
     const error = new Error('SQL error');
     vi.mocked(bridge.getReferencingForeignKeys).mockResolvedValueOnce([]);
-    vi.mocked(bridge.executeQuery).mockRejectedValueOnce(error);
+    vi.mocked(queryProvider.executeQuery).mockRejectedValueOnce(error);
     const onDdlError = vi.fn();
     const params = { ...createParams(), onDdlError };
     const { result } = renderHook(() => useTableActions(params));

--- a/frontend/src/tests/stores/connectionStore.profileId.test.ts
+++ b/frontend/src/tests/stores/connectionStore.profileId.test.ts
@@ -7,8 +7,8 @@ const mockCancelConnect = vi.fn();
 const mockDisconnect = vi.fn();
 const mockTestConnection = vi.fn();
 
-vi.mock('../../api/bridge', () => ({
-  bridge: {
+vi.mock('../../api/providers', () => ({
+  connectionProvider: {
     connectAsync: (...args: unknown[]) => mockConnectAsync(...args),
     getConnectResult: (...args: unknown[]) => mockGetConnectResult(...args),
     cancelConnect: (...args: unknown[]) => mockCancelConnect(...args),

--- a/frontend/src/tests/stores/connectionStore.test.ts
+++ b/frontend/src/tests/stores/connectionStore.test.ts
@@ -7,8 +7,8 @@ const mockCancelConnect = vi.fn();
 const mockDisconnect = vi.fn();
 const mockTestConnection = vi.fn();
 
-vi.mock('../../api/bridge', () => ({
-  bridge: {
+vi.mock('../../api/providers', () => ({
+  connectionProvider: {
     connectAsync: (...args: unknown[]) => mockConnectAsync(...args),
     getConnectResult: (...args: unknown[]) => mockGetConnectResult(...args),
     cancelConnect: (...args: unknown[]) => mockCancelConnect(...args),

--- a/frontend/src/utils/sql/ddl/view-ddl.ts
+++ b/frontend/src/utils/sql/ddl/view-ddl.ts
@@ -31,9 +31,9 @@ export async function fetchViewDefinition(
   viewName: string,
   dbType?: DatabaseType
 ): Promise<string> {
-  const { bridge } = await import('../../../api/bridge');
+  const { queryProvider } = await import('../../../api/providers');
   const defQuery = buildGetViewDefinitionSql(schema, viewName, dbType);
-  const result = await bridge.executeQuery(connectionId, defQuery);
+  const result = await queryProvider.executeQuery(connectionId, defQuery);
   if ('multipleResults' in result) return '';
   return result.rows[0]?.[0] ?? '';
 }


### PR DESCRIPTION
#516 (bridge facade 化) のサブ issue 2 件をまとめて対応。

bridge.ts の該当メソッドは個別 provider への委譲ラッパに変更し、直接呼び出している consumer (hook/component/util 計 7 ファイル) を
provider 経由に置換。DI 経由の slice (queryExecuteSlice 等) はbridge param が QueryBridgeable 等を満たすため変更なし (#527 で統一)。

方針検証: ✅ #517 採用 / feature-pruning: skipped
1ブランチ=1PR ルール例外: 親 #516 は 1 PR = 1 facade 設計だが、2 facade を 1 PR に集約。

Closes #518
Closes #519