### PR TITLE
refactor(frontend): ExportBridge を providers/export.ts に抽出 (#523)

### DIFF
--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -11,6 +11,7 @@ import type { ERDiagramModel } from '../utils/erDiagramParser';
 import { log } from '../utils/logger';
 import {
   connectionProvider,
+  exportProvider,
   queryProvider,
   schemaProvider,
   transactionProvider,
@@ -107,7 +108,8 @@ function toCardinality(value: string): Cardinality {
 // - Query history / cache / SQL builder (#520 で queryProvider に移管: getQueryHistory /
 //   removeQueryHistory / clearQueryHistory / setQueryHistoryFavorite / getCacheStats / clearCache /
 //   buildDataViewSql / buildWhereClause / buildDmlStatements / uppercaseKeywords)
-// - Schema / Transaction / Export / Settings / Search / IO: 未移管 (#521+)
+// - Schema (#521) / Transaction (#522) / Export (#523): 移管済 (委譲のみ)
+// - Settings / Search / IO: 未移管 (#524+)
 class Bridge {
   private async call<T>(
     method: string,
@@ -292,17 +294,17 @@ class Bridge {
     return transactionProvider.rollback(connectionId);
   }
 
-  // Export methods
+  // Export methods (→ exportProvider)
   async exportCSV(data: Record<string, string | null>[], filepath: string): Promise<void> {
-    return this.call('exportCSV', { data, filepath }, S.exportCSV);
+    return exportProvider.exportCSV(data, filepath);
   }
 
   async exportJSON(data: Record<string, string | null>[], filepath: string): Promise<void> {
-    return this.call('exportJSON', { data, filepath }, S.exportJSON);
+    return exportProvider.exportJSON(data, filepath);
   }
 
   async exportExcel(data: Record<string, string | null>[], filepath: string): Promise<void> {
-    return this.call('exportExcel', { data, filepath }, S.exportExcel);
+    return exportProvider.exportExcel(data, filepath);
   }
 
   // SQL builder methods (→ queryProvider)

--- a/frontend/src/api/providers/export.ts
+++ b/frontend/src/api/providers/export.ts
@@ -1,0 +1,44 @@
+import type { BridgeLogger, IpcInvoker, ResponseValidator } from './types';
+
+export interface ExportProvider {
+  exportCSV(data: Record<string, string | null>[], filepath: string): Promise<void>;
+  exportJSON(data: Record<string, string | null>[], filepath: string): Promise<void>;
+  exportExcel(data: Record<string, string | null>[], filepath: string): Promise<void>;
+}
+
+class ExportProviderImpl implements ExportProvider {
+  constructor(
+    private readonly invoker: IpcInvoker,
+    // 共通シグネチャ維持 (#517 軸③): 現状未使用だが将来 log.info 等を実利用するため
+    private readonly logger: BridgeLogger,
+    // 共通シグネチャ維持 (#517 軸③): zVoid のため現状 parse を省略しているが、
+    // 将来 structured schema 化された際に差し替えられるよう受け取りは維持する
+    private readonly validator: ResponseValidator
+  ) {
+    void this.logger; // TS6138 抑制: 共通シグネチャ維持のため未使用受け取りを許可
+    void this.validator; // TS6138 抑制: 同上
+  }
+
+  async exportCSV(data: Record<string, string | null>[], filepath: string): Promise<void> {
+    // S.exportCSV は z.any() で実質 noop のため parse を省略 (transaction.ts と同方針)
+    await this.invoker.invoke('exportCSV', { data, filepath });
+  }
+
+  async exportJSON(data: Record<string, string | null>[], filepath: string): Promise<void> {
+    // S.exportJSON は z.any() で実質 noop のため parse を省略
+    await this.invoker.invoke('exportJSON', { data, filepath });
+  }
+
+  async exportExcel(data: Record<string, string | null>[], filepath: string): Promise<void> {
+    // S.exportExcel は z.any() で実質 noop のため parse を省略
+    await this.invoker.invoke('exportExcel', { data, filepath });
+  }
+}
+
+export function createExportProvider(
+  invoker: IpcInvoker,
+  logger: BridgeLogger,
+  validator: ResponseValidator
+): ExportProvider {
+  return new ExportProviderImpl(invoker, logger, validator);
+}

--- a/frontend/src/api/providers/index.ts
+++ b/frontend/src/api/providers/index.ts
@@ -1,6 +1,7 @@
 import { log } from '../../utils/logger';
 import { type IpcInvoker, WindowIpcInvoker } from '../ipc/ipc-invoker';
 import { type ConnectionProvider, createConnectionProvider } from './connection';
+import { createExportProvider, type ExportProvider } from './export';
 import { createQueryProvider, type QueryProvider } from './query';
 import { createSchemaProvider, type SchemaProvider } from './schema';
 import { createTransactionProvider, type TransactionProvider } from './transaction';
@@ -16,6 +17,7 @@ interface Providers {
   query: QueryProvider;
   schema: SchemaProvider;
   transaction: TransactionProvider;
+  exportData: ExportProvider;
 }
 
 function buildProviders(): Providers {
@@ -24,6 +26,7 @@ function buildProviders(): Providers {
     query: createQueryProvider(invokerInstance, loggerInstance, validatorInstance),
     schema: createSchemaProvider(invokerInstance, loggerInstance, validatorInstance),
     transaction: createTransactionProvider(invokerInstance, loggerInstance, validatorInstance),
+    exportData: createExportProvider(invokerInstance, loggerInstance, validatorInstance),
   };
 }
 
@@ -46,6 +49,7 @@ export const connectionProvider: ConnectionProvider = makeProviderProxy('connect
 export const queryProvider: QueryProvider = makeProviderProxy('query');
 export const schemaProvider: SchemaProvider = makeProviderProxy('schema');
 export const transactionProvider: TransactionProvider = makeProviderProxy('transaction');
+export const exportProvider: ExportProvider = makeProviderProxy('exportData');
 
 /** テスト専用: invoker を差し替えて全 provider を再構築する */
 export function __setIpcInvokerForTest(invoker: IpcInvoker): void {

--- a/frontend/src/tests/api/exportProvider.test.ts
+++ b/frontend/src/tests/api/exportProvider.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockIpcInvoker } from '../../api/ipc/mock-ipc-invoker';
+import { __setIpcInvokerForTest, exportProvider } from '../../api/providers';
+import type { ExportProvider } from '../../api/providers/export';
+
+type ExportMethod = keyof ExportProvider;
+const EXPORT_METHODS: readonly ExportMethod[] = ['exportCSV', 'exportJSON', 'exportExcel'] as const;
+
+const SAMPLE_DATA: Record<string, string | null>[] = [
+  { id: '1', name: 'alice', note: null },
+  { id: '2', name: 'bob', note: 'memo' },
+];
+const SAMPLE_PATHS: Record<ExportMethod, string> = {
+  exportCSV: 'C:/tmp/out.csv',
+  exportJSON: 'C:/tmp/out.json',
+  exportExcel: 'C:/tmp/out.xlsx',
+};
+
+describe('exportProvider', () => {
+  let mock: MockIpcInvoker;
+
+  beforeEach(() => {
+    mock = new MockIpcInvoker();
+    __setIpcInvokerForTest(mock);
+  });
+
+  describe.each(EXPORT_METHODS)('%s', (method) => {
+    it('IPC を呼び data と filepath を渡す', async () => {
+      mock.setResponse(method, null);
+
+      await exportProvider[method](SAMPLE_DATA, SAMPLE_PATHS[method]);
+
+      expect(mock.calls[0]).toEqual({
+        method,
+        params: { data: SAMPLE_DATA, filepath: SAMPLE_PATHS[method] },
+      });
+    });
+
+    it('IPC エラー時に throw する', async () => {
+      mock.setError(method, `${method} failed`);
+
+      await expect(exportProvider[method](SAMPLE_DATA, SAMPLE_PATHS[method])).rejects.toThrow(
+        `${method} failed`
+      );
+    });
+  });
+
+  it('メソッドを分割代入してから呼んでも this が失われない', async () => {
+    mock.setResponse('exportCSV', null);
+    const { exportCSV } = exportProvider;
+
+    await exportCSV(SAMPLE_DATA, SAMPLE_PATHS.exportCSV);
+
+    expect(mock.calls[0]?.method).toBe('exportCSV');
+  });
+
+  it('__setIpcInvokerForTest 後に再度差し替えると新しい invoker が使われる', async () => {
+    const first = new MockIpcInvoker();
+    first.setResponse('exportJSON', null);
+    __setIpcInvokerForTest(first);
+
+    const second = new MockIpcInvoker();
+    second.setResponse('exportJSON', null);
+    __setIpcInvokerForTest(second);
+
+    await exportProvider.exportJSON(SAMPLE_DATA, SAMPLE_PATHS.exportJSON);
+
+    expect(second.calls).toHaveLength(1);
+    expect(first.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
- #516 の Bridge facade 化シリーズ。export 系 3 メソッドを提供層 ExportProvider に分離。

- providers/export.ts 新規 (45 行: interface + Impl + factory)
- providers/index.ts に exportProvider 登録 (内部キーは予約語回避で exportData)
- bridge.ts の exportCSV / exportJSON / exportExcel を委譲化
- tests/api/exportProvider.test.ts 新規 (describe.each で 8 cases: 正常系 3 + エラー系 3 + this 保持 + invoker 差替)

方針検証: premise-questioning skipped (理由: 親 #516 で方針確立済 / 先行 #521,#522 と
同パターン踏襲のため本 sub-issue では再検証不要)。

設計判断 (先行 PR #563 踏襲):

- zVoid に対する parse は省略 (transaction.ts と同方針、コメント明示)
- logger/validator は共通シグネチャ維持 (#517 軸③) のため受け取りのみ
- Providers interface の内部キーは ESM 予約語 export を避けて exportData (public な exportProvider 識別子は維持)
- テストデータ拡張子は各メソッドに対応 (.csv/.json/.xlsx) で意図を明示

検証:

- vitest: 8/8 PASS (新規) / 1092/1092 PASS (全体回帰)
- tsc: 0 error
- biome: 0 件

Closes #523
Parent: #516