### PR TITLE
test(perf): ResultCache hit/miss/eviction の bench を追加 (#548)

### DIFF
--- a/docs/PERFORMANCE_VALIDATION.md
+++ b/docs/PERFORMANCE_VALIDATION.md
@@ -149,8 +149,9 @@
 | 実装ファイル | `backend/database/result_cache.h:14-62`, `backend/database/result_cache.cpp` |
 | 実装手法 | `unordered_map` + `std::list` による O(1) アクセス・LRU 順序更新。デフォルト上限 100MB (`100 * 1024 * 1024`) |
 | 計測機構 | N/A (キャッシュは時間目標ではなくサイズ上限と LRU 動作が目標) |
-| 既存ベンチマーク | `tests/database/test_result_cache.cpp` で `put`/`get`/`evict`/サイズ追跡を検証済 |
-| 達成判定 | **✅ 達成**。実装・テスト共に存在 |
+| 既存ベンチマーク | `tests/database/test_result_cache.cpp` で `put`/`get`/`evict`/サイズ追跡を検証済 + `tests/perf/test_result_cache_bench.cpp` で hit / miss / eviction を伴う put のリグレッション検出 |
+| 計測手段 | `ctest --preset release -L perf` (perf bench), `ctest --preset release` (機能テスト) |
+| 達成判定 | **✅ 達成**。実装・機能テスト・perf bench 共に存在 |
 
 ## 計測手順
 

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PERF_TEST_SOURCES
     test_query_history_search_bench.cpp
     test_simd_filter_bench.cpp
     test_csv_exporter_bench.cpp
+    test_result_cache_bench.cpp
 )
 
 add_executable(VelocityDBPerfTests ${PERF_TEST_SOURCES})

--- a/tests/perf/test_result_cache_bench.cpp
+++ b/tests/perf/test_result_cache_bench.cpp
@@ -1,0 +1,142 @@
+// PERFORMANCE_VALIDATION.md #12: LRU result cache.
+//
+// README #12 のサイズ上限 (100MB) と LRU 動作は既存
+// `tests/database/test_result_cache.cpp` で機能検証済み。本 bench は時間目標
+// (= 明示的な README 値はない) ではなくリグレッション検出を目的とし、ヒット
+// 経路 / miss 経路 / eviction を伴う put 経路のそれぞれに CI フレンドリーな
+// 絶対上限を置く。
+//
+// `ResultCache::getAndApply` は `std::unordered_map::find` + `splice` + ユーザー
+// callback の合算で、O(1) を期待。`put` は eviction が走る場合のみ容量上限内に
+// 収まるまで先頭から `pop_front` するため、worst case では複数件 evict される。
+// SIMDFilter bench と同様、ratio は記録するが assert は loose な上限のみ。
+
+#include "database/result_cache.h"
+
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace velocitydb {
+namespace {
+
+constexpr size_t kBenchEntries = 1'000;
+constexpr size_t kEntryRows = 10;
+constexpr size_t kEntryCols = 4;
+
+// CI runner variance を吸収する loose な絶対上限。ローカル Release では各
+// テストとも 1ms 未満で完走するため、桁違いのリグレッション (たとえば
+// getAndApply の hash 計算が線形化する等) を捕捉できる粒度。
+constexpr auto HIT_TARGET = std::chrono::milliseconds(50);
+constexpr auto MISS_TARGET = std::chrono::milliseconds(50);
+constexpr auto PUT_WITH_EVICTION_TARGET = std::chrono::milliseconds(500);
+
+[[nodiscard]] ResultSet makeResultSet(size_t rows, size_t cols) {
+    ResultSet rs;
+    rs.columns.reserve(cols);
+    for (size_t c = 0; c < cols; ++c) {
+        rs.columns.push_back(ColumnInfo{.name = std::format("col_{}", c), .type = "VARCHAR"});
+    }
+    rs.rows.reserve(rows);
+    for (size_t r = 0; r < rows; ++r) {
+        ResultRow row;
+        row.values.reserve(cols);
+        row.nullFlags.assign(cols, false);
+        for (size_t c = 0; c < cols; ++c) {
+            row.values.push_back(std::format("val_{}_{}", r, c));
+        }
+        rs.rows.push_back(std::move(row));
+    }
+    return rs;
+}
+
+template <typename Fn>
+[[nodiscard]] std::chrono::nanoseconds measure(Fn&& fn) {
+    const auto start = std::chrono::steady_clock::now();
+    fn();
+    return std::chrono::steady_clock::now() - start;
+}
+
+class ResultCacheBench : public ::testing::Test {
+protected:
+    // 100MB は README #12 の上限。ヒット / miss 計測ではすべて収まる前提で
+    // eviction を意図的に起こさない構成。
+    ResultCache cache{100 * 1024 * 1024};
+    std::vector<std::string> keys;
+
+    void SetUp() override {
+        keys.reserve(kBenchEntries);
+        const auto sample = makeResultSet(kEntryRows, kEntryCols);
+        for (size_t i = 0; i < kBenchEntries; ++i) {
+            keys.push_back(std::format("key_{}", i));
+            cache.put(keys.back(), sample);
+        }
+    }
+};
+
+TEST_F(ResultCacheBench, HitLatencyUnderTarget) {
+    size_t total = 0;
+    const auto elapsed = measure([&] {
+        for (const auto& k : keys) {
+            total += cache.getAndApply(k, [](const ResultSet& r) { return r.rows.size(); });
+        }
+    });
+    ASSERT_EQ(total, kBenchEntries * kEntryRows);
+
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
+    std::cerr << "[bench] ResultCache hit x " << kBenchEntries << ": "
+              << elapsedMs.count() << "ms\n";
+    EXPECT_LT(elapsedMs, HIT_TARGET);
+}
+
+TEST_F(ResultCacheBench, MissLatencyUnderTarget) {
+    size_t total = 0;
+    const auto elapsed = measure([&] {
+        for (size_t i = 0; i < kBenchEntries; ++i) {
+            const auto miss = std::format("missing_{}", i);
+            total += cache.getAndApply(miss, [](const ResultSet& r) { return r.rows.size(); });
+        }
+    });
+    EXPECT_EQ(total, 0u);  // すべて miss → 0
+
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
+    std::cerr << "[bench] ResultCache miss x " << kBenchEntries << ": "
+              << elapsedMs.count() << "ms\n";
+    EXPECT_LT(elapsedMs, MISS_TARGET);
+}
+
+TEST(ResultCacheBenchEvict, PutWithEvictionUnderTarget) {
+    // 容量を「半分の件数しか入らない」サイズに絞ることで、後半の put すべてで
+    // eviction を強制する。これにより evictIfNeeded の loop 性能を捕捉。
+    const auto probeSample = makeResultSet(kEntryRows, kEntryCols);
+    ResultCache probe{100 * 1024 * 1024};
+    probe.put("probe", probeSample);
+    const auto entrySize = probe.getCurrentSize();
+    ASSERT_GT(entrySize, 0u);
+
+    const size_t capacity = entrySize * (kBenchEntries / 2);
+    ResultCache tight{capacity};
+
+    const auto sample = makeResultSet(kEntryRows, kEntryCols);
+    const auto elapsed = measure([&] {
+        for (size_t i = 0; i < kBenchEntries; ++i) {
+            tight.put(std::format("k_{}", i), sample);
+        }
+    });
+
+    const auto elapsedMs = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
+    std::cerr << "[bench] ResultCache put-with-eviction x " << kBenchEntries << ": "
+              << elapsedMs.count() << "ms (capacity=" << capacity
+              << " bytes, entry=" << entrySize << " bytes)\n";
+
+    // 後半半分で eviction が走るため、tight.getCurrentSize() <= capacity を確認。
+    EXPECT_LE(tight.getCurrentSize(), capacity);
+    EXPECT_LT(elapsedMs, PUT_WITH_EVICTION_TARGET);
+}
+
+}  // namespace
+}  // namespace velocitydb


