### PR TITLE
refactor(frontend): SearchBridge を providers/search.ts に抽出 (#525)

### DIFF
--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -14,6 +14,7 @@ import {
   exportProvider,
   queryProvider,
   schemaProvider,
+  searchProvider,
   settingsProvider,
   transactionProvider,
 } from './providers';
@@ -28,6 +29,7 @@ import type {
   ReferencingForeignKeyInfo,
   TriggerInfo,
 } from './providers/schema';
+import type { SearchObjectOptions, SearchObjectResult } from './providers/search';
 import type {
   AppSettings,
   ConnectionProfile,
@@ -117,8 +119,9 @@ function toCardinality(value: string): Cardinality {
 // - Query history / cache / SQL builder (#520 で queryProvider に移管: getQueryHistory /
 //   removeQueryHistory / clearQueryHistory / setQueryHistoryFavorite / getCacheStats / clearCache /
 //   buildDataViewSql / buildWhereClause / buildDmlStatements / uppercaseKeywords)
-// - Schema (#521) / Transaction (#522) / Export (#523) / Settings (#524): 移管済 (委譲のみ)
-// - Search / IO: 未移管 (#525+)
+// - Schema (#521) / Transaction (#522) / Export (#523) / Settings (#524) / Search (#525):
+//   移管済 (委譲のみ)
+// - IO: 未移管 (#526+)
 class Bridge {
   private async call<T>(
     method: string,
@@ -492,32 +495,17 @@ class Bridge {
     return settingsProvider.saveSessionState(state);
   }
 
-  // Search methods
+  // Search methods (→ searchProvider)
   async searchObjects(
     connectionId: string,
     pattern: string,
-    options?: {
-      searchTables?: boolean;
-      searchViews?: boolean;
-      searchProcedures?: boolean;
-      searchFunctions?: boolean;
-      searchColumns?: boolean;
-      caseSensitive?: boolean;
-      maxResults?: number;
-    }
-  ): Promise<
-    {
-      objectType: string;
-      schemaName: string;
-      objectName: string;
-      parentName: string;
-    }[]
-  > {
-    return this.call('searchObjects', { connectionId, pattern, ...options }, S.searchObjects);
+    options?: SearchObjectOptions
+  ): Promise<SearchObjectResult[]> {
+    return searchProvider.searchObjects(connectionId, pattern, options);
   }
 
   async quickSearch(connectionId: string, prefix: string, limit = 20): Promise<string[]> {
-    return this.call('quickSearch', { connectionId, prefix, limit }, S.quickSearch);
+    return searchProvider.quickSearch(connectionId, prefix, limit);
   }
 
   // Table metadata methods (→ schemaProvider)

--- a/frontend/src/api/providers/index.ts
+++ b/frontend/src/api/providers/index.ts
@@ -4,6 +4,7 @@ import { type ConnectionProvider, createConnectionProvider } from './connection'
 import { createExportProvider, type ExportProvider } from './export';
 import { createQueryProvider, type QueryProvider } from './query';
 import { createSchemaProvider, type SchemaProvider } from './schema';
+import { createSearchProvider, type SearchProvider } from './search';
 import { createSettingsProvider, type SettingsProvider } from './settings';
 import { createTransactionProvider, type TransactionProvider } from './transaction';
 import type { BridgeLogger, ResponseValidator } from './types';
@@ -20,6 +21,7 @@ interface Providers {
   transaction: TransactionProvider;
   exportData: ExportProvider;
   settings: SettingsProvider;
+  search: SearchProvider;
 }
 
 function buildProviders(): Providers {
@@ -30,6 +32,7 @@ function buildProviders(): Providers {
     transaction: createTransactionProvider(invokerInstance, loggerInstance, validatorInstance),
     exportData: createExportProvider(invokerInstance, loggerInstance, validatorInstance),
     settings: createSettingsProvider(invokerInstance, loggerInstance, validatorInstance),
+    search: createSearchProvider(invokerInstance, loggerInstance, validatorInstance),
   };
 }
 
@@ -54,6 +57,7 @@ export const schemaProvider: SchemaProvider = makeProviderProxy('schema');
 export const transactionProvider: TransactionProvider = makeProviderProxy('transaction');
 export const exportProvider: ExportProvider = makeProviderProxy('exportData');
 export const settingsProvider: SettingsProvider = makeProviderProxy('settings');
+export const searchProvider: SearchProvider = makeProviderProxy('search');
 
 /** テスト専用: invoker を差し替えて全 provider を再構築する */
 export function __setIpcInvokerForTest(invoker: IpcInvoker): void {

--- a/frontend/src/api/providers/search.ts
+++ b/frontend/src/api/providers/search.ts
@@ -1,0 +1,73 @@
+import * as S from '../schemas';
+import type { BridgeLogger, IpcInvoker, ResponseValidator } from './types';
+
+// ============================================================================
+// 検索結果 (searchObjects)
+// ============================================================================
+
+export interface SearchObjectResult {
+  objectType: string;
+  schemaName: string;
+  objectName: string;
+  parentName: string;
+}
+
+export interface SearchObjectOptions {
+  searchTables?: boolean;
+  searchViews?: boolean;
+  searchProcedures?: boolean;
+  searchFunctions?: boolean;
+  searchColumns?: boolean;
+  caseSensitive?: boolean;
+  maxResults?: number;
+}
+
+// ============================================================================
+// Provider IF
+// ============================================================================
+
+export interface SearchProvider {
+  searchObjects(
+    connectionId: string,
+    pattern: string,
+    options?: SearchObjectOptions
+  ): Promise<SearchObjectResult[]>;
+  quickSearch(connectionId: string, prefix: string, limit?: number): Promise<string[]>;
+}
+
+class SearchProviderImpl implements SearchProvider {
+  constructor(
+    private readonly invoker: IpcInvoker,
+    // 共通シグネチャ維持 (#517 軸③): 現状未使用だが将来 log.info 等を実利用するため
+    private readonly logger: BridgeLogger,
+    private readonly validator: ResponseValidator
+  ) {
+    void this.logger; // TS6138 抑制: 共通シグネチャ維持のため未使用受け取りを許可
+  }
+
+  async searchObjects(
+    connectionId: string,
+    pattern: string,
+    options?: SearchObjectOptions
+  ): Promise<SearchObjectResult[]> {
+    const raw = await this.invoker.invoke('searchObjects', {
+      connectionId,
+      pattern,
+      ...options,
+    });
+    return this.validator.parse(S.searchObjects, raw);
+  }
+
+  async quickSearch(connectionId: string, prefix: string, limit = 20): Promise<string[]> {
+    const raw = await this.invoker.invoke('quickSearch', { connectionId, prefix, limit });
+    return this.validator.parse(S.quickSearch, raw);
+  }
+}
+
+export function createSearchProvider(
+  invoker: IpcInvoker,
+  logger: BridgeLogger,
+  validator: ResponseValidator
+): SearchProvider {
+  return new SearchProviderImpl(invoker, logger, validator);
+}

--- a/frontend/src/tests/api/searchProvider.test.ts
+++ b/frontend/src/tests/api/searchProvider.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockIpcInvoker } from '../../api/ipc/mock-ipc-invoker';
+import { __setIpcInvokerForTest, searchProvider } from '../../api/providers';
+import type { SearchObjectResult } from '../../api/providers/search';
+
+const SAMPLE_RESULT: SearchObjectResult = {
+  objectType: 'TABLE',
+  schemaName: 'dbo',
+  objectName: 'users',
+  parentName: '',
+};
+
+describe('searchProvider', () => {
+  let mock: MockIpcInvoker;
+
+  beforeEach(() => {
+    mock = new MockIpcInvoker();
+    __setIpcInvokerForTest(mock);
+  });
+
+  describe('searchObjects', () => {
+    it('options 無し: connectionId と pattern を渡し配列を返す', async () => {
+      mock.setResponse('searchObjects', [SAMPLE_RESULT]);
+
+      const result = await searchProvider.searchObjects('c-1', 'user');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'searchObjects',
+        params: { connectionId: 'c-1', pattern: 'user' },
+      });
+      expect(result).toEqual([SAMPLE_RESULT]);
+    });
+
+    it('options 有り: options を spread して IPC に渡す', async () => {
+      mock.setResponse('searchObjects', [SAMPLE_RESULT]);
+
+      const result = await searchProvider.searchObjects('c-1', 'user', {
+        searchTables: true,
+        searchViews: false,
+        caseSensitive: true,
+        maxResults: 50,
+      });
+
+      expect(mock.calls[0]).toEqual({
+        method: 'searchObjects',
+        params: {
+          connectionId: 'c-1',
+          pattern: 'user',
+          searchTables: true,
+          searchViews: false,
+          caseSensitive: true,
+          maxResults: 50,
+        },
+      });
+      expect(result).toEqual([SAMPLE_RESULT]);
+    });
+
+    it('schema 不一致時に throw する', async () => {
+      mock.setResponse('searchObjects', [{ objectType: 'TABLE' }]);
+
+      await expect(searchProvider.searchObjects('c-1', 'user')).rejects.toThrow();
+    });
+  });
+
+  describe('quickSearch', () => {
+    it('limit 省略時に既定値 20 を渡し string 配列を返す', async () => {
+      mock.setResponse('quickSearch', ['users', 'user_roles']);
+
+      const result = await searchProvider.quickSearch('c-1', 'us');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'quickSearch',
+        params: { connectionId: 'c-1', prefix: 'us', limit: 20 },
+      });
+      expect(result).toEqual(['users', 'user_roles']);
+    });
+
+    it('limit 明示指定時にその値を渡す', async () => {
+      mock.setResponse('quickSearch', []);
+
+      await searchProvider.quickSearch('c-1', 'us', 5);
+
+      expect(mock.calls[0]).toEqual({
+        method: 'quickSearch',
+        params: { connectionId: 'c-1', prefix: 'us', limit: 5 },
+      });
+    });
+
+    it('schema 不一致時に throw する', async () => {
+      mock.setResponse('quickSearch', [1, 2, 3]);
+
+      await expect(searchProvider.quickSearch('c-1', 'us')).rejects.toThrow();
+    });
+  });
+
+  describe('エラー伝播', () => {
+    const cases: [string, () => Promise<unknown>][] = [
+      ['searchObjects', () => searchProvider.searchObjects('c-1', 'user')],
+      ['quickSearch', () => searchProvider.quickSearch('c-1', 'us')],
+    ];
+
+    it.each(cases)('%s: IPC エラーを呼出側に伝播する', async (method, call) => {
+      mock.setError(method, `${method} failed`);
+
+      await expect(call()).rejects.toThrow(`${method} failed`);
+    });
+  });
+
+  it('メソッドを分割代入してから呼んでも this が失われない', async () => {
+    mock.setResponse('quickSearch', []);
+    const { quickSearch } = searchProvider;
+
+    await quickSearch('c-1', 'us');
+
+    expect(mock.calls[0]?.method).toBe('quickSearch');
+  });
+
+  it('__setIpcInvokerForTest 後に再度差し替えると新しい invoker が使われる', async () => {
+    const first = new MockIpcInvoker();
+    first.setResponse('quickSearch', []);
+    __setIpcInvokerForTest(first);
+
+    const second = new MockIpcInvoker();
+    second.setResponse('quickSearch', []);
+    __setIpcInvokerForTest(second);
+
+    await searchProvider.quickSearch('c-1', 'us');
+
+    expect(second.calls).toHaveLength(1);
+    expect(first.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
親 #516 のサブ。bridge.searchObjects / quickSearch を提供層 SearchProvider に移管し、Bridge は委譲スタブとして残置(#527 で削除予定)。#521-#524 と同形パターン。

方針検証:

- premise-questioning: skipped (親 #516 で確定 + #521-#524 と同形)
- feature-pruning: skipped (機能追加・削減なし)

Closes #525