### PR TITLE
test(perf): CSVExporter 10 万行ベンチを追加 (#547)

### DIFF
--- a/.github/workflows/tool-version-upgrade.yml
+++ b/.github/workflows/tool-version-upgrade.yml
@@ -391,7 +391,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/docs/PERFORMANCE_VALIDATION.md
+++ b/docs/PERFORMANCE_VALIDATION.md
@@ -10,14 +10,14 @@
 ## サマリ
 
 | # | 目標 | 実装 | 計測機構 | 既存ベンチマーク | 達成判定 |
-|---|------|------|----------|------------------|----------|
+| --- | ------ | ------ | ---------- | ------------------ | ---------- |
 | 1 | アプリ起動 < 0.3s | ✅ | ❌ | ❌ | 🔍 未実測 |
 | 2 | SQL Server 接続 < 50ms | ✅ | ⚠️ 部分 | ❌ | 🔍 未実測 |
 | 3 | SELECT (100万行) < 500ms | ✅ | ✅ | ❌ | 🔍 未実測 |
 | 4 | 結果表示開始 < 100ms | ✅ | ✅ | ⚠️ 部分 | 🔍 未実測 |
 | 5 | 仮想スクロール 60fps | ✅ | ❌ | ⚠️ 部分 | 🔍 未実測 |
 | 6 | SQL フォーマット < 50ms | ✅ | ❌ | ❌ | 🔍 未実測 |
-| 7 | CSV エクスポート (10万行) < 2s | ✅ | ❌ | ❌ | 🔍 未実測 |
+| 7 | CSV エクスポート (10万行) < 2s | ✅ | ✅ | ✅ | 🔍 未実測 |
 | 8 | A5:ER ロード (100テーブル) < 1s | ✅ | ❌ | ❌ | 🔍 未実測 |
 | 9 | ER 図レンダリング (50テーブル) < 500ms | ✅ | ❌ | ❌ | 🔍 未実測 |
 | 10 | クエリ履歴検索 (1万件) < 100ms | ✅ | ❌ | ❌ | 🔍 未実測 |
@@ -33,7 +33,7 @@
 ### #1. アプリ起動 < 0.3s
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/webview_app.cpp:57-153` |
 | 実装手法 | WebView2 直接初期化 (`webview::webview`)、ブラウザキャッシュ無効化、仮想ホスト経由ナビゲート |
 | 計測機構 | なし (起動時刻のロギングなし) |
@@ -43,7 +43,7 @@
 ### #2. SQL Server 接続 < 50ms
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/database/connection_registry.h`, `backend/database/sqlserver_driver.cpp`, `backend/database/async_connection_executor.h` |
 | 実装手法 | ODBC Native API 直接利用、`shared_ptr` ベースの接続レジストリ、ThreadPool (MAX_THREADS=8) で非同期化 |
 | 計測機構 | 部分的 (`async_connection_executor` 内部) |
@@ -53,7 +53,7 @@
 ### #3. SELECT (100万行) < 500ms
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/database/async_query_executor.h:31-101`, `backend/database/async_query_executor.cpp` |
 | 実装手法 | ThreadPool で非同期実行、`AsyncQueryResult` に `startTime` / `endTime` (`std::chrono::steady_clock`) を保持 |
 | 計測機構 | あり (`AsyncQueryResult.startTime/endTime`) |
@@ -63,7 +63,7 @@
 ### #4. 結果表示開始 < 100ms
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `frontend/src/components/grid/GridTable.tsx:47-82`, `frontend/src/components/grid/ResultGrid.tsx`, `frontend/src/store/query/slices/dataViewSlice.ts` |
 | 実装手法 | TanStack React Virtual で行を仮想化。`broken-state` 検出時は `FALLBACK_RENDER_LIMIT=50` で先頭行のみ描画 (issue #417 参照) |
 | 計測機構 | `dataViewSlice` 内に `performance.now()` 利用箇所あり |
@@ -73,7 +73,7 @@
 ### #5. 仮想スクロール 60fps 安定
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `frontend/src/components/grid/GridTable.tsx`, `frontend/src/components/grid/ResultGrid.tsx` |
 | 実装手法 | TanStack Virtual + 行高固定 32px + `memo` 最適化 |
 | 計測機構 | なし |
@@ -83,7 +83,7 @@
 ### #6. SQL フォーマット < 50ms
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/parsers/sql_formatter.h:11-40`, `backend/parsers/sql_formatter.cpp` |
 | 実装手法 | `unordered_set` でキーワード判定 (O(1))、文字単位ストリーミングパース |
 | 計測機構 | なし |
@@ -93,17 +93,18 @@
 ### #7. CSV エクスポート (10万行) < 2s
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/exporters/csv_exporter.h`, `backend/exporters/csv_exporter.cpp:8-79` |
 | 実装手法 | `std::ofstream` バイナリモードでストリーム書き込み、UTF-8 BOM、CSV エスケープ、`reserve()` 事前割り当て |
-| 計測機構 | なし |
-| 計測手段 | `tests/exporters/test_csv_exporter.cpp` に 10 万行のダミー `ResultSet` を生成して計測アサート追加 |
-| 達成判定 | **未実測**。ディスク I/O 性能に依存 |
+| 計測機構 | あり (`tests/perf/test_csv_exporter_bench.cpp` の `std::chrono::steady_clock` 計測) |
+| 既存ベンチマーク | `tests/perf/test_csv_exporter_bench.cpp` (10 万行 × 10 列、NULL/エスケープ混在) で 2s 上限を `EXPECT_LT` |
+| 計測手段 | `ctest --preset release -L perf` で実行 |
+| 達成判定 | **未実測** (要 CI 実機)。ディスク I/O 性能に依存 |
 
 ### #8. A5:ER ロード (100テーブル) < 1s
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/parsers/a5er_parser.h`, `backend/parsers/a5er_parser.cpp` |
 | 実装手法 | `pugixml` 直接利用、テキスト/XML 両形式対応 |
 | 計測機構 | なし |
@@ -113,7 +114,7 @@
 ### #9. ER 図レンダリング (50テーブル) < 500ms
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `frontend/src/components/diagram/ERDiagram.tsx:1-100` |
 | 実装手法 | React Flow (`@xyflow/react`)、ノード/エッジの memo 化、`GRID_LAYOUT` 自動配置 |
 | 計測機構 | なし |
@@ -123,7 +124,7 @@
 ### #10. クエリ履歴検索 (1万件) < 100ms
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/database/query_history.h:46-72`, `backend/database/query_history.cpp:34-60` |
 | 実装手法 | `std::vector<HistoryItem>` で最大 10000 件保持。`std::search` + `std::tolower` による case-insensitive linear search (O(n*m)) |
 | 計測機構 | なし |
@@ -134,7 +135,7 @@
 ### #11. 結果フィルタリング (AVX2 SIMD)
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/utils/simd_filter.h:11-33`, `backend/utils/simd_filter.cpp` |
 | 実装手法 | AVX2 intrinsics (`_mm256_*`) 直接利用、`__cpuidex()` で実行時 AVX2 検出、非対応 CPU では `std::memcmp()` フォールバック |
 | 計測機構 | なし |
@@ -144,7 +145,7 @@
 ### #12. LRU 結果キャッシュ (100MB)
 
 | 項目 | 内容 |
-|------|------|
+| ------ | ------ |
 | 実装ファイル | `backend/database/result_cache.h:14-62`, `backend/database/result_cache.cpp` |
 | 実装手法 | `unordered_map` + `std::list` による O(1) アクセス・LRU 順序更新。デフォルト上限 100MB (`100 * 1024 * 1024`) |
 | 計測機構 | N/A (キャッシュは時間目標ではなくサイズ上限と LRU 動作が目標) |

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PERF_TEST_SOURCES
     test_smoke_bench.cpp
     test_query_history_search_bench.cpp
     test_simd_filter_bench.cpp
+    test_csv_exporter_bench.cpp
 )
 
 add_executable(VelocityDBPerfTests ${PERF_TEST_SOURCES})