### PR DESCRIPTION
## Summary

- `tests/perf/test_result_cache_bench.cpp` を新規追加: ResultCache の 3 シナリオを `std::chrono::steady_clock` で計測
  - `HitLatencyUnderTarget`: 1000 件投入後の `getAndApply` 1000 回 (< 50ms)
  - `MissLatencyUnderTarget`: 存在しないキーの `getAndApply` 1000 回 (< 50ms)
  - `PutWithEvictionUnderTarget`: 容量を半分に絞った tight cache に 1000 件 put、後半すべてで eviction 発生 (< 500ms)
- `tests/perf/CMakeLists.txt` の `VelocityDBPerfTests` に登録
- `docs/PERFORMANCE_VALIDATION.md` #12 を `tests/perf/test_result_cache_bench.cpp` の存在込みで更新

### 設計判断

- README #12 はサイズ目標 (100MB) のみで時間目標が明示されていないため、本 bench は「絶対値の達成判定」ではなく「リグレッション検出」を目的とする。SIMDFilter bench と同じ方針で CI runner variance を吸収する loose な絶対上限のみ assert。
- `PutWithEviction` は fixture 外の `TEST` に分離。fixture の 100MB cache は eviction を起こさないため、容量を絞った独立 cache を別途構築する責務分離。
- entry サイズは `probe.getCurrentSize()` で動的取得 (estimateSize 実装に追従)。固定 hard-code は ResultSet 構造変更でずれるため避けた。

### 実測 (12th-gen Intel, Release)

| シナリオ | 実測 | 目標 |
|---------|------|------|
| Hit x 1000 | 0ms | 50ms |
| Miss x 1000 | 0ms | 50ms |
| Put-with-eviction x 1000 | 1ms | 500ms |

## Test plan

- [x] \`uv run scripts/pdg.py build backend\` — Release ビルド成功
- [x] \`build/Release/VelocityDBPerfTests.exe --gtest_filter=ResultCacheBench*:*\` — 3/3 PASS
- [x] perf 全件 — 15/15 PASS (既存 12 件 + 新規 3 件)
- [x] \`uv run scripts/pdg.py lint\` — biome + tsc + clang-format pass
- [ ] CI 実機でのリグレッション基準値確立

Closes #548