### PR TITLE
feat(scripts): pdg.py build/test 並列化 (#533, #536)

### DIFF
--- a/scripts/_lib/build.py
+++ b/scripts/_lib/build.py
@@ -1,21 +1,23 @@
 """Build commands for Velocity-DB."""
 
+import io
 import shutil
+from concurrent.futures import ThreadPoolExecutor
+from typing import TextIO
 
 from . import utils
 
 
-def build_frontend(clean: bool = False) -> bool:
+def build_frontend(clean: bool = False, out: TextIO | None = None) -> bool:
     """Build the frontend."""
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
     subtitles = ("Mode: Clean Build",) if clean else ()
-    utils.print_header("Building Frontend", *subtitles)
+    utils.print_header("Building Frontend", *subtitles, file=out)
 
-    # Clear caches if --clean
     if clean:
-        print("\n[Cleaning caches...]")
+        print("\n[Cleaning caches...]", file=out)
         caches = [
             frontend_dir / "dist",
             frontend_dir / "node_modules" / ".vite",
@@ -25,150 +27,197 @@ def build_frontend(clean: bool = False) -> bool:
             if cache.exists():
                 try:
                     shutil.rmtree(cache)
-                    print(f"  [OK] Cleared: {cache.relative_to(project_root)}")
+                    print(f"  [OK] Cleared: {cache.relative_to(project_root)}", file=out)
                 except Exception as e:
-                    print(f"  [FAIL] {e}")
+                    print(f"  [FAIL] {e}", file=out)
 
-    # Check dependencies and get package manager
-    pkg_info = utils.ensure_frontend_deps()
+    pkg_info = utils.ensure_frontend_deps(out=out)
     if not pkg_info:
         return False
 
     pkg_manager, pkg_path = pkg_info
 
-    # Build
-    print("\n[Building...]")
+    print("\n[Building...]", file=out)
     success, _ = utils.run_command(
-        [str(pkg_path), "run", "build"], f"{pkg_manager} run build", cwd=frontend_dir
+        [str(pkg_path), "run", "build"],
+        f"{pkg_manager} run build",
+        cwd=frontend_dir,
+        out=out,
     )
 
     if not success:
-        print("\nERROR: Build failed")
+        print("\nERROR: Build failed", file=out)
         return False
 
-    # Report success
     dist_dir = frontend_dir / "dist"
     total_size = sum(f.stat().st_size for f in dist_dir.rglob("*") if f.is_file())
     file_count = sum(1 for _ in dist_dir.rglob("*") if _.is_file())
 
-    utils.print_footer("BUILD SUCCESSFUL")
-    print(f"\n  Output: {dist_dir}")
-    print(f"  Size: {total_size / 1024 / 1024:.2f} MB")
-    print(f"  Files: {file_count}")
+    utils.print_footer("BUILD SUCCESSFUL", file=out)
+    print(f"\n  Output: {dist_dir}", file=out)
+    print(f"  Size: {total_size / 1024 / 1024:.2f} MB", file=out)
+    print(f"  Files: {file_count}", file=out)
 
-    # Clear WebView2 cache
-    utils.clear_webview2_cache(project_root)
+    utils.clear_webview2_cache(project_root, out=out)
 
     return True
 
 
-def build_backend(build_type: str = "Release", clean: bool = False) -> bool:
+def _copy_frontend_to_build(build_type: str, out: TextIO | None = None) -> None:
+    """Copy frontend/dist to build/<type>/frontend (post-build step)."""
+    project_root = utils.get_project_root()
+    frontend_dist = project_root / "frontend" / "dist"
+    frontend_target = project_root / "build" / build_type / "frontend"
+
+    print("\n[Post-Build] Copying frontend files...", file=out)
+    if not frontend_dist.exists():
+        print("  [SKIP] Frontend dist not found", file=out)
+        print("  Run 'uv run scripts/pdg.py build frontend' first", file=out)
+        return
+    try:
+        if frontend_target.exists():
+            shutil.rmtree(frontend_target)
+        shutil.copytree(frontend_dist, frontend_target)
+        file_count = sum(1 for _ in frontend_target.rglob("*") if _.is_file())
+        print(f"  [OK] Copied: frontend/dist -> build/{build_type}/frontend", file=out)
+        print(f"  Files: {file_count}", file=out)
+    except Exception as e:
+        print(f"  [FAIL] {e}", file=out)
+
+
+def build_backend(
+    build_type: str = "Release",
+    clean: bool = False,
+    *,
+    copy_frontend: bool = True,
+    out: TextIO | None = None,
+) -> bool:
     """Build the backend."""
     if build_type not in ("Debug", "Release"):
-        print(f"ERROR: Invalid build type '{build_type}'. Use 'Debug' or 'Release'")
+        print(f"ERROR: Invalid build type '{build_type}'. Use 'Debug' or 'Release'", file=out)
         return False
 
     project_root = utils.get_project_root()
     build_dir = project_root / "build"
-    preset = build_type.lower()  # "debug" or "release"
+    preset = build_type.lower()
 
     subtitles = ("Mode: Clean Build",) if clean else ()
-    utils.print_header(f"Building Backend ({build_type})", *subtitles)
+    utils.print_header(f"Building Backend ({build_type})", *subtitles, file=out)
 
-    # Clean build directory if requested
     if clean and build_dir.exists():
-        print("\n[Cleaning build directory...]")
+        print("\n[Cleaning build directory...]", file=out)
         shutil.rmtree(build_dir)
-        print(f"  Removed: {build_dir}")
+        print(f"  Removed: {build_dir}", file=out)
 
-    # Setup MSVC environment
-    print("\n[1/4] Setting up MSVC environment...")
-    env = utils.get_msvc_env()
+    print("\n[1/4] Setting up MSVC environment...", file=out)
+    env = utils.get_msvc_env(out=out)
 
-    # Check tools
-    print("\n[2/4] Checking build tools...")
-    if not utils.check_build_tools(env):
+    print("\n[2/4] Checking build tools...", file=out)
+    if not utils.check_build_tools(env, out=out):
         return False
 
-    # Configure with Preset
-    print(f"\n[3/4] Configuring with CMake (preset: {preset})...")
+    print(f"\n[3/4] Configuring with CMake (preset: {preset})...", file=out)
     cmake_cmd = ["cmake", "--preset", preset]
-
-    success, stderr = utils.run_command(cmake_cmd, "CMake Configure", env=env, capture_output=True)
+    success, stderr = utils.run_command(
+        cmake_cmd, "CMake Configure", env=env, capture_output=True, out=out
+    )
     if not success:
-        print("\nERROR: CMake configuration failed")
-        if stderr:
+        print("\nERROR: CMake configuration failed", file=out)
+        if stderr and out is None:
             print(f"\n{stderr}")
         return False
 
-    # Build with Preset
-    print("\n[4/4] Building...")
+    print("\n[4/4] Building...", file=out)
     build_cmd = ["cmake", "--build", "--preset", preset]
-    success, _ = utils.run_command(build_cmd, f"CMake Build ({build_type})", env=env)
+    success, _ = utils.run_command(build_cmd, f"CMake Build ({build_type})", env=env, out=out)
     if not success:
-        print("\nERROR: Build failed")
+        print("\nERROR: Build failed", file=out)
         return False
 
-    # Find executable
     exe_path = build_dir / build_type / "VelocityDB.exe"
     if not exe_path.exists():
         for exe in build_dir.rglob("VelocityDB.exe"):
             exe_path = exe
             break
 
-    utils.print_footer("BUILD SUCCESSFUL")
+    utils.print_footer("BUILD SUCCESSFUL", file=out)
     if exe_path.exists():
-        print(f"\n  Executable: {exe_path}")
-        print(f"  Size: {exe_path.stat().st_size / 1024 / 1024:.2f} MB")
+        print(f"\n  Executable: {exe_path}", file=out)
+        print(f"  Size: {exe_path.stat().st_size / 1024 / 1024:.2f} MB", file=out)
 
-    # Copy frontend files
-    print("\n[Post-Build] Copying frontend files...")
-    frontend_dist = project_root / "frontend" / "dist"
-    frontend_target = build_dir / build_type / "frontend"
+    if copy_frontend:
+        _copy_frontend_to_build(build_type, out=out)
 
-    if frontend_dist.exists():
-        try:
-            if frontend_target.exists():
-                shutil.rmtree(frontend_target)
-            shutil.copytree(frontend_dist, frontend_target)
-            file_count = sum(1 for _ in frontend_target.rglob("*") if _.is_file())
-            print(f"  [OK] Copied: frontend/dist -> build/{build_type}/frontend")
-            print(f"  Files: {file_count}")
-        except Exception as e:
-            print(f"  [FAIL] {e}")
-    else:
-        print("  [SKIP] Frontend dist not found")
-        print("  Run 'uv run scripts/pdg.py build frontend' first")
+    utils.clear_webview2_cache(project_root, out=out)
 
-    # Clear WebView2 cache
-    utils.clear_webview2_cache(project_root)
-
-    # Final output: Show binary location
     if exe_path.exists():
-        utils.print_footer("BINARY LOCATION")
-        print(f"\n  {exe_path.absolute()}\n")
+        utils.print_footer("BINARY LOCATION", file=out)
+        print(f"\n  {exe_path.absolute()}\n", file=out)
 
     return True
 
 
-def build_all(build_type: str = "Release", clean: bool = False) -> bool:
-    """Build both frontend and backend."""
+def _print_labeled(label: str, content: str) -> None:
+    """Print captured output with a section label."""
+    bar = "=" * 60
+    print(f"\n{bar}\n  [{label}]\n{bar}")
+    import sys
+
+    sys.stdout.write(content)
+    if not content.endswith("\n"):
+        print()
+
+
+def build_all(build_type: str = "Release", clean: bool = False, parallel: bool = True) -> bool:
+    """Build both frontend and backend.
+
+    Runs frontend and backend builds in parallel by default. Pass parallel=False
+    for sequential execution (legacy behavior).
+    """
     project_root = utils.get_project_root()
     build_dir = project_root / "build"
 
     utils.print_footer("Building All (Frontend + Backend)")
 
-    # Build frontend first
-    if not build_frontend(clean=clean):
+    if not parallel:
+        if not build_frontend(clean=clean):
+            return False
+        if not build_backend(build_type=build_type, clean=clean):
+            return False
+        utils.print_footer("ALL BUILDS SUCCESSFUL")
+        exe_path = build_dir / build_type / "VelocityDB.exe"
+        if exe_path.exists():
+            print(f"\n  Binary: {exe_path.absolute()}")
+            print(f"  Run: {exe_path.name}")
+        return True
+
+    print("\n[Running frontend + backend build in parallel...]")
+    buf_front = io.StringIO()
+    buf_back = io.StringIO()
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        fut_front = executor.submit(build_frontend, clean=clean, out=buf_front)
+        # Skip frontend copy in parallel mode; we do it once after both complete.
+        fut_back = executor.submit(
+            build_backend,
+            build_type=build_type,
+            clean=clean,
+            copy_frontend=False,
+            out=buf_back,
+        )
+        success_front = fut_front.result()
+        success_back = fut_back.result()
+
+    _print_labeled("FRONTEND", buf_front.getvalue())
+    _print_labeled("BACKEND", buf_back.getvalue())
+
+    if not (success_front and success_back):
+        utils.print_footer("SOME BUILDS FAILED")
         return False
 
-    # Then build backend
-    if not build_backend(build_type=build_type, clean=clean):
-        return False
+    # Post: copy frontend to build dir (now that both have finished)
+    _copy_frontend_to_build(build_type)
 
     utils.print_footer("ALL BUILDS SUCCESSFUL")
-
-    # Show final binary location
     exe_path = build_dir / build_type / "VelocityDB.exe"
     if exe_path.exists():
         print(f"\n  Binary: {exe_path.absolute()}")

--- a/scripts/_lib/test.py
+++ b/scripts/_lib/test.py
@@ -1,65 +1,69 @@
 """Test commands for Velocity-DB."""
 
+import io
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from typing import TextIO
+
 from . import utils
 
 
-def test_frontend(watch: bool = False) -> bool:
+def test_frontend(watch: bool = False, out: TextIO | None = None) -> bool:
     """Run frontend tests."""
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
     subtitles = ("Mode: Watch",) if watch else ()
-    utils.print_header("Running Frontend Tests", *subtitles)
+    utils.print_header("Running Frontend Tests", *subtitles, file=out)
 
-    # Ensure dependencies
-    pkg_info = utils.ensure_frontend_deps()
+    pkg_info = utils.ensure_frontend_deps(out=out)
     if not pkg_info:
         return False
 
     pkg_manager, pkg_path = pkg_info
-    print(f"\nUsing {pkg_manager}: {pkg_path}")
+    print(f"\nUsing {pkg_manager}: {pkg_path}", file=out)
 
-    # Run tests
     test_cmd = [str(pkg_path), "run", "test"]
     if watch:
         test_cmd.append("--watch")
     else:
         test_cmd.append("--run")
 
-    success, _ = utils.run_command(test_cmd, f"{pkg_manager} run test", cwd=frontend_dir)
+    success, _ = utils.run_command(test_cmd, f"{pkg_manager} run test", cwd=frontend_dir, out=out)
 
     if success:
-        print("\n[OK] All tests passed!")
+        print("\n[OK] All tests passed!", file=out)
     else:
-        print("\n[FAIL] Tests failed")
+        print("\n[FAIL] Tests failed", file=out)
 
     return success
 
 
-def test_e2e() -> bool:
+def test_e2e(out: TextIO | None = None) -> bool:
     """Run E2E tests with Playwright."""
     project_root = utils.get_project_root()
     frontend_dir = project_root / "frontend"
 
-    utils.print_header("Running E2E Tests (Playwright)")
+    utils.print_header("Running E2E Tests (Playwright)", file=out)
 
-    pkg_info = utils.ensure_frontend_deps()
+    pkg_info = utils.ensure_frontend_deps(out=out)
     if not pkg_info:
         return False
 
     pkg_manager, pkg_path = pkg_info
-    print(f"\nUsing {pkg_manager}: {pkg_path}")
+    print(f"\nUsing {pkg_manager}: {pkg_path}", file=out)
 
     success, _ = utils.run_command(
         [str(pkg_path), "run", "test:e2e"],
         f"{pkg_manager} run test:e2e",
         cwd=frontend_dir,
+        out=out,
     )
 
     if success:
-        print("\n[OK] All E2E tests passed!")
+        print("\n[OK] All E2E tests passed!", file=out)
     else:
-        print("\n[FAIL] E2E tests failed")
+        print("\n[FAIL] E2E tests failed", file=out)
 
     return success
 
@@ -72,39 +76,35 @@ def _run_ctest_preset(
     cmd_label: str,
     ok_msg: str,
     fail_msg: str,
+    out: TextIO | None = None,
 ) -> bool:
-    """Run ctest under a CMake preset with the given label filter.
-
-    label_args は ctest にそのまま渡す追加引数 (例: ["--parallel", "-LE", "perf"])。
-    """
+    """Run ctest under a CMake preset with the given label filter."""
     if build_type not in ("Debug", "Release"):
-        print(f"ERROR: Invalid build type '{build_type}'")
+        print(f"ERROR: Invalid build type '{build_type}'", file=out)
         return False
 
     project_root = utils.get_project_root()
     build_dir = project_root / "build"
 
-    utils.print_header(f"{header} ({build_type})")
+    utils.print_header(f"{header} ({build_type})", file=out)
 
     if not build_dir.exists():
-        print("\nERROR: Build directory not found")
-        print("Run 'uv run scripts/pdg.py build backend' first")
+        print("\nERROR: Build directory not found", file=out)
+        print("Run 'uv run scripts/pdg.py build backend' first", file=out)
         return False
 
-    env = utils.get_msvc_env()
-    preset = build_type.lower()  # "debug" or "release"
+    env = utils.get_msvc_env(out=out)
+    preset = build_type.lower()
     test_cmd = ["ctest", "--preset", preset, "--output-on-failure", *label_args]
 
-    success, _ = utils.run_command(test_cmd, cmd_label, env=env)
+    success, _ = utils.run_command(test_cmd, cmd_label, env=env, out=out)
 
-    print(f"\n[{'OK' if success else 'FAIL'}] {ok_msg if success else fail_msg}")
+    print(f"\n[{'OK' if success else 'FAIL'}] {ok_msg if success else fail_msg}", file=out)
     return success
 
 
-def test_backend(build_type: str = "Release") -> bool:
+def test_backend(build_type: str = "Release", out: TextIO | None = None) -> bool:
     """Run backend unit tests (perf-labeled benchmarks excluded)."""
-    # -LE perf excludes performance benchmarks so the default test run stays
-    # fast; use `pdg bench backend` to run them.
     return _run_ctest_preset(
         build_type,
         ["--parallel", "-LE", "perf"],
@@ -112,10 +112,11 @@ def test_backend(build_type: str = "Release") -> bool:
         cmd_label="CTest",
         ok_msg="All tests passed!",
         fail_msg="Tests failed",
+        out=out,
     )
 
 
-def bench_backend(build_type: str = "Release") -> bool:
+def bench_backend(build_type: str = "Release", out: TextIO | None = None) -> bool:
     """Run backend performance benchmarks (perf-labeled tests only)."""
     return _run_ctest_preset(
         build_type,
@@ -124,4 +125,48 @@ def bench_backend(build_type: str = "Release") -> bool:
         cmd_label="CTest (perf)",
         ok_msg="All benchmarks passed!",
         fail_msg="Benchmarks failed",
+        out=out,
     )
+
+
+def _print_labeled(label: str, content: str) -> None:
+    """Print captured output with a section label."""
+    bar = "=" * 60
+    print(f"\n{bar}\n  [{label}]\n{bar}")
+    sys.stdout.write(content)
+    if not content.endswith("\n"):
+        print()
+
+
+def test_all(build_type: str = "Release", parallel: bool = True) -> bool:
+    """Run frontend and backend tests.
+
+    Runs frontend (vitest) and backend (ctest) in parallel by default.
+    Pass parallel=False for sequential execution.
+    """
+    utils.print_footer("Running All Tests (Frontend + Backend)")
+
+    if not parallel:
+        success_front = test_frontend()
+        success_back = test_backend(build_type=build_type)
+        utils.print_footer(
+            "ALL TESTS PASSED" if (success_front and success_back) else "SOME TESTS FAILED"
+        )
+        return success_front and success_back
+
+    print("\n[Running frontend + backend tests in parallel...]")
+    buf_front = io.StringIO()
+    buf_back = io.StringIO()
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        fut_front = executor.submit(test_frontend, out=buf_front)
+        fut_back = executor.submit(test_backend, build_type=build_type, out=buf_back)
+        success_front = fut_front.result()
+        success_back = fut_back.result()
+
+    _print_labeled("FRONTEND", buf_front.getvalue())
+    _print_labeled("BACKEND", buf_back.getvalue())
+
+    utils.print_footer(
+        "ALL TESTS PASSED" if (success_front and success_back) else "SOME TESTS FAILED"
+    )
+    return success_front and success_back

--- a/scripts/_lib/utils.py
+++ b/scripts/_lib/utils.py
@@ -40,33 +40,47 @@ def run_command(
     cwd: Path | None = None,
     env: dict[str, str] | None = None,
     capture_output: bool = False,
+    out: TextIO | None = None,
 ) -> tuple[bool, str]:
-    """Run a command and return success status and output."""
+    """Run a command and return success status and output.
+
+    When `out` is given, subprocess output is captured and written to `out`
+    (parallel-safe mode). When `out` is None and `capture_output` is False,
+    subprocess streams live to terminal.
+    """
     extras = [f"Command: {' '.join(cmd)}"]
     if cwd:
         extras.append(f"Working directory: {cwd}")
-    print_footer(description)
+    print_footer(description, file=out)
     for e in extras:
-        print(f"  {e}")
+        print(f"  {e}", file=out)
 
     merged_env = os.environ.copy()
     if env:
         merged_env.update(env)
 
+    # Force capture when `out` is set so subprocess output goes to `out`
+    do_capture = capture_output or out is not None
+
     try:
-        if capture_output:
+        if do_capture:
             result = subprocess.run(
                 cmd, cwd=cwd, env=merged_env, capture_output=True, encoding="utf-8"
             )
+            if out is not None:
+                if result.stdout:
+                    print(result.stdout, end="", file=out)
+                if result.stderr:
+                    print(result.stderr, end="", file=out)
             return result.returncode == 0, result.stderr or ""
         else:
             result = subprocess.run(cmd, cwd=cwd, env=merged_env)
             return result.returncode == 0, ""
     except FileNotFoundError:
-        print(f"ERROR: Command not found: {cmd[0]}")
+        print(f"ERROR: Command not found: {cmd[0]}", file=out)
         return False, f"Command not found: {cmd[0]}"
     except Exception as e:
-        print(f"ERROR: Failed to execute command: {e}")
+        print(f"ERROR: Failed to execute command: {e}", file=out)
         return False, str(e)
 
 
@@ -120,15 +134,15 @@ def find_vcvars() -> Path | None:
     return None
 
 
-def get_msvc_env() -> dict[str, str]:
+def get_msvc_env(out: TextIO | None = None) -> dict[str, str]:
     """Get environment variables from vcvars64.bat."""
     vcvars = find_vcvars()
     if not vcvars:
-        print("ERROR: Could not find vcvars64.bat")
-        print("Please install Visual Studio 2022 with C++ workload")
+        print("ERROR: Could not find vcvars64.bat", file=out)
+        print("Please install Visual Studio 2022 with C++ workload", file=out)
         sys.exit(1)
 
-    print(f"Using MSVC from: {vcvars}")
+    print(f"Using MSVC from: {vcvars}", file=out)
 
     # Run vcvars64.bat and capture environment
     # Security: Using shell=True here is intentional and safe because:
@@ -154,19 +168,19 @@ def get_msvc_env() -> dict[str, str]:
     return env
 
 
-def check_build_tools(env: dict[str, str]) -> bool:
+def check_build_tools(env: dict[str, str], out: TextIO | None = None) -> bool:
     """Check if required build tools are available."""
     # Check CMake
     try:
         result = subprocess.run(["cmake", "--version"], capture_output=True, text=True, env=env)
         if result.returncode == 0:
             version = result.stdout.split("\n")[0]
-            print(f"CMake: {version}")
+            print(f"CMake: {version}", file=out)
         else:
-            print("ERROR: CMake not found")
+            print("ERROR: CMake not found", file=out)
             return False
     except FileNotFoundError:
-        print("ERROR: CMake not found")
+        print("ERROR: CMake not found", file=out)
         return False
 
     # Check Ninja
@@ -174,16 +188,16 @@ def check_build_tools(env: dict[str, str]) -> bool:
         result = subprocess.run(["ninja", "--version"], capture_output=True, text=True, env=env)
         if result.returncode == 0:
             version = result.stdout.strip()
-            print(f"Ninja: {version}")
+            print(f"Ninja: {version}", file=out)
         else:
-            print("WARNING: Ninja not found, will use slower generator")
+            print("WARNING: Ninja not found, will use slower generator", file=out)
     except FileNotFoundError:
-        print("WARNING: Ninja not found, will use slower generator")
+        print("WARNING: Ninja not found, will use slower generator", file=out)
 
     return True
 
 
-def ensure_frontend_deps() -> PackageManager | None:
+def ensure_frontend_deps(out: TextIO | None = None) -> PackageManager | None:
     """Ensure frontend dependencies are up-to-date. Returns PackageManager on success."""
     project_root = get_project_root()
     frontend_dir = project_root / "frontend"
@@ -192,8 +206,8 @@ def ensure_frontend_deps() -> PackageManager | None:
 
     pkg_info = find_package_manager()
     if not pkg_info:
-        print("\nERROR: No package manager found")
-        print("  Install bun: https://bun.sh")
+        print("\nERROR: No package manager found", file=out)
+        print("  Install bun: https://bun.sh", file=out)
         return None
 
     pkg_manager, pkg_path = pkg_info
@@ -203,23 +217,23 @@ def ensure_frontend_deps() -> PackageManager | None:
         pkg_mtime = package_json.stat().st_mtime
         nm_mtime = node_modules.stat().st_mtime
         if pkg_mtime > nm_mtime:
-            print("[package.json updated since last install, reinstalling...]")
+            print("[package.json updated since last install, reinstalling...]", file=out)
             needs_install = True
 
     if needs_install:
-        print("\n[Dependencies outdated, installing...]")
+        print("\n[Dependencies outdated, installing...]", file=out)
         success, _ = run_command(
-            [str(pkg_path), "install"], f"{pkg_manager} install", cwd=frontend_dir
+            [str(pkg_path), "install"], f"{pkg_manager} install", cwd=frontend_dir, out=out
         )
         if not success:
-            print("\nERROR: Failed to install dependencies")
+            print("\nERROR: Failed to install dependencies", file=out)
             return None
     return pkg_info
 
 
-def clear_webview2_cache(project_root: Path) -> None:
+def clear_webview2_cache(project_root: Path, out: TextIO | None = None) -> None:
     """Clear WebView2 cache to ensure fresh frontend load."""
-    print("\n[Post-Build] Clearing WebView2 cache...")
+    print("\n[Post-Build] Clearing WebView2 cache...", file=out)
     webview2_caches = [
         project_root / "build" / "Debug" / "VelocityDB.exe.WebView2",
         project_root / "build" / "Release" / "VelocityDB.exe.WebView2",
@@ -230,12 +244,12 @@ def clear_webview2_cache(project_root: Path) -> None:
         if cache_path.exists():
             try:
                 shutil.rmtree(cache_path)
-                print(f"  [OK] Cleared: {cache_path.relative_to(project_root)}")
+                print(f"  [OK] Cleared: {cache_path.relative_to(project_root)}", file=out)
                 cleared = True
             except Exception as e:
-                print(f"  [FAIL] Failed to clear {cache_path}: {e}")
+                print(f"  [FAIL] Failed to clear {cache_path}: {e}", file=out)
 
     if cleared:
-        print("  WebView2 will load fresh frontend files on next startup")
+        print("  WebView2 will load fresh frontend files on next startup", file=out)
     else:
-        print("  No WebView2 cache to clear")
+        print("  No WebView2 cache to clear", file=out)

--- a/scripts/pdg.py
+++ b/scripts/pdg.py
@@ -44,13 +44,14 @@ def cmd_build(args: argparse.Namespace) -> bool:
     target: str = args.target
     clean: bool = args.clean
     build_type: str = args.type
+    parallel: bool = not args.no_async
 
     if target == "backend":
         return build.build_backend(build_type=build_type, clean=clean)
     elif target == "frontend":
         return build.build_frontend(clean=clean)
     elif target == "all":
-        return build.build_all(build_type=build_type, clean=clean)
+        return build.build_all(build_type=build_type, clean=clean, parallel=parallel)
     else:
         print(f"ERROR: Unknown build target: {target}")
         return False
@@ -67,6 +68,7 @@ def cmd_test(args: argparse.Namespace) -> bool:
     target: str = args.target
     watch: bool = args.watch
     build_type: str = args.type
+    parallel: bool = not args.no_async
 
     if target == "backend":
         return test.test_backend(build_type=build_type)
@@ -74,6 +76,8 @@ def cmd_test(args: argparse.Namespace) -> bool:
         return test.test_frontend(watch=watch)
     elif target == "e2e":
         return test.test_e2e()
+    elif target == "all":
+        return test.test_all(build_type=build_type, parallel=parallel)
     else:
         print(f"ERROR: Unknown test target: {target}")
         return False
@@ -402,6 +406,11 @@ def main() -> None:
         default="Release",
         help="Build type for backend (default: Release)",
     )
+    build_parser.add_argument(
+        "--no-async",
+        action="store_true",
+        help="Disable parallel execution for 'all' target (sequential build)",
+    )
 
     # Debug command (shortcut for build backend --type Debug)
     debug_parser = subparsers.add_parser("debug", help="Backend Debug build (shortcut)")
@@ -413,7 +422,7 @@ def main() -> None:
     test_parser = subparsers.add_parser("test", aliases=["t"], help="Run tests")
     test_parser.add_argument(
         "target",
-        choices=["backend", "frontend", "e2e"],
+        choices=["backend", "frontend", "e2e", "all"],
         default="frontend",
         nargs="?",
         help="Test target (default: frontend)",
@@ -427,6 +436,11 @@ def main() -> None:
         choices=["Debug", "Release"],
         default="Release",
         help="Build type for backend tests (default: Release)",
+    )
+    test_parser.add_argument(
+        "--no-async",
+        action="store_true",
+        help="Disable parallel execution for 'all' target (sequential test)",
     )
 
     # Bench command (perf-labeled tests only; excluded from `test` by default)


### PR DESCRIPTION
## Summary

- `uv run scripts/pdg.py build all` を**デフォルトで並列実行** (frontend と backend を ThreadPoolExecutor で同時ビルド)
- `uv run scripts/pdg.py test all` を**新規追加** (frontend vitest と backend ctest を並列実行)
- `--no-async` フラグで従来の直列実行も可能 (#533/#536 仕様準拠)

## Changes

| File | 変更 |
|---|---|
| `scripts/_lib/build.py` | `build_all` を ThreadPoolExecutor で並列化、`_copy_frontend_to_build` を抽出、全関数に `out: TextIO \| None` パラメータ追加 |
| `scripts/_lib/test.py` | `test_all` 新規追加、全関数に `out` パラメータ追加 |
| `scripts/_lib/utils.py` | `run_command` 等に `out` パラメータ追加。`out` 指定時は subprocess 出力を自動キャプチャ |
| `scripts/pdg.py` | `build --no-async`、`test all` choice + `--no-async` 追加 |

## 設計上の判断

### frontend コピーの分離
`build_backend` の post-build ステップ (`frontend/dist` → `build/<type>/frontend` コピー) は並列実行時に frontend ビルド完了を待たないため不整合のリスクがあった。`_copy_frontend_to_build()` に抽出し、並列モードでは `copy_frontend=False` で抑制。両完了後に1回だけ実行する。standalone の `build_backend` 呼び出しは従来通りコピー実行 (後方互換)。

### ThreadPoolExecutor + StringIO キャプチャ
#534 (lint並列化, PR #539) と同じパターン。各タスクは `out` パラメータで `StringIO` に出力を集約し、完了後に `[FRONTEND]`/`[BACKEND]` プレフィックス付きで表示。

### test の `all` choice 新規追加
test には元々 `all` choice が無かったため追加。デフォルト target は `frontend` のまま維持 (後方互換)。

## Test plan

- [x] `pdg.py build --help` / `pdg.py test --help` → `--no-async` / `all` 表示確認
- [x] `ruff check && ruff format --check` → pass
- [x] `pdg.py build all` / `test all` の実機並列動作確認 (ユーザー側)
- [x] `--no-async` での直列動作確認

## Related

- Closes #533
- Closes #536
- 親 issue #532 のサブタスク 2 件
- 兄弟 PR #539 (lint並列化、マージ済)