### PR TITLE
refactor(frontend): TransactionBridge を providers/transaction.ts に抽出 (#522)

### DIFF
--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -9,7 +9,12 @@ import type {
 import { DEFAULT_PAGE } from '../utils/erDiagramConstants';
 import type { ERDiagramModel } from '../utils/erDiagramParser';
 import { log } from '../utils/logger';
-import { connectionProvider, queryProvider, schemaProvider } from './providers';
+import {
+  connectionProvider,
+  queryProvider,
+  schemaProvider,
+  transactionProvider,
+} from './providers';
 import type { ConnectionInfo, TestConnectionInfo } from './providers/connection';
 import type { CacheStats, QueryHistoryEntry } from './providers/query';
 import type {
@@ -274,17 +279,17 @@ class Bridge {
     return schemaProvider.getColumns(connectionId, table);
   }
 
-  // Transaction methods
+  // Transaction methods (→ transactionProvider)
   async beginTransaction(connectionId: string): Promise<void> {
-    return this.call('beginTransaction', { connectionId }, S.beginTransaction);
+    return transactionProvider.beginTransaction(connectionId);
   }
 
   async commit(connectionId: string): Promise<void> {
-    return this.call('commit', { connectionId }, S.commit);
+    return transactionProvider.commit(connectionId);
   }
 
   async rollback(connectionId: string): Promise<void> {
-    return this.call('rollback', { connectionId }, S.rollback);
+    return transactionProvider.rollback(connectionId);
   }
 
   // Export methods

--- a/frontend/src/api/providers/index.ts
+++ b/frontend/src/api/providers/index.ts
@@ -3,6 +3,7 @@ import { type IpcInvoker, WindowIpcInvoker } from '../ipc/ipc-invoker';
 import { type ConnectionProvider, createConnectionProvider } from './connection';
 import { createQueryProvider, type QueryProvider } from './query';
 import { createSchemaProvider, type SchemaProvider } from './schema';
+import { createTransactionProvider, type TransactionProvider } from './transaction';
 import type { BridgeLogger, ResponseValidator } from './types';
 import { createZodValidator } from './validator';
 
@@ -14,6 +15,7 @@ interface Providers {
   connection: ConnectionProvider;
   query: QueryProvider;
   schema: SchemaProvider;
+  transaction: TransactionProvider;
 }
 
 function buildProviders(): Providers {
@@ -21,6 +23,7 @@ function buildProviders(): Providers {
     connection: createConnectionProvider(invokerInstance, loggerInstance, validatorInstance),
     query: createQueryProvider(invokerInstance, loggerInstance, validatorInstance),
     schema: createSchemaProvider(invokerInstance, loggerInstance, validatorInstance),
+    transaction: createTransactionProvider(invokerInstance, loggerInstance, validatorInstance),
   };
 }
 
@@ -42,6 +45,7 @@ function makeProviderProxy<K extends keyof Providers>(key: K): Providers[K] {
 export const connectionProvider: ConnectionProvider = makeProviderProxy('connection');
 export const queryProvider: QueryProvider = makeProviderProxy('query');
 export const schemaProvider: SchemaProvider = makeProviderProxy('schema');
+export const transactionProvider: TransactionProvider = makeProviderProxy('transaction');
 
 /** テスト専用: invoker を差し替えて全 provider を再構築する */
 export function __setIpcInvokerForTest(invoker: IpcInvoker): void {

--- a/frontend/src/api/providers/transaction.ts
+++ b/frontend/src/api/providers/transaction.ts
@@ -1,0 +1,44 @@
+import type { BridgeLogger, IpcInvoker, ResponseValidator } from './types';
+
+export interface TransactionProvider {
+  beginTransaction(connectionId: string): Promise<void>;
+  commit(connectionId: string): Promise<void>;
+  rollback(connectionId: string): Promise<void>;
+}
+
+class TransactionProviderImpl implements TransactionProvider {
+  constructor(
+    private readonly invoker: IpcInvoker,
+    // 共通シグネチャ維持 (#517 軸③): 現状未使用だが将来 log.info 等を実利用するため
+    private readonly logger: BridgeLogger,
+    // 共通シグネチャ維持 (#517 軸③): zVoid のため現状 parse を省略しているが、
+    // 将来 structured schema 化された際に差し替えられるよう受け取りは維持する
+    private readonly validator: ResponseValidator
+  ) {
+    void this.logger; // TS6138 抑制: 共通シグネチャ維持のため未使用受け取りを許可
+    void this.validator; // TS6138 抑制: 同上
+  }
+
+  async beginTransaction(connectionId: string): Promise<void> {
+    // S.beginTransaction は z.any() で実質 noop のため parse を省略 (connection.ts と同方針)
+    await this.invoker.invoke('beginTransaction', { connectionId });
+  }
+
+  async commit(connectionId: string): Promise<void> {
+    // S.commit は z.any() で実質 noop のため parse を省略
+    await this.invoker.invoke('commit', { connectionId });
+  }
+
+  async rollback(connectionId: string): Promise<void> {
+    // S.rollback は z.any() で実質 noop のため parse を省略
+    await this.invoker.invoke('rollback', { connectionId });
+  }
+}
+
+export function createTransactionProvider(
+  invoker: IpcInvoker,
+  logger: BridgeLogger,
+  validator: ResponseValidator
+): TransactionProvider {
+  return new TransactionProviderImpl(invoker, logger, validator);
+}

--- a/frontend/src/tests/api/transactionProvider.test.ts
+++ b/frontend/src/tests/api/transactionProvider.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockIpcInvoker } from '../../api/ipc/mock-ipc-invoker';
+import { __setIpcInvokerForTest, transactionProvider } from '../../api/providers';
+import type { TransactionProvider } from '../../api/providers/transaction';
+
+type TxMethod = keyof TransactionProvider;
+const TX_METHODS: readonly TxMethod[] = ['beginTransaction', 'commit', 'rollback'] as const;
+
+describe('transactionProvider', () => {
+  let mock: MockIpcInvoker;
+
+  beforeEach(() => {
+    mock = new MockIpcInvoker();
+    __setIpcInvokerForTest(mock);
+  });
+
+  describe.each(TX_METHODS)('%s', (method) => {
+    it('IPC を呼び connectionId を渡す', async () => {
+      mock.setResponse(method, null);
+
+      await transactionProvider[method]('conn-1');
+
+      expect(mock.calls[0]).toEqual({ method, params: { connectionId: 'conn-1' } });
+    });
+
+    it('IPC エラー時に throw する', async () => {
+      mock.setError(method, `${method} failed`);
+
+      await expect(transactionProvider[method]('conn-1')).rejects.toThrow(`${method} failed`);
+    });
+  });
+
+  it('メソッドを分割代入してから呼んでも this が失われない', async () => {
+    mock.setResponse('beginTransaction', null);
+    const { beginTransaction } = transactionProvider;
+
+    await beginTransaction('conn-1');
+
+    expect(mock.calls[0]?.method).toBe('beginTransaction');
+  });
+
+  it('__setIpcInvokerForTest 後に再度差し替えると新しい invoker が使われる', async () => {
+    const first = new MockIpcInvoker();
+    first.setResponse('commit', null);
+    __setIpcInvokerForTest(first);
+
+    const second = new MockIpcInvoker();
+    second.setResponse('commit', null);
+    __setIpcInvokerForTest(second);
+
+    await transactionProvider.commit('conn-1');
+
+    expect(second.calls).toHaveLength(1);
+    expect(first.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
#516 の Bridge facade 化シリーズ。transaction 系 3 メソッドを提供層TransactionProvider に分離。

- providers/transaction.ts 新規 (45 行: interface + Impl + factory)
- providers/index.ts に transactionProvider 登録
- bridge.ts の beginTransaction / commit / rollback を委譲化
- tests/api/transactionProvider.test.ts 新規
  - (describe.each で table-driven 化 正常系 3 + エラー系 3 + this 保持 + invoker 差替 = 8 cases)

設計判断:

- zVoid (z.any()) に対する parse は connection.ts の cancelConnect/disconnect と同方針で省略 (コメント明示)
- logger/validator は共通シグネチャ維持 (#517 軸③) のため受け取りのみ、未使用

検証:

- vitest: 8/8 PASS (新規) / 1084/1084 PASS (全体回帰)
- tsc: 0 error
- biome: 0 件

Closes #522
Parent: #516