### PR TITLE
fix(search): SIMDFilter::filter* を SIMD primitives 経由に配線 (#542)

### DIFF
--- a/backend/search/simd_filter.cpp
+++ b/backend/search/simd_filter.cpp
@@ -86,7 +86,7 @@ std::vector<size_t> SIMDFilter::filterEquals(const ResultSet& data, size_t colum
     for (size_t i = 0; i < data.rows.size(); ++i) {
         if (columnIndex < data.rows[i].values.size() && !data.rows[i].isNull(columnIndex)) {
             const auto& cellValue = data.rows[i].values[columnIndex];
-            if (cellValue == value) {
+            if (cellValue.size() == value.size() && simdStringEquals(cellValue.data(), value.data(), value.size())) {
                 result.push_back(i);
             }
         }
@@ -102,7 +102,7 @@ std::vector<size_t> SIMDFilter::filterContains(const ResultSet& data, size_t col
     for (size_t i = 0; i < data.rows.size(); ++i) {
         if (columnIndex < data.rows[i].values.size() && !data.rows[i].isNull(columnIndex)) {
             const auto& cellValue = data.rows[i].values[columnIndex];
-            if (cellValue.find(substring) != std::string::npos) {
+            if (simdStringContains(cellValue.data(), cellValue.size(), substring.data(), substring.size())) {
                 result.push_back(i);
             }
         }

--- a/backend/search/simd_filter.h
+++ b/backend/search/simd_filter.h
@@ -26,9 +26,10 @@ public:
     // Check if AVX2 is available
     static bool isAVX2Available();
 
-    // SIMD-optimized string primitives. Public so perf benchmarks can compare
-    // the AVX2 path against std::memcmp / std::string_view::find directly —
-    // the public filter* methods above currently do not route through these.
+    // SIMD-optimized string primitives. filterEquals / filterContains above
+    // route through these so the AVX2 path is actually exercised at runtime.
+    // Kept public so perf benchmarks can compare them against std::memcmp /
+    // std::string_view::find without going through the row-loop overhead.
     bool simdStringEquals(const char* a, const char* b, size_t len) const;
     bool simdStringContains(const char* haystack, size_t haystackLen, const char* needle, size_t needleLen) const;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_SOURCES
     providers/test_query_result_formatter.cpp
     providers/test_settings_provider.cpp
     providers/test_utility_provider.cpp
+    search/test_simd_filter.cpp
     utils/test_sql_validation.cpp
     database/test_thread_pool.cpp
     database/test_result_cache.cpp

--- a/tests/perf/test_simd_filter_bench.cpp
+++ b/tests/perf/test_simd_filter_bench.cpp
@@ -1,11 +1,11 @@
 // README #11: AVX2 SIMD filtering — qualitative target ("fast"; see issue #537
 // follow-up to make the goal quantitative).
 //
-// The public SIMDFilter::filter* methods do not currently route through the
-// SIMD primitives (they use std::string operators directly). To make the AVX2
-// vs fallback comparison meaningful, this bench targets the SIMD primitives
-// (simdStringEquals / simdStringContains) and pits them against the obvious
-// scalar equivalents (std::memcmp / std::string_view::find).
+// SIMDFilter::filter* routes through the SIMD primitives (simdStringEquals /
+// simdStringContains); this bench targets the primitives directly so the
+// per-call AVX2 wall time is isolated from the row-loop overhead in filter*.
+// They are pitted against the obvious scalar equivalents (std::memcmp /
+// std::string_view::find).
 //
 // The point is to detect regressions in the AVX2 path itself, not to assert
 // a fixed speedup ratio — modern std::memcmp is already vectorised, and CI

--- a/tests/search/test_simd_filter.cpp
+++ b/tests/search/test_simd_filter.cpp
@@ -1,0 +1,169 @@
+// Correctness regression net for SIMDFilter::filter* (issue #542).
+// The public filter* methods are being rerouted to go through the AVX2
+// primitives; these tests pin the observable behaviour so the rewrite
+// cannot silently regress matching semantics (NULL handling, column-index
+// bounds, short-string fallback below the 32-byte AVX2 chunk, range
+// inclusivity).
+
+#include "search/simd_filter.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace velocitydb {
+namespace test {
+
+namespace {
+
+ResultRow makeRow(std::initializer_list<std::string> values) {
+    ResultRow row;
+    for (const auto& v : values) {
+        row.values.push_back(v);
+        row.nullFlags.push_back(false);
+    }
+    return row;
+}
+
+ResultRow makeRowWithNull(size_t nullIndex, std::initializer_list<std::string> values) {
+    auto row = makeRow(values);
+    if (nullIndex < row.nullFlags.size()) {
+        row.nullFlags[nullIndex] = true;
+    }
+    return row;
+}
+
+}  // namespace
+
+class SIMDFilterTest : public ::testing::Test {
+protected:
+    SIMDFilter filter;
+};
+
+TEST_F(SIMDFilterTest, FilterEquals_MatchesExactValues) {
+    ResultSet data;
+    data.rows = {makeRow({"alpha"}), makeRow({"beta"}), makeRow({"alpha"})};
+
+    const auto matches = filter.filterEquals(data, 0, "alpha");
+
+    ASSERT_EQ(matches.size(), 2u);
+    EXPECT_EQ(matches[0], 0u);
+    EXPECT_EQ(matches[1], 2u);
+}
+
+TEST_F(SIMDFilterTest, FilterEquals_SkipsNullCells) {
+    ResultSet data;
+    data.rows = {makeRowWithNull(0, {"alpha"}), makeRow({"alpha"})};
+
+    const auto matches = filter.filterEquals(data, 0, "alpha");
+
+    ASSERT_EQ(matches.size(), 1u);
+    EXPECT_EQ(matches[0], 1u);
+}
+
+TEST_F(SIMDFilterTest, FilterEquals_SkipsRowsWithMissingColumn) {
+    ResultSet data;
+    data.rows = {makeRow({"alpha"}), makeRow({})};
+
+    const auto matches = filter.filterEquals(data, 0, "alpha");
+
+    ASSERT_EQ(matches.size(), 1u);
+    EXPECT_EQ(matches[0], 0u);
+}
+
+TEST_F(SIMDFilterTest, FilterEquals_LengthMismatchIsNotEqual) {
+    // The AVX2 path operates byte-wise on equal-length spans; ensure the
+    // public API still rejects length-mismatched values like operator== does.
+    ResultSet data;
+    data.rows = {makeRow({"alpha"}), makeRow({"alphabet"})};
+
+    const auto matches = filter.filterEquals(data, 0, "alpha");
+
+    ASSERT_EQ(matches.size(), 1u);
+    EXPECT_EQ(matches[0], 0u);
+}
+
+TEST_F(SIMDFilterTest, FilterEquals_LongStringExercisesAvx2Chunk) {
+    // 64 bytes >= the 32-byte AVX2 chunk so the SIMD loop fires when AVX2
+    // is available. The fallback path must still match the same answer.
+    const std::string longA(64, 'x');
+    const std::string longB(64, 'y');
+    ResultSet data;
+    data.rows = {makeRow({longA}), makeRow({longB}), makeRow({longA})};
+
+    const auto matches = filter.filterEquals(data, 0, longA);
+
+    ASSERT_EQ(matches.size(), 2u);
+    EXPECT_EQ(matches[0], 0u);
+    EXPECT_EQ(matches[1], 2u);
+}
+
+TEST_F(SIMDFilterTest, FilterContains_FindsSubstring) {
+    ResultSet data;
+    data.rows = {makeRow({"hello world"}), makeRow({"goodbye"}), makeRow({"world peace"})};
+
+    const auto matches = filter.filterContains(data, 0, "world");
+
+    ASSERT_EQ(matches.size(), 2u);
+    EXPECT_EQ(matches[0], 0u);
+    EXPECT_EQ(matches[1], 2u);
+}
+
+TEST_F(SIMDFilterTest, FilterContains_EmptyNeedleMatchesEveryRow) {
+    // Matches std::string::find semantics (empty needle is always found).
+    ResultSet data;
+    data.rows = {makeRow({"alpha"}), makeRow({""})};
+
+    const auto matches = filter.filterContains(data, 0, "");
+
+    ASSERT_EQ(matches.size(), 2u);
+}
+
+TEST_F(SIMDFilterTest, FilterContains_NeedleLongerThanHaystackHasNoMatch) {
+    ResultSet data;
+    data.rows = {makeRow({"abc"})};
+
+    const auto matches = filter.filterContains(data, 0, "abcdefghij");
+
+    EXPECT_TRUE(matches.empty());
+}
+
+TEST_F(SIMDFilterTest, FilterContains_LongHaystackExercisesAvx2Chunk) {
+    // 64 bytes of 'a' with "NEEDLE" planted near the tail forces the AVX2
+    // first-char scan path to fire and then verify the full substring.
+    std::string haystack(64, 'a');
+    const std::string needle = "NEEDLE";
+    haystack.replace(haystack.size() - needle.size() - 1, needle.size(), needle);
+
+    ResultSet data;
+    data.rows = {makeRow({haystack}), makeRow({"plain"})};
+
+    const auto matches = filter.filterContains(data, 0, needle);
+
+    ASSERT_EQ(matches.size(), 1u);
+    EXPECT_EQ(matches[0], 0u);
+}
+
+TEST_F(SIMDFilterTest, FilterContains_SkipsNullCells) {
+    ResultSet data;
+    data.rows = {makeRowWithNull(0, {"world"}), makeRow({"world peace"})};
+
+    const auto matches = filter.filterContains(data, 0, "world");
+
+    ASSERT_EQ(matches.size(), 1u);
+    EXPECT_EQ(matches[0], 1u);
+}
+
+TEST_F(SIMDFilterTest, FilterRange_IncludesBoundaries) {
+    ResultSet data;
+    data.rows = {makeRow({"apple"}), makeRow({"banana"}), makeRow({"cherry"}), makeRow({"date"})};
+
+    const auto matches = filter.filterRange(data, 0, "banana", "cherry");
+
+    ASSERT_EQ(matches.size(), 2u);
+    EXPECT_EQ(matches[0], 1u);
+    EXPECT_EQ(matches[1], 2u);
+}
+
+}  // namespace test
+}  // namespace velocitydb


### PR DESCRIPTION
## Summary

- `SIMDFilter::filterEquals` / `filterContains` が private な `simdStringEquals` / `simdStringContains` を呼ばず、`std::string::operator==` / `std::string::find` を直接使っていた配線忘れを修正 (issue #542)
- 修正前に #537 follow-up の SIMD bench で性能差を確認: `simdStringContains` は `std::string::find` 比 ratio **0.27 (約 4倍速)**、`simdStringEquals` は `std::memcmp` 比 ratio 1.10 (誤差 — memcmp は自動 vectorise 済)。一貫性優先で両方を SIMD 経路化
- 振る舞いリグレッションネット 11 ケース (`tests/search/test_simd_filter.cpp`) を追加: NULL セル / 列外 / 長さ不一致 / 長文 AVX2 32B経路 / 空 needle / range 境界

## Test plan

- [x] `uv run scripts/pdg.py build backend` (Release)
- [x] `ctest --preset release --test-dir build -LE perf` — 334/334 GREEN
- [x] `ctest --preset release --test-dir build -R SIMDFilterTest` — 11/11 GREEN
- [x] `ctest --preset release --test-dir build -L perf -V -R SimdFilter` — 6/6 GREEN, ratio 維持
- [x] `uv run scripts/pdg.py lint` — clang-format パス

Closes #542