### PR TITLE
refactor(frontend): QueryProvider に履歴/キャッシュ/SQL組立を抽出 (#520)

### DIFF
--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -11,6 +11,7 @@ import type { ERDiagramModel } from '../utils/erDiagramParser';
 import { log } from '../utils/logger';
 import { connectionProvider, queryProvider } from './providers';
 import type { ConnectionInfo, TestConnectionInfo } from './providers/connection';
+import type { CacheStats, QueryHistoryEntry } from './providers/query';
 import type { ConnectResultResponse } from './schemas';
 import * as S from './schemas';
 
@@ -146,7 +147,10 @@ function toCardinality(value: string): Cardinality {
 // - Connection methods (#518 で connectionProvider に移管)
 // - Query methods (#519 で queryProvider に移管: executeQuery / executeQueryPaginated / getRowCount /
 //   cancelQuery / lintSql / async query 5 件 / filterResultSet / getExecutionPlan)
-// - Schema / Transaction / Export / Settings / Search / IO / SQLBuilder: 未移管 (#520+)
+// - Query history / cache / SQL builder (#520 で queryProvider に移管: getQueryHistory /
+//   removeQueryHistory / clearQueryHistory / setQueryHistoryFavorite / getCacheStats / clearCache /
+//   buildDataViewSql / buildWhereClause / buildDmlStatements / uppercaseKeywords)
+// - Schema / Transaction / Export / Settings / Search / IO: 未移管 (#521+)
 class Bridge {
   private async call<T>(
     method: string,
@@ -378,25 +382,21 @@ class Bridge {
     return this.call('exportExcel', { data, filepath }, S.exportExcel);
   }
 
-  // SQL builder methods (dialect-aware, delegated to backend)
+  // SQL builder methods (→ queryProvider)
   async buildDataViewSql(
     connectionId: string,
     tableName: string,
     limit: number,
     whereClause?: string
   ): Promise<{ sql: string }> {
-    return this.call(
-      'buildDataViewSql',
-      { connectionId, tableName, limit, whereClause },
-      S.buildDataViewSql
-    );
+    return queryProvider.buildDataViewSql(connectionId, tableName, limit, whereClause);
   }
 
   async buildWhereClause(
     connectionId: string,
     conditions: { column: string; value: string | null }[]
   ): Promise<{ whereClause: string }> {
-    return this.call('buildWhereClause', { connectionId, conditions }, S.buildWhereClause);
+    return queryProvider.buildWhereClause(connectionId, conditions);
   }
 
   async buildDmlStatements(
@@ -413,41 +413,29 @@ class Bridge {
       deletes?: Record<string, string | null>[];
     }
   ): Promise<{ statements: string[] }> {
-    return this.call('buildDmlStatements', { connectionId, ...params }, S.buildDmlStatements);
+    return queryProvider.buildDmlStatements(connectionId, params);
   }
 
-  // SQL methods
+  // SQL methods (→ queryProvider)
   async uppercaseKeywords(sql: string): Promise<{ sql: string }> {
-    return this.call('uppercaseKeywords', { sql }, S.uppercaseKeywords);
+    return queryProvider.uppercaseKeywords(sql);
   }
 
-  // History methods
-  async getQueryHistory(): Promise<
-    {
-      id: string;
-      sql: string;
-      connectionId: string;
-      timestamp: number;
-      executionTimeMs: number;
-      success: boolean;
-      errorMessage: string;
-      affectedRows: number;
-      isFavorite: boolean;
-    }[]
-  > {
-    return this.call('getQueryHistory', {}, S.getQueryHistory);
+  // History methods (→ queryProvider)
+  async getQueryHistory(): Promise<QueryHistoryEntry[]> {
+    return queryProvider.getQueryHistory();
   }
 
   async removeQueryHistory(id: string): Promise<{ removed: boolean }> {
-    return this.call('removeQueryHistory', { id }, S.removeQueryHistory);
+    return queryProvider.removeQueryHistory(id);
   }
 
   async clearQueryHistory(): Promise<{ cleared: boolean }> {
-    return this.call('clearQueryHistory', {}, S.clearQueryHistory);
+    return queryProvider.clearQueryHistory();
   }
 
   async setQueryHistoryFavorite(id: string, isFavorite: boolean): Promise<{ updated: boolean }> {
-    return this.call('setQueryHistoryFavorite', { id, isFavorite }, S.setQueryHistoryFavorite);
+    return queryProvider.setQueryHistoryFavorite(id, isFavorite);
   }
 
   // ER diagram methods
@@ -468,17 +456,13 @@ class Bridge {
     return queryProvider.getExecutionPlan(connectionId, sql, actual);
   }
 
-  // Cache methods
-  async getCacheStats(): Promise<{
-    currentSizeBytes: number;
-    maxSizeBytes: number;
-    usagePercent: number;
-  }> {
-    return this.call('getCacheStats', {}, S.getCacheStats);
+  // Cache methods (→ queryProvider)
+  async getCacheStats(): Promise<CacheStats> {
+    return queryProvider.getCacheStats();
   }
 
   async clearCache(): Promise<{ cleared: boolean }> {
-    return this.call('clearCache', {}, S.clearCache);
+    return queryProvider.clearCache();
   }
 
   async clearSchemaCache(): Promise<{ cleared: boolean }> {

--- a/frontend/src/api/providers/query.ts
+++ b/frontend/src/api/providers/query.ts
@@ -50,6 +50,41 @@ export interface FilterResultSet {
 export type SortModel = Array<{ colId: string; sort: 'asc' | 'desc' }>;
 export type FilterType = 'equals' | 'contains' | 'range';
 
+export interface QueryHistoryEntry {
+  id: string;
+  sql: string;
+  connectionId: string;
+  timestamp: number;
+  executionTimeMs: number;
+  success: boolean;
+  errorMessage: string;
+  affectedRows: number;
+  isFavorite: boolean;
+}
+
+export interface CacheStats {
+  currentSizeBytes: number;
+  maxSizeBytes: number;
+  usagePercent: number;
+}
+
+export interface BuildWhereCondition {
+  column: string;
+  value: string | null;
+}
+
+export interface BuildDmlParams {
+  schema: string;
+  table: string;
+  pkColumns: string[];
+  updates?: {
+    changes: Record<string, string | null>;
+    originalData: Record<string, string | null>;
+  }[];
+  inserts?: Record<string, string | null>[];
+  deletes?: Record<string, string | null>[];
+}
+
 export interface QueryProvider {
   executeQuery(connectionId: string, sql: string, useCache?: boolean): Promise<ExecuteQueryResult>;
   executeQueryPaginated(
@@ -80,6 +115,27 @@ export interface QueryProvider {
     sql: string,
     actual?: boolean
   ): Promise<{ plan: string; actual: boolean }>;
+  getQueryHistory(): Promise<QueryHistoryEntry[]>;
+  removeQueryHistory(id: string): Promise<{ removed: boolean }>;
+  clearQueryHistory(): Promise<{ cleared: boolean }>;
+  setQueryHistoryFavorite(id: string, isFavorite: boolean): Promise<{ updated: boolean }>;
+  getCacheStats(): Promise<CacheStats>;
+  clearCache(): Promise<{ cleared: boolean }>;
+  buildDataViewSql(
+    connectionId: string,
+    tableName: string,
+    limit: number,
+    whereClause?: string
+  ): Promise<{ sql: string }>;
+  buildWhereClause(
+    connectionId: string,
+    conditions: BuildWhereCondition[]
+  ): Promise<{ whereClause: string }>;
+  buildDmlStatements(
+    connectionId: string,
+    params: BuildDmlParams
+  ): Promise<{ statements: string[] }>;
+  uppercaseKeywords(sql: string): Promise<{ sql: string }>;
 }
 
 class QueryProviderImpl implements QueryProvider {
@@ -184,6 +240,72 @@ class QueryProviderImpl implements QueryProvider {
   ): Promise<{ plan: string; actual: boolean }> {
     const raw = await this.invoker.invoke('getExecutionPlan', { connectionId, sql, actual });
     return this.validator.parse(S.getExecutionPlan, raw);
+  }
+
+  async getQueryHistory(): Promise<QueryHistoryEntry[]> {
+    const raw = await this.invoker.invoke('getQueryHistory', {});
+    return this.validator.parse(S.getQueryHistory, raw);
+  }
+
+  async removeQueryHistory(id: string): Promise<{ removed: boolean }> {
+    const raw = await this.invoker.invoke('removeQueryHistory', { id });
+    return this.validator.parse(S.removeQueryHistory, raw);
+  }
+
+  async clearQueryHistory(): Promise<{ cleared: boolean }> {
+    const raw = await this.invoker.invoke('clearQueryHistory', {});
+    return this.validator.parse(S.clearQueryHistory, raw);
+  }
+
+  async setQueryHistoryFavorite(id: string, isFavorite: boolean): Promise<{ updated: boolean }> {
+    const raw = await this.invoker.invoke('setQueryHistoryFavorite', { id, isFavorite });
+    return this.validator.parse(S.setQueryHistoryFavorite, raw);
+  }
+
+  async getCacheStats(): Promise<CacheStats> {
+    const raw = await this.invoker.invoke('getCacheStats', {});
+    return this.validator.parse(S.getCacheStats, raw);
+  }
+
+  async clearCache(): Promise<{ cleared: boolean }> {
+    const raw = await this.invoker.invoke('clearCache', {});
+    return this.validator.parse(S.clearCache, raw);
+  }
+
+  async buildDataViewSql(
+    connectionId: string,
+    tableName: string,
+    limit: number,
+    whereClause?: string
+  ): Promise<{ sql: string }> {
+    const raw = await this.invoker.invoke('buildDataViewSql', {
+      connectionId,
+      tableName,
+      limit,
+      whereClause,
+    });
+    return this.validator.parse(S.buildDataViewSql, raw);
+  }
+
+  async buildWhereClause(
+    connectionId: string,
+    conditions: BuildWhereCondition[]
+  ): Promise<{ whereClause: string }> {
+    const raw = await this.invoker.invoke('buildWhereClause', { connectionId, conditions });
+    return this.validator.parse(S.buildWhereClause, raw);
+  }
+
+  async buildDmlStatements(
+    connectionId: string,
+    params: BuildDmlParams
+  ): Promise<{ statements: string[] }> {
+    const raw = await this.invoker.invoke('buildDmlStatements', { connectionId, ...params });
+    return this.validator.parse(S.buildDmlStatements, raw);
+  }
+
+  async uppercaseKeywords(sql: string): Promise<{ sql: string }> {
+    const raw = await this.invoker.invoke('uppercaseKeywords', { sql });
+    return this.validator.parse(S.uppercaseKeywords, raw);
   }
 }
 

--- a/frontend/src/components/grid/hooks/useGridEdit.ts
+++ b/frontend/src/components/grid/hooks/useGridEdit.ts
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from 'react';
-import { bridge } from '../../../api/bridge';
 import { queryProvider } from '../../../api/providers';
 import { type CellChange, useEditStore } from '../../../store/editStore';
 import type { Query, ResultSet } from '../../../types';
@@ -170,7 +169,7 @@ export function useGridEdit({
     setApplyError(null);
 
     try {
-      const { statements } = await bridge.buildDmlStatements(activeConnectionId, dmlParams);
+      const { statements } = await queryProvider.buildDmlStatements(activeConnectionId, dmlParams);
       if (statements.length > 0) {
         setPreviewStatements(statements);
       }

--- a/frontend/src/components/grid/hooks/useRelatedRows.ts
+++ b/frontend/src/components/grid/hooks/useRelatedRows.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+// bridge: getForeignKeys (Schema系) — #521 で SchemaProvider に移管予定
+// queryProvider: buildWhereClause (Query系) — #520 移管済
 import { bridge } from '../../../api/bridge';
+import { queryProvider } from '../../../api/providers';
 import type { ForeignKeyInfo } from '../../../types';
 import { log } from '../../../utils/logger';
 
@@ -94,7 +97,7 @@ export function useRelatedRows({
           value: rowData[fkCol],
         }));
 
-        const { whereClause } = await bridge.buildWhereClause(connectionId, conditions);
+        const { whereClause } = await queryProvider.buildWhereClause(connectionId, conditions);
         log.debug(`[useRelatedRows] Navigate to ${fkInfo.referencedTable} WHERE ${whereClause}`);
 
         await onOpenRelatedTable(fkInfo.referencedTable, whereClause);

--- a/frontend/src/store/historyStore.ts
+++ b/frontend/src/store/historyStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
-import { bridge } from '../api/bridge';
+import { queryProvider } from '../api/providers';
 import type { HistoryItem } from '../types';
 
 export interface HistoryStats {
@@ -29,7 +29,7 @@ export const useHistoryStore = create<HistoryState>()((set, get) => ({
 
   fetchHistory: async () => {
     try {
-      const items = await bridge.getQueryHistory();
+      const items = await queryProvider.getQueryHistory();
       set({ history: items });
     } catch (error) {
       console.error('Failed to fetch query history:', error);
@@ -38,7 +38,7 @@ export const useHistoryStore = create<HistoryState>()((set, get) => ({
 
   removeHistory: async (id) => {
     try {
-      await bridge.removeQueryHistory(id);
+      await queryProvider.removeQueryHistory(id);
       await get().fetchHistory();
     } catch (error) {
       console.error('Failed to remove history:', error);
@@ -47,7 +47,7 @@ export const useHistoryStore = create<HistoryState>()((set, get) => ({
 
   clearHistory: async () => {
     try {
-      await bridge.clearQueryHistory();
+      await queryProvider.clearQueryHistory();
       await get().fetchHistory();
     } catch (error) {
       console.error('Failed to clear history:', error);
@@ -56,7 +56,7 @@ export const useHistoryStore = create<HistoryState>()((set, get) => ({
 
   setFavorite: async (id, isFavorite) => {
     try {
-      await bridge.setQueryHistoryFavorite(id, isFavorite);
+      await queryProvider.setQueryHistoryFavorite(id, isFavorite);
       await get().fetchHistory();
     } catch (error) {
       console.error('Failed to set favorite:', error);

--- a/frontend/src/store/query/slices/dataViewSlice.ts
+++ b/frontend/src/store/query/slices/dataViewSlice.ts
@@ -1,4 +1,4 @@
-import { bridge as apiBridge } from '../../../api/bridge';
+import { queryProvider } from '../../../api/providers';
 import type { Query } from '../../../types';
 import { log } from '../../../utils/logger';
 import { getSettings } from '../../../utils/settingsUtils';
@@ -77,7 +77,7 @@ export function createDataViewSlice(
       abort.register(id, controller);
 
       try {
-        const { sql } = await apiBridge.buildDataViewSql(
+        const { sql } = await queryProvider.buildDataViewSql(
           connectionId,
           tableName,
           PAGE_SIZE + 1,
@@ -157,7 +157,7 @@ export function createDataViewSlice(
       abort.register(id, controller);
 
       try {
-        const { sql } = await apiBridge.buildDataViewSql(
+        const { sql } = await queryProvider.buildDataViewSql(
           connectionId,
           query.sourceTable,
           PAGE_SIZE + 1,

--- a/frontend/src/tests/api/queryProvider.test.ts
+++ b/frontend/src/tests/api/queryProvider.test.ts
@@ -191,4 +191,157 @@ describe('queryProvider', () => {
 
     await expect(queryProvider.getRowCount('conn1', 'SELECT 1')).rejects.toThrow();
   });
+
+  // --- History (#520) ---
+  it('getQueryHistory は履歴エントリ配列を返す', async () => {
+    mock.setResponse('getQueryHistory', [
+      {
+        id: 'h-1',
+        sql: 'SELECT 1',
+        connectionId: 'conn1',
+        timestamp: 1000,
+        executionTimeMs: 5,
+        success: true,
+        errorMessage: '',
+        affectedRows: 0,
+        isFavorite: false,
+      },
+    ]);
+
+    const result = await queryProvider.getQueryHistory();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('h-1');
+    expect(mock.calls[0]).toEqual({ method: 'getQueryHistory', params: {} });
+  });
+
+  it('removeQueryHistory は id を渡し removed フラグを返す', async () => {
+    mock.setResponse('removeQueryHistory', { removed: true });
+
+    const result = await queryProvider.removeQueryHistory('h-1');
+
+    expect(result).toEqual({ removed: true });
+    expect(mock.calls[0]).toEqual({ method: 'removeQueryHistory', params: { id: 'h-1' } });
+  });
+
+  it('clearQueryHistory は cleared フラグを返す', async () => {
+    mock.setResponse('clearQueryHistory', { cleared: true });
+
+    const result = await queryProvider.clearQueryHistory();
+
+    expect(result).toEqual({ cleared: true });
+    expect(mock.calls[0]).toEqual({ method: 'clearQueryHistory', params: {} });
+  });
+
+  it('setQueryHistoryFavorite は id/isFavorite を渡し updated フラグを返す', async () => {
+    mock.setResponse('setQueryHistoryFavorite', { updated: true });
+
+    const result = await queryProvider.setQueryHistoryFavorite('h-1', true);
+
+    expect(result).toEqual({ updated: true });
+    expect(mock.calls[0]).toEqual({
+      method: 'setQueryHistoryFavorite',
+      params: { id: 'h-1', isFavorite: true },
+    });
+  });
+
+  it('setQueryHistoryFavorite は isFavorite=false でも正しく渡す', async () => {
+    mock.setResponse('setQueryHistoryFavorite', { updated: true });
+
+    await queryProvider.setQueryHistoryFavorite('h-1', false);
+
+    expect(mock.calls[0]?.params).toMatchObject({ isFavorite: false });
+  });
+
+  // --- Cache (#520) ---
+  it('getCacheStats は CacheStats を返す', async () => {
+    mock.setResponse('getCacheStats', {
+      currentSizeBytes: 100,
+      maxSizeBytes: 1000,
+      usagePercent: 10,
+    });
+
+    const result = await queryProvider.getCacheStats();
+
+    expect(result).toEqual({ currentSizeBytes: 100, maxSizeBytes: 1000, usagePercent: 10 });
+  });
+
+  it('clearCache は cleared フラグを返す', async () => {
+    mock.setResponse('clearCache', { cleared: true });
+
+    const result = await queryProvider.clearCache();
+
+    expect(result).toEqual({ cleared: true });
+    expect(mock.calls[0]).toEqual({ method: 'clearCache', params: {} });
+  });
+
+  // --- SQL builder (#520) ---
+  it('buildDataViewSql は whereClause を含む全パラメータを渡す', async () => {
+    mock.setResponse('buildDataViewSql', { sql: 'SELECT TOP 10 * FROM [t] WHERE id = 1' });
+
+    const result = await queryProvider.buildDataViewSql('conn1', 't', 10, 'id = 1');
+
+    expect(result).toEqual({ sql: 'SELECT TOP 10 * FROM [t] WHERE id = 1' });
+    expect(mock.calls[0]).toEqual({
+      method: 'buildDataViewSql',
+      params: { connectionId: 'conn1', tableName: 't', limit: 10, whereClause: 'id = 1' },
+    });
+  });
+
+  it('buildDataViewSql は whereClause 省略時に undefined を渡す', async () => {
+    mock.setResponse('buildDataViewSql', { sql: 'SELECT TOP 10 * FROM [t]' });
+
+    await queryProvider.buildDataViewSql('conn1', 't', 10);
+
+    expect(mock.calls[0]?.params).toMatchObject({ whereClause: undefined });
+  });
+
+  it('buildWhereClause は connectionId/conditions を渡し whereClause を返す', async () => {
+    mock.setResponse('buildWhereClause', { whereClause: "id = 1 AND name = 'a'" });
+
+    const result = await queryProvider.buildWhereClause('conn1', [
+      { column: 'id', value: '1' },
+      { column: 'name', value: 'a' },
+    ]);
+
+    expect(result.whereClause).toBe("id = 1 AND name = 'a'");
+    expect(mock.calls[0]?.params).toEqual({
+      connectionId: 'conn1',
+      conditions: [
+        { column: 'id', value: '1' },
+        { column: 'name', value: 'a' },
+      ],
+    });
+  });
+
+  it('buildDmlStatements は connectionId をフラットに展開して params を渡す', async () => {
+    mock.setResponse('buildDmlStatements', { statements: ["UPDATE t SET name='b' WHERE id=1"] });
+
+    const result = await queryProvider.buildDmlStatements('conn1', {
+      schema: 'dbo',
+      table: 't',
+      pkColumns: ['id'],
+      updates: [{ changes: { name: 'b' }, originalData: { id: '1', name: 'a' } }],
+    });
+
+    expect(result.statements).toHaveLength(1);
+    expect(mock.calls[0]?.params).toMatchObject({
+      connectionId: 'conn1',
+      schema: 'dbo',
+      table: 't',
+      pkColumns: ['id'],
+    });
+  });
+
+  it('uppercaseKeywords は sql を渡し変換後 sql を返す', async () => {
+    mock.setResponse('uppercaseKeywords', { sql: 'SELECT * FROM t' });
+
+    const result = await queryProvider.uppercaseKeywords('select * from t');
+
+    expect(result).toEqual({ sql: 'SELECT * FROM t' });
+    expect(mock.calls[0]).toEqual({
+      method: 'uppercaseKeywords',
+      params: { sql: 'select * from t' },
+    });
+  });
 });

--- a/frontend/src/tests/grid/useGridEdit.test.ts
+++ b/frontend/src/tests/grid/useGridEdit.test.ts
@@ -33,8 +33,8 @@ vi.mock('../../store/editStore', () => ({
   }),
 }));
 
-vi.mock('../../api/bridge', () => ({
-  bridge: {
+vi.mock('../../api/providers', () => ({
+  queryProvider: {
     buildDmlStatements: vi.fn(),
     executeQuery: vi.fn(),
   },

--- a/frontend/src/tests/stores/historyStore.test.ts
+++ b/frontend/src/tests/stores/historyStore.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useHistoryStore } from '../../store/historyStore';
 
-// Mock bridge
-vi.mock('../../api/bridge', () => ({
-  bridge: {
+// Mock providers (#520 で queryProvider に移管済み)
+vi.mock('../../api/providers', () => ({
+  queryProvider: {
     getQueryHistory: vi.fn().mockResolvedValue([]),
     removeQueryHistory: vi.fn().mockResolvedValue({ removed: true }),
     clearQueryHistory: vi.fn().mockResolvedValue({ cleared: true }),
@@ -12,7 +12,7 @@ vi.mock('../../api/bridge', () => ({
 }));
 
 // Import after mock
-const { bridge } = await import('../../api/bridge');
+const { queryProvider } = await import('../../api/providers');
 
 describe('historyStore', () => {
   beforeEach(() => {
@@ -26,7 +26,7 @@ describe('historyStore', () => {
 
   describe('fetchHistory', () => {
     it('should fetch history from backend and update store', async () => {
-      vi.mocked(bridge.getQueryHistory).mockResolvedValue([
+      vi.mocked(queryProvider.getQueryHistory).mockResolvedValue([
         {
           id: 'hist_1',
           sql: 'SELECT * FROM users',
@@ -106,7 +106,7 @@ describe('historyStore', () => {
 
   describe('setFavorite', () => {
     it('should call backend and refetch', async () => {
-      vi.mocked(bridge.getQueryHistory).mockResolvedValue([
+      vi.mocked(queryProvider.getQueryHistory).mockResolvedValue([
         {
           id: 'hist_1',
           sql: 'SELECT 1',
@@ -122,19 +122,19 @@ describe('historyStore', () => {
 
       await useHistoryStore.getState().setFavorite('hist_1', true);
 
-      expect(bridge.setQueryHistoryFavorite).toHaveBeenCalledWith('hist_1', true);
-      expect(bridge.getQueryHistory).toHaveBeenCalled();
+      expect(queryProvider.setQueryHistoryFavorite).toHaveBeenCalledWith('hist_1', true);
+      expect(queryProvider.getQueryHistory).toHaveBeenCalled();
     });
   });
 
   describe('clearHistory', () => {
     it('should call backend and refetch', async () => {
-      vi.mocked(bridge.getQueryHistory).mockResolvedValue([]);
+      vi.mocked(queryProvider.getQueryHistory).mockResolvedValue([]);
 
       await useHistoryStore.getState().clearHistory();
 
-      expect(bridge.clearQueryHistory).toHaveBeenCalled();
-      expect(bridge.getQueryHistory).toHaveBeenCalled();
+      expect(queryProvider.clearQueryHistory).toHaveBeenCalled();
+      expect(queryProvider.getQueryHistory).toHaveBeenCalled();
     });
   });
 
@@ -198,12 +198,12 @@ describe('historyStore', () => {
 
   describe('removeHistory', () => {
     it('should call backend and refetch', async () => {
-      vi.mocked(bridge.getQueryHistory).mockResolvedValue([]);
+      vi.mocked(queryProvider.getQueryHistory).mockResolvedValue([]);
 
       await useHistoryStore.getState().removeHistory('hist_1');
 
-      expect(bridge.removeQueryHistory).toHaveBeenCalledWith('hist_1');
-      expect(bridge.getQueryHistory).toHaveBeenCalled();
+      expect(queryProvider.removeQueryHistory).toHaveBeenCalledWith('hist_1');
+      expect(queryProvider.getQueryHistory).toHaveBeenCalled();
     });
   });
 });

--- a/frontend/src/tests/stores/queryStore.dataview.test.ts
+++ b/frontend/src/tests/stores/queryStore.dataview.test.ts
@@ -12,13 +12,21 @@ vi.mock('../../api/bridge', () => ({
     getColumns: vi.fn(),
     saveQueryToFile: vi.fn(),
     loadQueryFromFile: vi.fn(),
+  },
+}));
+
+// #520 で queryProvider に移管: buildDataViewSql
+vi.mock('../../api/providers', () => ({
+  queryProvider: {
     buildDataViewSql: vi.fn(),
   },
 }));
 
 import { bridge } from '../../api/bridge';
+import { queryProvider } from '../../api/providers';
 
 const mockedBridge = vi.mocked(bridge);
+const mockedQueryProvider = vi.mocked(queryProvider);
 
 function mockDataViewQuery(columns: { name: string; type: string }[], rows: string[][]) {
   mockedBridge.getColumns.mockResolvedValue([]);
@@ -31,7 +39,7 @@ function mockDataViewQuery(columns: { name: string; type: string }[], rows: stri
     affectedRows: 0,
     executionTimeMs: 10,
   });
-  mockedBridge.buildDataViewSql.mockImplementation(
+  mockedQueryProvider.buildDataViewSql.mockImplementation(
     async (_connId: string, tableName: string, limit: number, whereClause?: string) => {
       const quoted = tableName
         .split('.')
@@ -47,7 +55,9 @@ function mockDataViewQuery(columns: { name: string; type: string }[], rows: stri
 
 function mockDataViewError(error: Error) {
   mockedBridge.getColumns.mockResolvedValue([]);
-  mockedBridge.buildDataViewSql.mockResolvedValue({ sql: 'SELECT TOP 10001 * FROM [test]' });
+  mockedQueryProvider.buildDataViewSql.mockResolvedValue({
+    sql: 'SELECT TOP 10001 * FROM [test]',
+  });
   mockedBridge.executeAsyncQuery.mockRejectedValue(error);
 }
 
@@ -82,7 +92,7 @@ describe('DataView operations', () => {
       expect(state.queries[0].content).toContain('SELECT');
       expect(state.queries[0].content).toContain('dbo');
       expect(state.activeQueryId).toBe(state.queries[0].id);
-      expect(mockedBridge.buildDataViewSql).toHaveBeenCalledWith(
+      expect(mockedQueryProvider.buildDataViewSql).toHaveBeenCalledWith(
         'conn_1',
         'dbo.Users',
         10001,
@@ -118,7 +128,7 @@ describe('DataView operations', () => {
       const state = useQueryStore.getState();
       expect(state.queries).toHaveLength(2);
       expect(state.queries[1].content).toContain('WHERE id = 1');
-      expect(mockedBridge.buildDataViewSql).toHaveBeenCalledWith(
+      expect(mockedQueryProvider.buildDataViewSql).toHaveBeenCalledWith(
         'conn_1',
         'dbo.Users',
         10001,

--- a/frontend/src/tests/stores/queryStore.pagination.test.ts
+++ b/frontend/src/tests/stores/queryStore.pagination.test.ts
@@ -11,15 +11,23 @@ vi.mock('../../api/bridge', () => ({
     removeAsyncQuery: vi.fn().mockResolvedValue({ removed: true }),
     cancelQuery: vi.fn(),
     getColumns: vi.fn(),
-    buildDataViewSql: vi.fn(),
     executeQueryPaginated: vi.fn(),
     getRowCount: vi.fn(),
   },
 }));
 
+// #520 で queryProvider に移管: buildDataViewSql
+vi.mock('../../api/providers', () => ({
+  queryProvider: {
+    buildDataViewSql: vi.fn(),
+  },
+}));
+
 import { bridge } from '../../api/bridge';
+import { queryProvider } from '../../api/providers';
 
 const mockedBridge = vi.mocked(bridge);
+const mockedQueryProvider = vi.mocked(queryProvider);
 
 function mockTruncatedDataView(rowCount: number) {
   const rows = Array.from({ length: PAGE_SIZE }, (_, i) => [String(i)]);
@@ -34,7 +42,7 @@ function mockTruncatedDataView(rowCount: number) {
     executionTimeMs: 10,
     truncated: true,
   });
-  mockedBridge.buildDataViewSql.mockImplementation(
+  mockedQueryProvider.buildDataViewSql.mockImplementation(
     async (_connId: string, tableName: string, limit: number) => ({
       sql: `SELECT TOP ${limit} * FROM [${tableName}]`,
     })


### PR DESCRIPTION
#517 確定境界 (1 IF / backend provider) に従い、bridge.ts の 10 メソッドを queryProvider に移管。consumer (historyStore / useGridEdit / useRelatedRows / dataViewSlice) も provider 直接利用に切替。

Closes #520