### PR TITLE
fix(frontend): logger ↔ bridge 循環参照を解消 (#556)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,7 @@ frontend/
 - CSS Modules、Zustand、memo化 (GridToolbar, GridStatusBar, ResultGrid)
 - biome: lineWidth 100, シングルクォート, セミコロンあり
 - イベントハンドラ名に `handle` 接頭辞禁止（`deleteRow` ✅ / `handleDeleteRow` ❌）
+- **`utils/logger.ts` は最下層ユーティリティ**: `api/bridge` や `api/providers/*` 等の facade / 上位層を import 禁止。backend への書き出しは `window.invoke` 直叩きで行う (#556: 循環参照解消)。各 Bridge 抽出 (#521-#527) でも同原則を維持する
 
 ### Python (scripts/)
 

--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -15,12 +15,6 @@ import type { CacheStats, QueryHistoryEntry } from './providers/query';
 import type { ConnectResultResponse } from './schemas';
 import * as S from './schemas';
 
-declare global {
-  interface Window {
-    invoke?: (request: string) => Promise<string>;
-  }
-}
-
 /** ER diagram parse result returned from backend IPC (tool-agnostic) */
 export interface ERDiagramParseResult {
   name: string;

--- a/frontend/src/api/ipc/ipc-invoker.ts
+++ b/frontend/src/api/ipc/ipc-invoker.ts
@@ -1,11 +1,5 @@
 import { type IPCRequest, type IPCResponse, isIPCResponse } from './ipc-protocol';
 
-declare global {
-  interface Window {
-    invoke?: (request: string) => Promise<string>;
-  }
-}
-
 const MOCK_NETWORK_DELAY_MS = 50;
 
 // ログ送信自体が backend へ writeFrontendLog として渡るため、ログ出力で無限ループしないようスキップ

--- a/frontend/src/tests/utils/logger.test.ts
+++ b/frontend/src/tests/utils/logger.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 構造的な「bridge / providers facade を import しない」検査は @types/node 未導入のため
+// 振る舞いテスト群で間接担保 (循環参照が再発すると logger 自体が undefined を経由して下記テストが壊れる)。
+// 永続的な強制は CLAUDE.md 規約 + 将来 biome の useImportRestrictions ルール導入で対応 (別 Issue)。
+describe('logger', () => {
+  const originalInvoke = window.invoke;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    window.invoke = originalInvoke;
+    window.localStorage.removeItem('velocitydb_frontend_logs');
+  });
+
+  it('forceFlush で window.invoke を writeFrontendLog メソッドで呼ぶ', async () => {
+    const invoke = vi.fn().mockResolvedValue(JSON.stringify({ success: true, data: null }));
+    window.invoke = invoke;
+
+    const { logger } = await import('../../utils/logger');
+    logger.error('test message');
+    await logger.forceFlush();
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    const rawRequest = invoke.mock.calls[0]?.[0];
+    expect(typeof rawRequest).toBe('string');
+    const request = JSON.parse(rawRequest as string) as {
+      method: string;
+      params: string;
+    };
+    expect(request.method).toBe('writeFrontendLog');
+    const params = JSON.parse(request.params) as { content: string };
+    expect(params.content).toContain('test message');
+  });
+
+  it('window.invoke が無くても forceFlush は throw しない (DEV mode 互換)', async () => {
+    window.invoke = undefined;
+    const { logger } = await import('../../utils/logger');
+    logger.error('test');
+    await expect(logger.forceFlush()).resolves.toBeUndefined();
+  });
+
+  it('window.invoke が throw しても logger は throw しない (無限ループ防止)', async () => {
+    window.invoke = vi.fn().mockRejectedValue(new Error('backend down'));
+    const { logger } = await import('../../utils/logger');
+    logger.error('test');
+    await expect(logger.forceFlush()).resolves.toBeUndefined();
+  });
+
+  it('backend が success=false を返しても logger は throw せず原本 console.error に出す', async () => {
+    window.invoke = vi
+      .fn()
+      .mockResolvedValue(JSON.stringify({ success: false, error: 'disk full' }));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { logger } = await import('../../utils/logger');
+    logger.error('test');
+    await expect(logger.forceFlush()).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('disk full'));
+    errorSpy.mockRestore();
+  });
+});

--- a/frontend/src/types/window.d.ts
+++ b/frontend/src/types/window.d.ts
@@ -1,0 +1,8 @@
+// WebView2 が注入する IPC エントリポイント。bridge / ipc-invoker / logger から参照される。
+declare global {
+  interface Window {
+    invoke?: (request: string) => Promise<string>;
+  }
+}
+
+export {};

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,4 +1,28 @@
-import { bridge } from '../api/bridge';
+// console.error が後段で override されるため、module load 時に原本を捕捉しておく。
+// override 後の console.error を呼ぶと logger.addToQueue → flush → 再度ここに到達して無限ループする。
+const pristineConsoleError =
+  typeof console !== 'undefined' ? console.error.bind(console) : () => {};
+
+// logger は最下層ユーティリティとして bridge / facade に依存しない。
+// writeFrontendLog 用の IPC 呼び出しを window.invoke 直叩きで行う (#556: 循環参照解消)。
+async function invokeWriteFrontendLog(content: string): Promise<void> {
+  const winInvoke = window.invoke;
+  if (!winInvoke) return;
+  const request = JSON.stringify({
+    method: 'writeFrontendLog',
+    params: JSON.stringify({ content }),
+  });
+  const raw = await winInvoke(request);
+  // backend が success=false を返した場合は捕捉済みの原本 console.error に出す (無限ループ防止)
+  try {
+    const parsed = JSON.parse(raw) as { success?: boolean; error?: string };
+    if (parsed.success === false) {
+      pristineConsoleError(`[logger] writeFrontendLog failed: ${parsed.error ?? 'unknown'}`);
+    }
+  } catch {
+    // parse 失敗は無視 (無限ループ防止)
+  }
+}
 
 export enum LogLevel {
   DEBUG = 'DEBUG',
@@ -115,8 +139,7 @@ class Logger {
         }
       }
 
-      // Write to backend file (log/frontend.log)
-      await bridge.writeFrontendLog(logs);
+      await invokeWriteFrontendLog(logs);
     } catch (_error) {
       // Ignore log write errors (to avoid infinite loops)
       // Note: Does not error even in environments without localStorage


### PR DESCRIPTION
## 根本原因

`logger.ts:1 → bridge.ts:11 → bridge.ts:12 → providers/index.ts:8` の評価順で、`new WindowIpcInvoker(log)` 時点で `log` が `undefined` のまま注入されていた。

## 対策

- `logger.ts` から `bridge` import を削除し `window.invoke` 直叩き
- `Window.invoke` 型定義を `types/window.d.ts` に集約 (3 重複解消)
- `pristineConsoleError` (module load 時に bind した原本) で IPC 失敗を無限ループ無しに通知
- `CLAUDE.md` に "logger は facade 依存禁止" 規約を追記

## premise-questioning

✅ A 案採用 (window.invoke 直叩き)。3 案比較済 (A: 直叩き / B: 遅延 DI / C: lazy provider)。hierarchical-architecture 準拠 + #527 旧Bridge 削除と独立。

## テスト

- `logger.test.ts` 4 cases 追加 (forceFlush IPC 発火 / window.invoke 不在 / throw / success=false)
- 全 vitest 1060 tests PASS / biome 0 件 / tsc 0 error

## 関連

- 次タスク #521-#527 (各 Bridge 抽出) でも logger 依存禁止規約を維持

Closes #556