### PR TITLE
feat(scripts): pdg.py lint 並列化 (#534)

### DIFF
--- a/scripts/_lib/lint.py
+++ b/scripts/_lib/lint.py
@@ -1,28 +1,61 @@
 """Lint commands for Velocity-DB."""
 
+import io
 import shutil
 import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TextIO
 
 from . import utils
 
 
-def lint_frontend(fix: bool = False, unsafe: bool = False) -> bool:
+def _run_subprocess(
+    cmd: list[str],
+    description: str,
+    cwd: Path | None = None,
+    out: TextIO | None = None,
+) -> bool:
+    """Run a subprocess. Streams live to terminal when `out` is None;
+    captures and writes to `out` otherwise (parallel-safe)."""
+    if out is None:
+        success, _ = utils.run_command(cmd, description, cwd=cwd)
+        return success
+
+    utils.print_footer(description, file=out)
+    print(f"  Command: {' '.join(cmd)}", file=out)
+    if cwd:
+        print(f"  Working directory: {cwd}", file=out)
+    try:
+        result = subprocess.run(cmd, cwd=cwd, capture_output=True, encoding="utf-8")
+    except FileNotFoundError:
+        print(f"ERROR: Command not found: {cmd[0]}", file=out)
+        return False
+    if result.stdout:
+        print(result.stdout, end="", file=out)
+    if result.stderr:
+        print(result.stderr, end="", file=out)
+    return result.returncode == 0
+
+
+def lint_frontend(fix: bool = False, unsafe: bool = False, out: TextIO | None = None) -> bool:
     """Lint frontend code with Biome."""
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
     if fix:
         mode = "Auto-fix (safe + unsafe)" if unsafe else "Auto-fix (safe only)"
-        utils.print_header("Linting Frontend", f"Mode: {mode}")
+        utils.print_header("Linting Frontend", f"Mode: {mode}", file=out)
     else:
-        utils.print_header("Linting Frontend")
+        utils.print_header("Linting Frontend", file=out)
 
-    # Ensure dependencies
+    # Ensure dependencies (output goes to real stdout in parallel mode; rare path)
     pkg_info = utils.ensure_frontend_deps()
     if not pkg_info:
         return False
 
-    pkg_manager, pkg_path = pkg_info
+    _, pkg_path = pkg_info
 
     # Run lint
     lint_cmd = [str(pkg_path), "run", "lint"]
@@ -32,54 +65,57 @@ def lint_frontend(fix: bool = False, unsafe: bool = False) -> bool:
         if unsafe:
             lint_cmd.append("--unsafe")
 
-    success, _ = utils.run_command(lint_cmd, "Biome lint", cwd=frontend_dir)
+    success = _run_subprocess(lint_cmd, "Biome lint", cwd=frontend_dir, out=out)
 
     # Run type check
-    print("\n[Type checking...]")
-    success2, _ = utils.run_command(
-        [str(pkg_path), "run", "typecheck"], "TypeScript check", cwd=frontend_dir
+    print("\n[Type checking...]", file=out)
+    success2 = _run_subprocess(
+        [str(pkg_path), "run", "typecheck"],
+        "TypeScript check",
+        cwd=frontend_dir,
+        out=out,
     )
 
     if success and success2:
-        print("\n[OK] Lint passed!")
+        print("\n[OK] Lint passed!", file=out)
         return True
     else:
-        print("\n[FAIL] Lint failed")
+        print("\n[FAIL] Lint failed", file=out)
         return False
 
 
-def lint_cpp(fix: bool = False) -> bool:
+def lint_cpp(fix: bool = False, out: TextIO | None = None) -> bool:
     """Lint C++ code with clang-format."""
     project_root = utils.get_project_root()
     src_dir = project_root / "backend"
 
     subtitles = ("Mode: Auto-fix",) if fix else ()
-    utils.print_header("Linting C++", *subtitles)
+    utils.print_header("Linting C++", *subtitles, file=out)
 
     # Check for clang-format
     clang_format = shutil.which("clang-format")
     if not clang_format:
-        print("\nERROR: clang-format not found")
-        print("Install: winget install LLVM.LLVM")
+        print("\nERROR: clang-format not found", file=out)
+        print("Install: winget install LLVM.LLVM", file=out)
         return False
 
     # Get version
     try:
         result = subprocess.run([clang_format, "--version"], capture_output=True, text=True)
-        print(f"\n{result.stdout.strip()}")
+        print(f"\n{result.stdout.strip()}", file=out)
     except Exception:
         pass
 
     # Find all C++ files
-    cpp_files = []
+    cpp_files: list[Path] = []
     for ext in ["*.cpp", "*.h"]:
         cpp_files.extend(src_dir.rglob(ext))
 
     if not cpp_files:
-        print("\nERROR: No C++ files found")
+        print("\nERROR: No C++ files found", file=out)
         return False
 
-    print(f"\nFound {len(cpp_files)} C++ files")
+    print(f"\nFound {len(cpp_files)} C++ files", file=out)
 
     # Run clang-format on all files at once (much faster than one-by-one)
     file_args = [str(f) for f in cpp_files]
@@ -87,56 +123,58 @@ def lint_cpp(fix: bool = False) -> bool:
         cmd = [clang_format, "-i", "-style=file", "--verbose"] + file_args
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.stderr:
-            print(result.stderr.strip())
+            print(result.stderr.strip(), file=out)
         if result.returncode != 0:
-            print("\n[FAIL] clang-format failed")
+            print("\n[FAIL] clang-format failed", file=out)
             return False
-        print(f"\n[OK] {len(cpp_files)} files formatted!")
+        print(f"\n[OK] {len(cpp_files)} files formatted!", file=out)
         return True
     else:
         cmd = [clang_format, "--style=file", "--dry-run", "--Werror"] + file_args
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
+            seen: set[str] = set()
             if result.stderr:
                 # Extract filenames from warnings
-                seen: set[str] = set()
                 for line in result.stderr.splitlines():
                     for f in cpp_files:
                         rel = str(f.relative_to(project_root))
                         if str(f) in line and rel not in seen:
-                            print(f"  [FAIL] {rel}")
+                            print(f"  [FAIL] {rel}", file=out)
                             seen.add(rel)
-            print(f"\n[FAIL] {len(seen) if result.stderr else '?'} file(s) need formatting")
-            print("Run with --fix to auto-format")
+            print(
+                f"\n[FAIL] {len(seen) if result.stderr else '?'} file(s) need formatting", file=out
+            )
+            print("Run with --fix to auto-format", file=out)
             return False
-        print(f"\n[OK] All {len(cpp_files)} files properly formatted!")
+        print(f"\n[OK] All {len(cpp_files)} files properly formatted!", file=out)
         return True
 
 
-def lint_python(fix: bool = False) -> bool:
+def lint_python(fix: bool = False, out: TextIO | None = None) -> bool:
     """Lint Python code with Ruff."""
     project_root = utils.get_project_root()
     scripts_dir = project_root / "scripts"
 
     subtitles = ("Mode: Auto-fix",) if fix else ()
-    utils.print_header("Linting Python", *subtitles)
+    utils.print_header("Linting Python", *subtitles, file=out)
 
     # Check for ruff
     ruff = shutil.which("ruff")
     if not ruff:
-        print("\nERROR: ruff not found")
-        print("Install: uv pip install ruff")
+        print("\nERROR: ruff not found", file=out)
+        print("Install: uv pip install ruff", file=out)
         return False
 
     # Get version
     try:
         result = subprocess.run([ruff, "--version"], capture_output=True, text=True)
-        print(f"\n{result.stdout.strip()}")
+        print(f"\n{result.stdout.strip()}", file=out)
     except Exception:
         pass
 
     # Run ruff check (linting)
-    print("\n[Linting...]")
+    print("\n[Linting...]", file=out)
     check_cmd = [ruff, "check", str(scripts_dir)]
     if fix:
         check_cmd.append("--fix")
@@ -145,21 +183,21 @@ def lint_python(fix: bool = False) -> bool:
     success_check = result_check.returncode == 0
 
     if result_check.stdout:
-        print(result_check.stdout)
+        print(result_check.stdout, file=out)
     if result_check.stderr:
-        print(result_check.stderr)
+        print(result_check.stderr, file=out)
 
     # Run ruff format (formatting)
-    print("\n[Formatting...]")
+    print("\n[Formatting...]", file=out)
     if fix:
         format_cmd = [ruff, "format", str(scripts_dir)]
         result_format = subprocess.run(format_cmd, capture_output=True, text=True)
         success_format = result_format.returncode == 0
 
         if result_format.stdout:
-            print(result_format.stdout)
+            print(result_format.stdout, file=out)
         if result_format.stderr:
-            print(result_format.stderr)
+            print(result_format.stderr, file=out)
     else:
         # Check formatting without modifying
         format_cmd = [ruff, "format", "--check", str(scripts_dir)]
@@ -167,26 +205,54 @@ def lint_python(fix: bool = False) -> bool:
         success_format = result_format.returncode == 0
 
         if result_format.stdout:
-            print(result_format.stdout)
+            print(result_format.stdout, file=out)
         if result_format.stderr:
-            print(result_format.stderr)
+            print(result_format.stderr, file=out)
 
     if success_check and success_format:
-        print("\n[OK] Python lint passed!")
+        print("\n[OK] Python lint passed!", file=out)
         return True
     else:
-        print("\n[FAIL] Python lint failed")
+        print("\n[FAIL] Python lint failed", file=out)
         if not fix:
-            print("Run with --fix to auto-format")
+            print("Run with --fix to auto-format", file=out)
         return False
 
 
-def lint_all(fix: bool = False, unsafe: bool = False) -> bool:
-    """Lint frontend and C++ code (product code only)."""
+def _print_labeled(label: str, content: str) -> None:
+    """Print captured output with a section label."""
+    bar = "=" * 60
+    print(f"\n{bar}\n  [{label}]\n{bar}")
+    sys.stdout.write(content)
+    if not content.endswith("\n"):
+        print()
+
+
+def lint_all(fix: bool = False, unsafe: bool = False, parallel: bool = True) -> bool:
+    """Lint frontend and C++ code (product code only).
+
+    Runs frontend and C++ lint in parallel by default. Pass parallel=False
+    for sequential execution (legacy behavior).
+    """
     utils.print_footer("Linting All (Frontend + C++)")
 
-    success1 = lint_frontend(fix=fix, unsafe=unsafe)
-    success2 = lint_cpp(fix=fix)
+    if not parallel:
+        success1 = lint_frontend(fix=fix, unsafe=unsafe)
+        success2 = lint_cpp(fix=fix)
+        utils.print_footer("ALL LINTS PASSED" if (success1 and success2) else "SOME LINTS FAILED")
+        return success1 and success2
+
+    print("\n[Running frontend + C++ lint in parallel...]")
+    buf_front = io.StringIO()
+    buf_cpp = io.StringIO()
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        fut_front = executor.submit(lint_frontend, fix=fix, unsafe=unsafe, out=buf_front)
+        fut_cpp = executor.submit(lint_cpp, fix=fix, out=buf_cpp)
+        success1 = fut_front.result()
+        success2 = fut_cpp.result()
+
+    _print_labeled("FRONTEND", buf_front.getvalue())
+    _print_labeled("CPP", buf_cpp.getvalue())
 
     utils.print_footer("ALL LINTS PASSED" if (success1 and success2) else "SOME LINTS FAILED")
     return success1 and success2

--- a/scripts/_lib/utils.py
+++ b/scripts/_lib/utils.py
@@ -5,26 +5,27 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import TextIO
 
 PackageManager = tuple[str, Path]
 
 _BANNER_WIDTH = 60
 
 
-def print_header(title: str, *subtitles: str) -> None:
+def print_header(title: str, *subtitles: str, file: TextIO | None = None) -> None:
     """Print a section header (e.g. '#  Building Backend (Debug)')."""
-    print(f"\n{'#' * _BANNER_WIDTH}")
-    print(f"#  {title}")
+    print(f"\n{'#' * _BANNER_WIDTH}", file=file)
+    print(f"#  {title}", file=file)
     for s in subtitles:
-        print(f"#  {s}")
-    print(f"{'#' * _BANNER_WIDTH}")
+        print(f"#  {s}", file=file)
+    print(f"{'#' * _BANNER_WIDTH}", file=file)
 
 
-def print_footer(message: str) -> None:
+def print_footer(message: str, *, file: TextIO | None = None) -> None:
     """Print a footer banner (e.g. 'BUILD SUCCESSFUL')."""
-    print(f"\n{'=' * _BANNER_WIDTH}")
-    print(f"  {message}")
-    print(f"{'=' * _BANNER_WIDTH}")
+    print(f"\n{'=' * _BANNER_WIDTH}", file=file)
+    print(f"  {message}", file=file)
+    print(f"{'=' * _BANNER_WIDTH}", file=file)
 
 
 def get_project_root() -> Path:

--- a/scripts/pdg.py
+++ b/scripts/pdg.py
@@ -95,7 +95,8 @@ def cmd_lint(args: argparse.Namespace) -> bool:
     """Handle lint command."""
     fix: bool = args.fix
     unsafe: bool = args.unsafe
-    return lint.lint_all(fix=fix, unsafe=unsafe)
+    parallel: bool = not args.no_async
+    return lint.lint_all(fix=fix, unsafe=unsafe, parallel=parallel)
 
 
 def cmd_dev(_args: argparse.Namespace) -> bool:
@@ -450,6 +451,11 @@ def main() -> None:
     lint_parser.add_argument("--fix", "-f", action="store_true", help="Auto-fix issues")
     lint_parser.add_argument(
         "--unsafe", "-u", action="store_true", help="Apply unsafe fixes (requires --fix)"
+    )
+    lint_parser.add_argument(
+        "--no-async",
+        action="store_true",
+        help="Disable parallel execution (run frontend and C++ lint sequentially)",
     )
 
     # Dev command


### PR DESCRIPTION
## Summary

- `uv run scripts/pdg.py lint` を**デフォルトで並列実行** (frontend biome+tsc と C++ clang-format を ThreadPoolExecutor で同時実行)
- `--no-async` フラグで従来の直列実行も可能 (issue #534 の仕様準拠)
- 出力は `[FRONTEND]` / `[CPP]` プレフィックスでセクション分けし混線を防止

## Changes

| File | 変更 |
|---|---|
| `scripts/_lib/lint.py` | `_run_subprocess` ヘルパー追加、`lint_frontend`/`lint_cpp`/`lint_python` に `out: TextIO \| None` パラメータ追加、`lint_all` を ThreadPoolExecutor で並列化 (`parallel=True` がデフォルト) |
| `scripts/_lib/utils.py` | `print_header`/`print_footer` に `file: TextIO \| None` パラメータ追加 |
| `scripts/pdg.py` | lint コマンドに `--no-async` フラグ追加、`cmd_lint` で並列フラグ転送 |

## 設計上の判断

- **ThreadPoolExecutor 採用**: 各 lint 関数の subprocess は `capture_output=True` で出力をキャプチャ、結果を `print(..., file=out)` で `StringIO` バッファへ書き込み。スレッド間の `sys.stdout` 共有を避けるため明示的な `out` パラメータ伝播設計
- **後方互換**: 既存の `lint_all(fix=...)` 呼び出し (`cmd_check`, `cmd_release`) はデフォルトで並列モードに切り替わる。出力プレフィックスが付くだけで挙動は同等
- **失敗時挙動**: 片方失敗でも両方を最後まで実行 (CI での結果取得性)

## 計測 (Windows, ローカル)

| モード | wall-clock |
|---|---|
| `pdg.py lint` (並列) | 5.40s |
| `pdg.py lint --no-async` (直列) | 5.76s |

biome と clang-format がいずれも既に高速なため改善幅は小さい。bun 起動オーバーヘッドが支配的。CI 環境やリポジトリ規模が大きくなった際により効果が出る想定。

## Test plan

- [x] `uv run scripts/pdg.py lint` → 並列実行で全 lint pass、`[FRONTEND]`/`[CPP]` セクション付き出力
- [x] `uv run scripts/pdg.py lint --no-async` → 直列実行で従来通り live ストリーミング出力
- [x] `uv run scripts/pdg.py lint --help` → `--no-async` ヘルプ表示
- [x] `ruff check scripts/ && ruff format --check scripts/` → all pass
- [x] Pylance 診断 → クリーン (`pkg_manager` 未使用変数解消、`cpp_files: list[Path]` 型注釈追加)

## Related

- Closes #534
- 親 issue #532 のサブタスクの 1 つ
- #531 (biome→oxc 調査) はコメントで結論報告予定 (実装変更なし)