### PR TITLE
refactor(frontend): SettingsBridge を providers/settings.ts に抽出 (#524)

### DIFF
--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -14,6 +14,7 @@ import {
   exportProvider,
   queryProvider,
   schemaProvider,
+  settingsProvider,
   transactionProvider,
 } from './providers';
 import type { ConnectionInfo, TestConnectionInfo } from './providers/connection';
@@ -27,6 +28,14 @@ import type {
   ReferencingForeignKeyInfo,
   TriggerInfo,
 } from './providers/schema';
+import type {
+  AppSettings,
+  ConnectionProfile,
+  SaveConnectionProfileInput,
+  SaveSessionStateInput,
+  SessionState,
+  UpdateSettingsInput,
+} from './providers/settings';
 import type { ConnectResultResponse } from './schemas';
 import * as S from './schemas';
 
@@ -108,8 +117,8 @@ function toCardinality(value: string): Cardinality {
 // - Query history / cache / SQL builder (#520 で queryProvider に移管: getQueryHistory /
 //   removeQueryHistory / clearQueryHistory / setQueryHistoryFavorite / getCacheStats / clearCache /
 //   buildDataViewSql / buildWhereClause / buildDmlStatements / uppercaseKeywords)
-// - Schema (#521) / Transaction (#522) / Export (#523): 移管済 (委譲のみ)
-// - Settings / Search / IO: 未移管 (#524+)
+// - Schema (#521) / Transaction (#522) / Export (#523) / Settings (#524): 移管済 (委譲のみ)
+// - Search / IO: 未移管 (#525+)
 class Bridge {
   private async call<T>(
     method: string,
@@ -440,196 +449,47 @@ class Bridge {
     );
   }
 
-  // Settings methods
-  async getSettings(): Promise<{
-    general: {
-      autoConnect: boolean;
-      lastConnectionId: string;
-      confirmOnExit: boolean;
-      maxQueryHistory: number;
-      maxRecentConnections: number;
-      language: string;
-    };
-    editor: {
-      fontSize: number;
-      fontFamily: string;
-      wordWrap: boolean;
-      tabSize: number;
-      insertSpaces: boolean;
-      showLineNumbers: boolean;
-      showMinimap: boolean;
-      theme: string;
-    };
-    grid: {
-      defaultPageSize: number;
-      showRowNumbers: boolean;
-      enableCellEditing: boolean;
-      dateFormat: string;
-      nullDisplay: string;
-    };
-    query: {
-      timeoutSeconds: number;
-    };
-  }> {
-    return this.call('getSettings', {}, S.getSettings);
+  // Settings methods (→ settingsProvider)
+  async getSettings(): Promise<AppSettings> {
+    return settingsProvider.getSettings();
   }
 
-  async updateSettings(settings: {
-    general?: Partial<{
-      autoConnect: boolean;
-      confirmOnExit: boolean;
-      maxQueryHistory: number;
-      language: string;
-    }>;
-    editor?: Partial<{
-      fontSize: number;
-      fontFamily: string;
-      wordWrap: boolean;
-      tabSize: number;
-      theme: string;
-    }>;
-    grid?: Partial<{
-      defaultPageSize: number;
-      showRowNumbers: boolean;
-      nullDisplay: string;
-    }>;
-    query?: Partial<{
-      timeoutSeconds: number;
-    }>;
-    window?: Partial<{
-      width: number;
-      height: number;
-      x: number;
-      y: number;
-      isMaximized: boolean;
-    }>;
-  }): Promise<{ saved: boolean }> {
-    return this.call('updateSettings', settings, S.updateSettings);
+  async updateSettings(settings: UpdateSettingsInput): Promise<{ saved: boolean }> {
+    return settingsProvider.updateSettings(settings);
   }
 
-  // Connection profile methods
-  async getConnectionProfiles(): Promise<{
-    profiles: {
-      id: string;
-      name: string;
-      server: string;
-      port?: number;
-      database: string;
-      username: string;
-      useWindowsAuth: boolean;
-      savePassword?: boolean;
-      isProduction?: boolean;
-      isReadOnly?: boolean;
-      environment?: 'development' | 'staging' | 'production';
-      dbType?: 'sqlserver' | 'postgresql' | 'mysql';
-      folderPath?: string;
-      ssh?: {
-        enabled: boolean;
-        host: string;
-        port: number;
-        username: string;
-        authType: 'password' | 'privateKey';
-        privateKeyPath: string;
-        savePassword: boolean;
-      };
-    }[];
-  }> {
-    return this.call('getConnectionProfiles', {}, S.getConnectionProfiles);
+  // Connection profile methods (→ settingsProvider)
+  async getConnectionProfiles(): Promise<{ profiles: ConnectionProfile[] }> {
+    return settingsProvider.getConnectionProfiles();
   }
 
-  async saveConnectionProfile(profile: {
-    id?: string;
-    name: string;
-    server: string;
-    port?: number;
-    database: string;
-    username?: string;
-    useWindowsAuth: boolean;
-    savePassword?: boolean;
-    password?: string;
-    isProduction?: boolean;
-    isReadOnly?: boolean;
-    environment?: 'development' | 'staging' | 'production';
-    dbType?: 'sqlserver' | 'postgresql' | 'mysql';
-    folderPath?: string;
-    ssh?: {
-      enabled: boolean;
-      host: string;
-      port: number;
-      username: string;
-      authType: 'password' | 'privateKey';
-      privateKeyPath?: string;
-      savePassword?: boolean;
-      password?: string;
-      keyPassphrase?: string;
-    };
-  }): Promise<{ id: string }> {
-    return this.call('saveConnectionProfile', profile, S.saveConnectionProfile);
+  async saveConnectionProfile(profile: SaveConnectionProfileInput): Promise<{ id: string }> {
+    return settingsProvider.saveConnectionProfile(profile);
   }
 
   async deleteConnectionProfile(id: string): Promise<{ deleted: boolean }> {
-    return this.call('deleteConnectionProfile', { id }, S.deleteConnectionProfile);
+    return settingsProvider.deleteConnectionProfile(id);
   }
 
   async getProfilePassword(profileId: string): Promise<{ password: string }> {
-    return this.call('getProfilePassword', { id: profileId }, S.getProfilePassword);
+    return settingsProvider.getProfilePassword(profileId);
   }
 
   async getSshPassword(profileId: string): Promise<{ password: string }> {
-    return this.call('getSshPassword', { id: profileId }, S.getSshPassword);
+    return settingsProvider.getSshPassword(profileId);
   }
 
   async getSshKeyPassphrase(profileId: string): Promise<{ passphrase: string }> {
-    return this.call('getSshKeyPassphrase', { id: profileId }, S.getSshKeyPassphrase);
+    return settingsProvider.getSshKeyPassphrase(profileId);
   }
 
-  // Session methods
-  async getSessionState(): Promise<{
-    activeConnectionId: string;
-    activeTabId: string;
-    windowX: number;
-    windowY: number;
-    windowWidth: number;
-    windowHeight: number;
-    isMaximized: boolean;
-    leftPanelWidth: number;
-    bottomPanelHeight: number;
-    openTabs: {
-      id: string;
-      title: string;
-      content: string;
-      filePath: string;
-      isDirty: boolean;
-      cursorLine: number;
-      cursorColumn: number;
-    }[];
-    expandedTreeNodes: string[];
-  }> {
-    return this.call('getSessionState', {}, S.getSessionState);
+  // Session methods (→ settingsProvider)
+  async getSessionState(): Promise<SessionState> {
+    return settingsProvider.getSessionState();
   }
 
-  async saveSessionState(state: {
-    activeConnectionId?: string;
-    activeTabId?: string;
-    windowX?: number;
-    windowY?: number;
-    windowWidth?: number;
-    windowHeight?: number;
-    isMaximized?: boolean;
-    leftPanelWidth?: number;
-    bottomPanelHeight?: number;
-    openTabs?: {
-      id: string;
-      title: string;
-      content: string;
-      filePath: string;
-      isDirty: boolean;
-      cursorLine: number;
-      cursorColumn: number;
-    }[];
-    expandedTreeNodes?: string[];
-  }): Promise<{ saved: boolean }> {
-    return this.call('saveSessionState', state, S.saveSessionState);
+  async saveSessionState(state: SaveSessionStateInput): Promise<{ saved: boolean }> {
+    return settingsProvider.saveSessionState(state);
   }
 
   // Search methods

--- a/frontend/src/api/providers/index.ts
+++ b/frontend/src/api/providers/index.ts
@@ -4,6 +4,7 @@ import { type ConnectionProvider, createConnectionProvider } from './connection'
 import { createExportProvider, type ExportProvider } from './export';
 import { createQueryProvider, type QueryProvider } from './query';
 import { createSchemaProvider, type SchemaProvider } from './schema';
+import { createSettingsProvider, type SettingsProvider } from './settings';
 import { createTransactionProvider, type TransactionProvider } from './transaction';
 import type { BridgeLogger, ResponseValidator } from './types';
 import { createZodValidator } from './validator';
@@ -18,6 +19,7 @@ interface Providers {
   schema: SchemaProvider;
   transaction: TransactionProvider;
   exportData: ExportProvider;
+  settings: SettingsProvider;
 }
 
 function buildProviders(): Providers {
@@ -27,6 +29,7 @@ function buildProviders(): Providers {
     schema: createSchemaProvider(invokerInstance, loggerInstance, validatorInstance),
     transaction: createTransactionProvider(invokerInstance, loggerInstance, validatorInstance),
     exportData: createExportProvider(invokerInstance, loggerInstance, validatorInstance),
+    settings: createSettingsProvider(invokerInstance, loggerInstance, validatorInstance),
   };
 }
 
@@ -50,6 +53,7 @@ export const queryProvider: QueryProvider = makeProviderProxy('query');
 export const schemaProvider: SchemaProvider = makeProviderProxy('schema');
 export const transactionProvider: TransactionProvider = makeProviderProxy('transaction');
 export const exportProvider: ExportProvider = makeProviderProxy('exportData');
+export const settingsProvider: SettingsProvider = makeProviderProxy('settings');
 
 /** テスト専用: invoker を差し替えて全 provider を再構築する */
 export function __setIpcInvokerForTest(invoker: IpcInvoker): void {

--- a/frontend/src/api/providers/settings.ts
+++ b/frontend/src/api/providers/settings.ts
@@ -1,0 +1,275 @@
+import * as S from '../schemas';
+import type { BridgeLogger, IpcInvoker, ResponseValidator } from './types';
+
+// ============================================================================
+// 設定 (getSettings / updateSettings)
+// ============================================================================
+
+export interface AppSettings {
+  general: {
+    autoConnect: boolean;
+    lastConnectionId: string;
+    confirmOnExit: boolean;
+    maxQueryHistory: number;
+    maxRecentConnections: number;
+    language: string;
+  };
+  editor: {
+    fontSize: number;
+    fontFamily: string;
+    wordWrap: boolean;
+    tabSize: number;
+    insertSpaces: boolean;
+    showLineNumbers: boolean;
+    showMinimap: boolean;
+    theme: string;
+  };
+  grid: {
+    defaultPageSize: number;
+    showRowNumbers: boolean;
+    enableCellEditing: boolean;
+    dateFormat: string;
+    nullDisplay: string;
+  };
+  query: {
+    timeoutSeconds: number;
+  };
+}
+
+export interface UpdateSettingsInput {
+  general?: Partial<{
+    autoConnect: boolean;
+    confirmOnExit: boolean;
+    maxQueryHistory: number;
+    language: string;
+  }>;
+  editor?: Partial<{
+    fontSize: number;
+    fontFamily: string;
+    wordWrap: boolean;
+    tabSize: number;
+    theme: string;
+  }>;
+  grid?: Partial<{
+    defaultPageSize: number;
+    showRowNumbers: boolean;
+    nullDisplay: string;
+  }>;
+  query?: Partial<{
+    timeoutSeconds: number;
+  }>;
+  window?: Partial<{
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+    isMaximized: boolean;
+  }>;
+}
+
+// ============================================================================
+// 接続プロファイル (getConnectionProfiles / saveConnectionProfile / deleteConnectionProfile /
+//                 getProfilePassword / getSshPassword / getSshKeyPassphrase)
+// ============================================================================
+
+export interface ConnectionProfile {
+  id: string;
+  name: string;
+  server: string;
+  port?: number;
+  database: string;
+  username: string;
+  useWindowsAuth: boolean;
+  savePassword?: boolean;
+  isProduction?: boolean;
+  isReadOnly?: boolean;
+  environment?: 'development' | 'staging' | 'production';
+  dbType?: 'sqlserver' | 'postgresql' | 'mysql';
+  folderPath?: string;
+  ssh?: {
+    enabled: boolean;
+    host: string;
+    port: number;
+    username: string;
+    authType: 'password' | 'privateKey';
+    privateKeyPath: string;
+    savePassword: boolean;
+  };
+}
+
+export interface SaveConnectionProfileInput {
+  id?: string;
+  name: string;
+  server: string;
+  port?: number;
+  database: string;
+  username?: string;
+  useWindowsAuth: boolean;
+  savePassword?: boolean;
+  password?: string;
+  isProduction?: boolean;
+  isReadOnly?: boolean;
+  environment?: 'development' | 'staging' | 'production';
+  dbType?: 'sqlserver' | 'postgresql' | 'mysql';
+  folderPath?: string;
+  ssh?: {
+    enabled: boolean;
+    host: string;
+    port: number;
+    username: string;
+    authType: 'password' | 'privateKey';
+    privateKeyPath?: string;
+    savePassword?: boolean;
+    password?: string;
+    keyPassphrase?: string;
+  };
+}
+
+// ============================================================================
+// セッション (getSessionState / saveSessionState)
+// ============================================================================
+
+export interface SessionTab {
+  id: string;
+  title: string;
+  content: string;
+  filePath: string;
+  isDirty: boolean;
+  cursorLine: number;
+  cursorColumn: number;
+}
+
+export interface SessionState {
+  activeConnectionId: string;
+  activeTabId: string;
+  windowX: number;
+  windowY: number;
+  windowWidth: number;
+  windowHeight: number;
+  isMaximized: boolean;
+  leftPanelWidth: number;
+  bottomPanelHeight: number;
+  openTabs: SessionTab[];
+  expandedTreeNodes: string[];
+}
+
+export interface SaveSessionStateInput {
+  activeConnectionId?: string;
+  activeTabId?: string;
+  windowX?: number;
+  windowY?: number;
+  windowWidth?: number;
+  windowHeight?: number;
+  isMaximized?: boolean;
+  leftPanelWidth?: number;
+  bottomPanelHeight?: number;
+  openTabs?: SessionTab[];
+  expandedTreeNodes?: string[];
+}
+
+// ============================================================================
+// Provider IF
+// ============================================================================
+
+export interface SettingsProvider {
+  // 設定
+  getSettings(): Promise<AppSettings>;
+  updateSettings(settings: UpdateSettingsInput): Promise<{ saved: boolean }>;
+  // 接続プロファイル
+  getConnectionProfiles(): Promise<{ profiles: ConnectionProfile[] }>;
+  saveConnectionProfile(profile: SaveConnectionProfileInput): Promise<{ id: string }>;
+  deleteConnectionProfile(id: string): Promise<{ deleted: boolean }>;
+  getProfilePassword(profileId: string): Promise<{ password: string }>;
+  getSshPassword(profileId: string): Promise<{ password: string }>;
+  getSshKeyPassphrase(profileId: string): Promise<{ passphrase: string }>;
+  // セッション
+  getSessionState(): Promise<SessionState>;
+  saveSessionState(state: SaveSessionStateInput): Promise<{ saved: boolean }>;
+}
+
+class SettingsProviderImpl implements SettingsProvider {
+  constructor(
+    private readonly invoker: IpcInvoker,
+    // 共通シグネチャ維持 (#517 軸③): 現状未使用だが将来 log.info 等を実利用するため
+    private readonly logger: BridgeLogger,
+    private readonly validator: ResponseValidator
+  ) {
+    void this.logger; // TS6138 抑制: 共通シグネチャ維持のため未使用受け取りを許可
+  }
+
+  // ---- 設定 ----
+
+  async getSettings(): Promise<AppSettings> {
+    // S.getSettings は z.any() で実質 noop のため parse を省略 (connection.ts と同方針)
+    const raw = await this.invoker.invoke('getSettings', {});
+    return raw as AppSettings;
+  }
+
+  async updateSettings(settings: UpdateSettingsInput): Promise<{ saved: boolean }> {
+    const raw = await this.invoker.invoke(
+      'updateSettings',
+      settings as unknown as Record<string, unknown>
+    );
+    return this.validator.parse(S.updateSettings, raw);
+  }
+
+  // ---- 接続プロファイル ----
+
+  async getConnectionProfiles(): Promise<{ profiles: ConnectionProfile[] }> {
+    // S.getConnectionProfiles は z.any() で実質 noop のため parse を省略
+    const raw = await this.invoker.invoke('getConnectionProfiles', {});
+    return raw as { profiles: ConnectionProfile[] };
+  }
+
+  async saveConnectionProfile(profile: SaveConnectionProfileInput): Promise<{ id: string }> {
+    const raw = await this.invoker.invoke(
+      'saveConnectionProfile',
+      profile as unknown as Record<string, unknown>
+    );
+    return this.validator.parse(S.saveConnectionProfile, raw);
+  }
+
+  async deleteConnectionProfile(id: string): Promise<{ deleted: boolean }> {
+    const raw = await this.invoker.invoke('deleteConnectionProfile', { id });
+    return this.validator.parse(S.deleteConnectionProfile, raw);
+  }
+
+  async getProfilePassword(profileId: string): Promise<{ password: string }> {
+    const raw = await this.invoker.invoke('getProfilePassword', { id: profileId });
+    return this.validator.parse(S.getProfilePassword, raw);
+  }
+
+  async getSshPassword(profileId: string): Promise<{ password: string }> {
+    const raw = await this.invoker.invoke('getSshPassword', { id: profileId });
+    return this.validator.parse(S.getSshPassword, raw);
+  }
+
+  async getSshKeyPassphrase(profileId: string): Promise<{ passphrase: string }> {
+    const raw = await this.invoker.invoke('getSshKeyPassphrase', { id: profileId });
+    return this.validator.parse(S.getSshKeyPassphrase, raw);
+  }
+
+  // ---- セッション ----
+
+  async getSessionState(): Promise<SessionState> {
+    // S.getSessionState は z.any() で実質 noop のため parse を省略
+    const raw = await this.invoker.invoke('getSessionState', {});
+    return raw as SessionState;
+  }
+
+  async saveSessionState(state: SaveSessionStateInput): Promise<{ saved: boolean }> {
+    const raw = await this.invoker.invoke(
+      'saveSessionState',
+      state as unknown as Record<string, unknown>
+    );
+    return this.validator.parse(S.saveSessionState, raw);
+  }
+}
+
+export function createSettingsProvider(
+  invoker: IpcInvoker,
+  logger: BridgeLogger,
+  validator: ResponseValidator
+): SettingsProvider {
+  return new SettingsProviderImpl(invoker, logger, validator);
+}

--- a/frontend/src/tests/api/settingsProvider.test.ts
+++ b/frontend/src/tests/api/settingsProvider.test.ts
@@ -1,0 +1,259 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockIpcInvoker } from '../../api/ipc/mock-ipc-invoker';
+import { __setIpcInvokerForTest, settingsProvider } from '../../api/providers';
+import type {
+  AppSettings,
+  ConnectionProfile,
+  SaveConnectionProfileInput,
+  SaveSessionStateInput,
+  SessionState,
+  UpdateSettingsInput,
+} from '../../api/providers/settings';
+
+const SAMPLE_SETTINGS: AppSettings = {
+  general: {
+    autoConnect: true,
+    lastConnectionId: 'conn-1',
+    confirmOnExit: false,
+    maxQueryHistory: 100,
+    maxRecentConnections: 10,
+    language: 'ja',
+  },
+  editor: {
+    fontSize: 14,
+    fontFamily: 'Consolas',
+    wordWrap: true,
+    tabSize: 2,
+    insertSpaces: true,
+    showLineNumbers: true,
+    showMinimap: false,
+    theme: 'dark',
+  },
+  grid: {
+    defaultPageSize: 50,
+    showRowNumbers: true,
+    enableCellEditing: true,
+    dateFormat: 'YYYY-MM-DD',
+    nullDisplay: '(null)',
+  },
+  query: {
+    timeoutSeconds: 30,
+  },
+};
+
+const SAMPLE_PROFILE: ConnectionProfile = {
+  id: 'p-1',
+  name: 'dev',
+  server: 'localhost',
+  database: 'test',
+  username: 'sa',
+  useWindowsAuth: false,
+};
+
+const SAMPLE_SAVE_PROFILE: SaveConnectionProfileInput = {
+  name: 'dev',
+  server: 'localhost',
+  database: 'test',
+  useWindowsAuth: false,
+};
+
+const SAMPLE_SESSION: SessionState = {
+  activeConnectionId: 'conn-1',
+  activeTabId: 'tab-1',
+  windowX: 0,
+  windowY: 0,
+  windowWidth: 1280,
+  windowHeight: 720,
+  isMaximized: false,
+  leftPanelWidth: 240,
+  bottomPanelHeight: 200,
+  openTabs: [
+    {
+      id: 'tab-1',
+      title: 'q1.sql',
+      content: 'SELECT 1',
+      filePath: '',
+      isDirty: false,
+      cursorLine: 0,
+      cursorColumn: 0,
+    },
+  ],
+  expandedTreeNodes: ['db.public'],
+};
+
+const SAMPLE_SAVE_SESSION: SaveSessionStateInput = {
+  activeConnectionId: 'conn-1',
+};
+
+const SAMPLE_UPDATE_SETTINGS: UpdateSettingsInput = {
+  general: { autoConnect: false },
+};
+
+describe('settingsProvider', () => {
+  let mock: MockIpcInvoker;
+
+  beforeEach(() => {
+    mock = new MockIpcInvoker();
+    __setIpcInvokerForTest(mock);
+  });
+
+  describe('設定 (getSettings / updateSettings)', () => {
+    it('getSettings: IPC を呼び戻り値を返す', async () => {
+      mock.setResponse('getSettings', SAMPLE_SETTINGS);
+
+      const result = await settingsProvider.getSettings();
+
+      expect(mock.calls[0]).toEqual({ method: 'getSettings', params: {} });
+      expect(result).toEqual(SAMPLE_SETTINGS);
+    });
+
+    it('updateSettings: IPC に引数を渡し saved を返す', async () => {
+      mock.setResponse('updateSettings', { saved: true });
+
+      const result = await settingsProvider.updateSettings(SAMPLE_UPDATE_SETTINGS);
+
+      expect(mock.calls[0]).toEqual({
+        method: 'updateSettings',
+        params: SAMPLE_UPDATE_SETTINGS,
+      });
+      expect(result).toEqual({ saved: true });
+    });
+
+    it('updateSettings: schema 不一致時に throw する', async () => {
+      mock.setResponse('updateSettings', { saved: 'true' });
+
+      await expect(settingsProvider.updateSettings(SAMPLE_UPDATE_SETTINGS)).rejects.toThrow();
+    });
+  });
+
+  describe('接続プロファイル', () => {
+    it('getConnectionProfiles: IPC を呼び profiles を返す', async () => {
+      mock.setResponse('getConnectionProfiles', { profiles: [SAMPLE_PROFILE] });
+
+      const result = await settingsProvider.getConnectionProfiles();
+
+      expect(mock.calls[0]).toEqual({ method: 'getConnectionProfiles', params: {} });
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0]).toEqual(SAMPLE_PROFILE);
+    });
+
+    it('saveConnectionProfile: IPC を呼び id を返す', async () => {
+      mock.setResponse('saveConnectionProfile', { id: 'p-new' });
+
+      const result = await settingsProvider.saveConnectionProfile(SAMPLE_SAVE_PROFILE);
+
+      expect(mock.calls[0]).toEqual({
+        method: 'saveConnectionProfile',
+        params: SAMPLE_SAVE_PROFILE,
+      });
+      expect(result).toEqual({ id: 'p-new' });
+    });
+
+    it('deleteConnectionProfile: id を {id} として渡し deleted を返す', async () => {
+      mock.setResponse('deleteConnectionProfile', { deleted: true });
+
+      const result = await settingsProvider.deleteConnectionProfile('p-1');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'deleteConnectionProfile',
+        params: { id: 'p-1' },
+      });
+      expect(result).toEqual({ deleted: true });
+    });
+
+    it('getProfilePassword: profileId を {id} として渡し password を返す', async () => {
+      mock.setResponse('getProfilePassword', { password: 'secret' });
+
+      const result = await settingsProvider.getProfilePassword('p-1');
+
+      expect(mock.calls[0]).toEqual({ method: 'getProfilePassword', params: { id: 'p-1' } });
+      expect(result).toEqual({ password: 'secret' });
+    });
+
+    it('getSshPassword: profileId を {id} として渡し password を返す', async () => {
+      mock.setResponse('getSshPassword', { password: 'ssh-secret' });
+
+      const result = await settingsProvider.getSshPassword('p-1');
+
+      expect(mock.calls[0]).toEqual({ method: 'getSshPassword', params: { id: 'p-1' } });
+      expect(result).toEqual({ password: 'ssh-secret' });
+    });
+
+    it('getSshKeyPassphrase: profileId を {id} として渡し passphrase を返す', async () => {
+      mock.setResponse('getSshKeyPassphrase', { passphrase: 'pass' });
+
+      const result = await settingsProvider.getSshKeyPassphrase('p-1');
+
+      expect(mock.calls[0]).toEqual({ method: 'getSshKeyPassphrase', params: { id: 'p-1' } });
+      expect(result).toEqual({ passphrase: 'pass' });
+    });
+  });
+
+  describe('セッション (getSessionState / saveSessionState)', () => {
+    it('getSessionState: IPC を呼び戻り値を返す', async () => {
+      mock.setResponse('getSessionState', SAMPLE_SESSION);
+
+      const result = await settingsProvider.getSessionState();
+
+      expect(mock.calls[0]).toEqual({ method: 'getSessionState', params: {} });
+      expect(result).toEqual(SAMPLE_SESSION);
+    });
+
+    it('saveSessionState: IPC に引数を渡し saved を返す', async () => {
+      mock.setResponse('saveSessionState', { saved: true });
+
+      const result = await settingsProvider.saveSessionState(SAMPLE_SAVE_SESSION);
+
+      expect(mock.calls[0]).toEqual({
+        method: 'saveSessionState',
+        params: SAMPLE_SAVE_SESSION,
+      });
+      expect(result).toEqual({ saved: true });
+    });
+  });
+
+  describe('エラー伝播 (全メソッド)', () => {
+    const cases: [string, () => Promise<unknown>][] = [
+      ['getSettings', () => settingsProvider.getSettings()],
+      ['updateSettings', () => settingsProvider.updateSettings(SAMPLE_UPDATE_SETTINGS)],
+      ['getConnectionProfiles', () => settingsProvider.getConnectionProfiles()],
+      ['saveConnectionProfile', () => settingsProvider.saveConnectionProfile(SAMPLE_SAVE_PROFILE)],
+      ['deleteConnectionProfile', () => settingsProvider.deleteConnectionProfile('p-1')],
+      ['getProfilePassword', () => settingsProvider.getProfilePassword('p-1')],
+      ['getSshPassword', () => settingsProvider.getSshPassword('p-1')],
+      ['getSshKeyPassphrase', () => settingsProvider.getSshKeyPassphrase('p-1')],
+      ['getSessionState', () => settingsProvider.getSessionState()],
+      ['saveSessionState', () => settingsProvider.saveSessionState(SAMPLE_SAVE_SESSION)],
+    ];
+
+    it.each(cases)('%s: IPC エラーを呼出側に伝播する', async (method, call) => {
+      mock.setError(method, `${method} failed`);
+
+      await expect(call()).rejects.toThrow(`${method} failed`);
+    });
+  });
+
+  it('メソッドを分割代入してから呼んでも this が失われない', async () => {
+    mock.setResponse('getSettings', SAMPLE_SETTINGS);
+    const { getSettings } = settingsProvider;
+
+    await getSettings();
+
+    expect(mock.calls[0]?.method).toBe('getSettings');
+  });
+
+  it('__setIpcInvokerForTest 後に再度差し替えると新しい invoker が使われる', async () => {
+    const first = new MockIpcInvoker();
+    first.setResponse('getSettings', SAMPLE_SETTINGS);
+    __setIpcInvokerForTest(first);
+
+    const second = new MockIpcInvoker();
+    second.setResponse('getSettings', SAMPLE_SETTINGS);
+    __setIpcInvokerForTest(second);
+
+    await settingsProvider.getSettings();
+
+    expect(second.calls).toHaveLength(1);
+    expect(first.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
- #516 の Bridge facade 化シリーズ。Settings / ConnectionProfile / SessionState 系 10 メソッドを提供層 SettingsProvider に分離。

- providers/settings.ts 新規 (262 行: 型 7 + interface + Impl + factory)
- 型: AppSettings / UpdateSettingsInput / ConnectionProfile / SaveConnectionProfileInput / SessionTab / SessionState / SaveSessionStateInput
- メソッド: 設定 2 + 接続プロファイル 6 + セッション 2
- providers/index.ts に settingsProvider 登録
- bridge.ts の 10 メソッドを委譲化 + インライン anonymous 型を named type import に置換 (bridge.ts -180/+44)
- tests/api/settingsProvider.test.ts 新規 (23 cases: 各メソッド正常系 10 + エラー伝播 it.each 10 + schema 不一致 1 + this 保持 + invoker 差替)

方針検証: premise-questioning skipped (理由: 親 #516 で方針確立済 / 先行 #521-#523 と同パターン踏襲 / 公開 IF 不変)。

設計判断 (先行 PR #562-#564 踏襲):

- z.any() 系 (getSettings / getConnectionProfiles / getSessionState) は parse 省略 + raw as T で型キャスト (connection.ts / transaction.ts と同方針、コメント明示)
- z.object 系 (updateSettings / saveConnectionProfile / deleteConnectionProfile / getProfilePassword / getSshPassword / getSshKeyPassphrase / saveSessionState) はvalidator.parse で構造検証
- インライン anonymous 型を export interface 化 (bridge.ts の DRY 違反解消、利用側コードは型推論経由なので無影響)
- 3 ドメイン (設定 / プロファイル / セッション) は Issue #524 タイトル仕様準拠で 1 facade に統合。SRP 観点の 3 facade 分割は別 Issue 起票候補

code-review 結果: PASS (Critical 0 / Warning 1 / Suggestion 3)

- W#1 (SRP / 3 ドメイン混在): 別 Issue 起票候補 (Issue 仕様準拠で見送り)
- S#2 (raw as T runtime 未検証): 別 Issue 起票候補 (schemas.ts 構造化 zod 化)
- S#3 (エラー系 8 メソッド未カバー): 本 PR で it.each 追加 (修正済)
- S#4 (S. 名前空間命名): 先行一貫性のため見送り

検証:

- vitest: 23/23 PASS (新規) / 1106/1106 PASS (全体回帰)
- tsc: 0 error
- biome: 0 件

Closes #524
Parent: #516