### PR TITLE
test(perf): SIMDFilter primitives の AVX2 vs scalar ベンチを追加 (#537)

### DIFF
--- a/backend/search/simd_filter.h
+++ b/backend/search/simd_filter.h
@@ -26,8 +26,9 @@ public:
     // Check if AVX2 is available
     static bool isAVX2Available();
 
-private:
-    // SIMD-optimized string comparison (when available)
+    // SIMD-optimized string primitives. Public so perf benchmarks can compare
+    // the AVX2 path against std::memcmp / std::string_view::find directly —
+    // the public filter* methods above currently do not route through these.
     bool simdStringEquals(const char* a, const char* b, size_t len) const;
     bool simdStringContains(const char* haystack, size_t haystackLen, const char* needle, size_t needleLen) const;
 };

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -10,6 +10,7 @@ set(PERF_TEST_SOURCES
     test_main.cpp
     test_smoke_bench.cpp
     test_query_history_search_bench.cpp
+    test_simd_filter_bench.cpp
 )
 
 add_executable(VelocityDBPerfTests ${PERF_TEST_SOURCES})

--- a/tests/perf/test_simd_filter_bench.cpp
+++ b/tests/perf/test_simd_filter_bench.cpp
@@ -1,0 +1,170 @@
+// README #11: AVX2 SIMD filtering — qualitative target ("fast"; see issue #537
+// follow-up to make the goal quantitative).
+//
+// The public SIMDFilter::filter* methods do not currently route through the
+// SIMD primitives (they use std::string operators directly). To make the AVX2
+// vs fallback comparison meaningful, this bench targets the SIMD primitives
+// (simdStringEquals / simdStringContains) and pits them against the obvious
+// scalar equivalents (std::memcmp / std::string_view::find).
+//
+// The point is to detect regressions in the AVX2 path itself, not to assert
+// a fixed speedup ratio — modern std::memcmp is already vectorised, and CI
+// runner variance makes ratio assertions flaky. We log the ratio and assert
+// only a loose absolute upper bound.
+
+#include "search/simd_filter.h"
+
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+namespace velocitydb {
+namespace {
+
+constexpr size_t kEqualsIterations = 100'000;
+constexpr size_t kEqualsLen = 64;  // >=32 so AVX2 path is exercised
+
+// Targets are loose absolute upper bounds, not micro-benchmark precision —
+// CI runner variance can easily double real wall time. Local Release on a
+// 12th-gen Intel measured ~120ms for simdStringEquals, dominated by the per-
+// iteration isAVX2Available() cpuid call; std::memcmp benefits from compiler
+// auto-vectorisation and is measurably faster. Both observations are logged
+// (see ratio output) rather than asserted, so regressions in the SIMD path
+// itself are caught without the test going flaky on the comparison.
+constexpr auto EQUALS_TARGET = std::chrono::milliseconds(500);
+
+constexpr size_t kHaystackLen = 64 * 1024;
+constexpr size_t kContainsIterations = 1'000;
+constexpr auto CONTAINS_TARGET = std::chrono::milliseconds(500);
+
+[[nodiscard]] std::string makeRepeated(char c, size_t n) {
+    return std::string(n, c);
+}
+
+// haystack of `len` bytes with `needle` planted near the tail so neither side
+// can short-circuit on the first byte.
+[[nodiscard]] std::string makeHaystackWithNeedleAtTail(size_t len, std::string_view needle) {
+    std::string s(len, 'a');
+    if (needle.size() <= len) {
+        const auto pos = len - needle.size() - 1;
+        std::memcpy(s.data() + pos, needle.data(), needle.size());
+    }
+    return s;
+}
+
+template <typename Fn>
+[[nodiscard]] std::chrono::nanoseconds measure(Fn&& fn) {
+    const auto start = std::chrono::steady_clock::now();
+    fn();
+    return std::chrono::steady_clock::now() - start;
+}
+
+TEST(SimdFilterBench, IsAvx2AvailableReturnsBool) {
+    // Smoke: ensure the runtime probe links and returns a value.
+    const bool available = SIMDFilter::isAVX2Available();
+    std::cerr << "[bench] AVX2 available: " << (available ? "yes" : "no") << "\n";
+    SUCCEED();
+}
+
+TEST(SimdFilterBench, StringEqualsAvx2PathUnderTarget) {
+    const auto a = makeRepeated('x', kEqualsLen);
+    const auto b = makeRepeated('x', kEqualsLen);
+    SIMDFilter filter;
+
+    const auto simdElapsed = measure([&] {
+        for (size_t i = 0; i < kEqualsIterations; ++i) {
+            const bool eq = filter.simdStringEquals(a.data(), b.data(), a.size());
+            ASSERT_TRUE(eq);
+        }
+    });
+
+    const auto scalarElapsed = measure([&] {
+        for (size_t i = 0; i < kEqualsIterations; ++i) {
+            const bool eq = std::memcmp(a.data(), b.data(), a.size()) == 0;
+            ASSERT_TRUE(eq);
+        }
+    });
+
+    const auto simdMs = std::chrono::duration_cast<std::chrono::milliseconds>(simdElapsed);
+    const auto scalarMs = std::chrono::duration_cast<std::chrono::milliseconds>(scalarElapsed);
+    const double ratio = scalarElapsed.count() > 0
+        ? static_cast<double>(simdElapsed.count()) / static_cast<double>(scalarElapsed.count())
+        : 0.0;
+
+    std::cerr << "[bench] simdStringEquals: " << simdMs.count() << "ms, "
+              << "std::memcmp: " << scalarMs.count() << "ms, "
+              << "ratio (simd/scalar): " << ratio << "\n";
+
+    EXPECT_LT(simdMs, EQUALS_TARGET) << "simdStringEquals took " << simdMs.count() << "ms";
+}
+
+TEST(SimdFilterBench, StringEqualsShorterThan32BUsesFallback) {
+    // Boundary: len < 32 skips the AVX2 chunk loop and falls through to memcmp.
+    const auto a = makeRepeated('y', 16);
+    const auto b = makeRepeated('y', 16);
+    SIMDFilter filter;
+
+    EXPECT_TRUE(filter.simdStringEquals(a.data(), b.data(), a.size()));
+
+    auto bMismatch = b;
+    bMismatch[10] = 'z';
+    EXPECT_FALSE(filter.simdStringEquals(a.data(), bMismatch.data(), a.size()));
+}
+
+TEST(SimdFilterBench, StringContainsAvx2PathUnderTarget) {
+    const std::string needle = "NEEDLE!!";
+    const auto haystack = makeHaystackWithNeedleAtTail(kHaystackLen, needle);
+    SIMDFilter filter;
+
+    const auto simdElapsed = measure([&] {
+        for (size_t i = 0; i < kContainsIterations; ++i) {
+            const bool found = filter.simdStringContains(
+                haystack.data(), haystack.size(), needle.data(), needle.size());
+            ASSERT_TRUE(found);
+        }
+    });
+
+    const auto scalarElapsed = measure([&] {
+        for (size_t i = 0; i < kContainsIterations; ++i) {
+            const auto pos = std::string_view(haystack).find(std::string_view(needle));
+            ASSERT_NE(pos, std::string_view::npos);
+        }
+    });
+
+    const auto simdMs = std::chrono::duration_cast<std::chrono::milliseconds>(simdElapsed);
+    const auto scalarMs = std::chrono::duration_cast<std::chrono::milliseconds>(scalarElapsed);
+    const double ratio = scalarElapsed.count() > 0
+        ? static_cast<double>(simdElapsed.count()) / static_cast<double>(scalarElapsed.count())
+        : 0.0;
+
+    std::cerr << "[bench] simdStringContains: " << simdMs.count() << "ms, "
+              << "std::string_view::find: " << scalarMs.count() << "ms, "
+              << "ratio (simd/scalar): " << ratio << "\n";
+
+    EXPECT_LT(simdMs, CONTAINS_TARGET) << "simdStringContains took " << simdMs.count() << "ms";
+}
+
+TEST(SimdFilterBench, StringContainsEmptyNeedleReturnsTrue) {
+    // Boundary: empty needle is conventionally a match.
+    const auto haystack = makeRepeated('a', 64);
+    SIMDFilter filter;
+
+    EXPECT_TRUE(filter.simdStringContains(haystack.data(), haystack.size(), "", 0));
+}
+
+TEST(SimdFilterBench, StringContainsNeedleLongerThanHaystackReturnsFalse) {
+    // Boundary: needle longer than haystack cannot match.
+    const std::string haystack = "short";
+    const std::string needle = "much longer needle than the haystack itself";
+    SIMDFilter filter;
+
+    EXPECT_FALSE(filter.simdStringContains(
+        haystack.data(), haystack.size(), needle.data(), needle.size()));
+}
+
+}  // namespace
+}  // namespace velocitydb


### PR DESCRIPTION
## Summary

- README #11 (AVX2 SIMD フィルタ) の継続計測テストを tests/perf/ に追加
- simdStringEquals / simdStringContains を public 化 (ベンチ用途、h にコメント明示)
- AVX2 経路 vs scalar (std::memcmp / std::string_view::find) の経過時間を並列計測し ratio をログ出力
- 閾値は absolute 上限のみアサート (ratio は flaky 回避で EXPECT せず)

## Test plan

- [x] uv run scripts/pdg.py bench backend → 11/11 PASS (ローカル Release, AVX2: yes)
- [x] uv run scripts/pdg.py lint → PASS
- [x] 境界値: len<32 fallback / 空 needle / needle>haystack を含む

## 関連

- issue #537 (本対応)
- 基盤 #425 (完了済み)

## 観察 (本 PR スコープ外 / follow-up 推奨)

- 公開 filterEquals/filterContains は SIMD primitives を呼んでおらず std::string 演算直接 → README #11 と実装が不一致
- simdStringEquals が isAVX2Available() (cpuid) を毎ループ呼ぶオーバーヘッドで std::memcmp に大きく劣後 (ratio ~346x slow) → `cpuid` キャッシュ化推奨