--- a/tests/perf/test_csv_exporter_bench.cpp
+++ b/tests/perf/test_csv_exporter_bench.cpp
@@ -1,0 +1,139 @@
+// PERFORMANCE_VALIDATION.md #7: CSV export (100,000 rows) under 2s.
+//
+// CSVExporter streams to std::ofstream in binary mode and is dominated by
+// per-cell escaping + stream writes. This bench builds an in-memory 10-column
+// ResultSet (mix of int-as-string / short text / NULL / quote-bearing text so
+// every escapeCSV branch is exercised), calls exportData(), and asserts the
+// wall time stays below the 2s target.
+//
+// The target is a CI-friendly upper bound, not a microbenchmark — disk I/O
+// and OS cache state cause real variance. 2s aligns with the documented goal;
+// local Release runs sit well below it.
+
+#include "exporters/csv_exporter.h"
+
+#include <chrono>
+#include <filesystem>
+#include <format>
+#include <iostream>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace velocitydb {
+namespace {
+
+constexpr size_t kBenchRows = 100'000;
+constexpr size_t kBenchColumns = 10;
+constexpr auto EXPORT_TARGET = std::chrono::milliseconds(2'000);
+
+// NULL を散らす頻度 (約 5.9% のセルが SQL NULL になる)。escapedNullValue 経路を
+// 偏らせず分布させ、行ごとに NULL 位置がずれることで分岐予測の偏りを抑える。
+constexpr size_t kNullEveryNthCell = 17;
+// 1 セルだけ delimiter + quote を埋め込み、escapeCSV のクオート経路を強制的に
+// 通す。列インデックスはこの目的専用に固定。
+constexpr size_t kEscapeHeavyColumn = 3;
+
+// セル値の生成パターン。CSVExporter::escapeCSV の分岐 (NULL / クオート必要 /
+// 平文) を網羅するために列ごとに役割を切り替える。
+enum class CellKind {
+    SqlNull,        // SQL NULL — escapedNullValue 経路
+    EscapeHeavy,    // delimiter + quote 含む — 強制クオート経路
+    NumericLike,    // 数値のみ — 短い平文経路
+    ShortText,      // 短文 — 標準クオート経路
+};
+
+[[nodiscard]] CellKind classifyCell(size_t row, size_t col) {
+    if ((row + col) % kNullEveryNthCell == 0) return CellKind::SqlNull;
+    if (col == kEscapeHeavyColumn) return CellKind::EscapeHeavy;
+    if (col % 2 == 0) return CellKind::NumericLike;
+    return CellKind::ShortText;
+}
+
+[[nodiscard]] std::string makeCellValue(CellKind kind, size_t row, size_t col) {
+    switch (kind) {
+        case CellKind::SqlNull:      return {};
+        case CellKind::EscapeHeavy:  return std::format("v,{}\"x", row);
+        case CellKind::NumericLike:  return std::format("{}", row * (col + 1));
+        case CellKind::ShortText:    return std::format("row_{}_col_{}", row, col);
+    }
+    return {};  // unreachable
+}
+
+class CSVExporterBench : public ::testing::Test {
+protected:
+    ResultSet data;
+    std::filesystem::path outPath;
+
+    void SetUp() override {
+        data.columns = buildColumns();
+        data.rows = buildRows();
+        outPath = makeTempOutputPath();
+    }
+
+    void TearDown() override {
+        std::error_code ec;
+        std::filesystem::remove(outPath, ec);
+    }
+
+private:
+    static std::vector<ColumnInfo> buildColumns() {
+        std::vector<ColumnInfo> cols;
+        cols.reserve(kBenchColumns);
+        for (size_t c = 0; c < kBenchColumns; ++c) {
+            ColumnInfo col;
+            col.name = std::format("col_{}", c);
+            cols.push_back(std::move(col));
+        }
+        return cols;
+    }
+
+    static std::vector<ResultRow> buildRows() {
+        std::vector<ResultRow> rows;
+        rows.reserve(kBenchRows);
+        for (size_t r = 0; r < kBenchRows; ++r) {
+            rows.push_back(buildRow(r));
+        }
+        return rows;
+    }
+
+    static ResultRow buildRow(size_t r) {
+        ResultRow row;
+        row.values.reserve(kBenchColumns);
+        row.nullFlags.resize(kBenchColumns, false);
+        for (size_t c = 0; c < kBenchColumns; ++c) {
+            const auto kind = classifyCell(r, c);
+            row.values.emplace_back(makeCellValue(kind, r, c));
+            if (kind == CellKind::SqlNull) {
+                row.nullFlags[c] = true;
+            }
+        }
+        return row;
+    }
+
+    static std::filesystem::path makeTempOutputPath() {
+        return std::filesystem::temp_directory_path()
+               / std::format("velocitydb_csv_bench_{}.csv",
+                             std::chrono::steady_clock::now().time_since_epoch().count());
+    }
+};
+
+TEST_F(CSVExporterBench, Export100kRowsUnderTarget) {
+    CSVExporter exporter;
+
+    const auto start = std::chrono::steady_clock::now();
+    const bool ok = exporter.exportData(data, outPath.string());
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    ASSERT_TRUE(ok);
+
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
+    std::cerr << "[bench] CSVExporter 100k rows x " << kBenchColumns << " cols: "
+              << elapsedMs.count() << "ms\n";
+
+    EXPECT_LT(elapsedMs, EXPORT_TARGET)
+        << "CSV export of " << kBenchRows << " rows took " << elapsedMs.count() << "ms";
+}
+
+}  // namespace
+}  // namespace velocitydb


