### PR TITLE
perf(search): isAVX2Available の cpuid 結果をキャッシュ (#543)

### DIFF
--- a/backend/search/simd_filter.cpp
+++ b/backend/search/simd_filter.cpp
@@ -61,17 +61,22 @@ namespace {
 }  // namespace
 
 bool SIMDFilter::isAVX2Available() {
+    // Cache the cpuid probe result. __cpuidex is a CPU-synchronising instruction;
+    // calling it on every primitive invocation dominated wall time in the SIMD
+    // bench (#543). C++11 guarantees thread-safe init of function-scope statics.
+    static const bool cached = []() {
 #ifdef _MSC_VER
-    int cpuInfo[4];
-    __cpuid(cpuInfo, 0);
-    int nIds = cpuInfo[0];
-
-    if (nIds >= 7) {
-        __cpuidex(cpuInfo, 7, 0);
-        return (cpuInfo[1] & (1 << 5)) != 0;  // AVX2 bit
-    }
+        int cpuInfo[4];
+        __cpuid(cpuInfo, 0);
+        const int nIds = cpuInfo[0];
+        if (nIds >= 7) {
+            __cpuidex(cpuInfo, 7, 0);
+            return (cpuInfo[1] & (1 << 5)) != 0;  // AVX2 bit
+        }
 #endif
-    return false;
+        return false;
+    }();
+    return cached;
 }
 
 std::vector<size_t> SIMDFilter::filterEquals(const ResultSet& data, size_t columnIndex, const std::string& value) const {

--- a/tests/perf/test_simd_filter_bench.cpp
+++ b/tests/perf/test_simd_filter_bench.cpp
@@ -29,17 +29,17 @@ constexpr size_t kEqualsIterations = 100'000;
 constexpr size_t kEqualsLen = 64;  // >=32 so AVX2 path is exercised
 
 // Targets are loose absolute upper bounds, not micro-benchmark precision —
-// CI runner variance can easily double real wall time. Local Release on a
-// 12th-gen Intel measured ~120ms for simdStringEquals, dominated by the per-
-// iteration isAVX2Available() cpuid call; std::memcmp benefits from compiler
-// auto-vectorisation and is measurably faster. Both observations are logged
-// (see ratio output) rather than asserted, so regressions in the SIMD path
-// itself are caught without the test going flaky on the comparison.
-constexpr auto EQUALS_TARGET = std::chrono::milliseconds(500);
+// CI runner variance can easily multiply real wall time. After #543 cached
+// the cpuid probe, local Release on a 12th-gen Intel measured <1ms for both
+// primitives; 50ms leaves ample headroom while still flagging order-of-
+// magnitude regressions (e.g. accidentally re-introducing per-call cpuid).
+// Ratios stay logged-not-asserted because std::memcmp benefits from compiler
+// auto-vectorisation and the comparison is noisy on small wall times.
+constexpr auto EQUALS_TARGET = std::chrono::milliseconds(50);
 
 constexpr size_t kHaystackLen = 64 * 1024;
 constexpr size_t kContainsIterations = 1'000;
-constexpr auto CONTAINS_TARGET = std::chrono::milliseconds(500);
+constexpr auto CONTAINS_TARGET = std::chrono::milliseconds(50);
 
 [[nodiscard]] std::string makeRepeated(char c, size_t n) {
     return std::string(n, c);


### PR DESCRIPTION
## Summary

- `SIMDFilter::isAVX2Available()` の `__cpuidex` 結果を関数スコープ static でキャッシュ
- SIMD primitives (`simdStringEquals` / `simdStringContains`) のループ内 cpuid オーバーヘッドを除去
- bench 閾値を 500ms → 50ms に絞ってリグレッション検出精度を向上

## ベンチ結果 (Release / 12th-gen Intel, AVX2: yes)

| 関数 | 修正前 | 修正後 |
| ------ | ------- | ------- |
| simdStringEquals (100K回 × 64B) | 123ms (ratio 346× slow) | 0ms (ratio 1.02× ≒ memcmp 並) |
| simdStringContains (1K回 × 64KB) | 2ms (ratio 0.50×) | 1ms (ratio 0.24×) |

## Test plan

- [x] uv run scripts/pdg.py bench backend → 11/11 PASS
- [x] uv run scripts/pdg.py lint → PASS
- [x] tighter bench targets (50ms) でも余裕パス

Closes #543