### PR DESCRIPTION
## Summary

- `tests/perf/test_csv_exporter_bench.cpp` を新規追加: 10 万行 × 10 列の `ResultSet` (NULL / delimiter+quote / 数値 / 短文を混在) を生成し `CSVExporter::exportData()` の所要時間を `std::chrono::steady_clock` で計測、`EXPECT_LT(elapsedMs, 2000ms)` で目標を強制。
- `tests/perf/CMakeLists.txt` の `VelocityDBPerfTests` に登録 (perf ラベルで `ctest -L perf` 実行可)。
- `docs/PERFORMANCE_VALIDATION.md` #7 行を「計測機構あり / 既存ベンチマークあり」に更新、詳細表に実行コマンドを追記。

ローカル Release 計測 (12th-gen Intel): 154–171ms (目標 2000ms に対し約 8%)。CI 実機での実測は別途。

なお `.github/workflows/tool-version-upgrade.yml` の 1 行修正 (`app-id` → `client-id`) が同コミットに混入しています。スコープ的には別件ですが、`actions/create-github-app-token@v3` の入力名変更に追随する修正です。

## Test plan

- [x] `uv run scripts/pdg.py build backend` — Release ビルド成功
- [x] `build/Release/VelocityDBPerfTests.exe --gtest_filter=CSVExporterBench.*` — 1/1 PASS (154ms)
- [x] `build/Release/VelocityDBPerfTests.exe` (perf 全件) — 12/12 PASS
- [x] `uv run scripts/pdg.py lint` — biome + tsc + clang-format pass
- [ ] CI 実機での実測値確認 (bench.yml workflow_dispatch)

Closes #547