### PR TITLE
refactor(frontend): IOBridge を providers/io.ts に抽出 (#526)

### DIFF
--- a/frontend/src/api/bridge.ts
+++ b/frontend/src/api/bridge.ts
@@ -2,16 +2,14 @@ import type {
   AsyncQueryResultResponse,
   ConstraintInfo,
   DatabaseType,
-  IPCRequest,
-  IPCResponse,
   TableMetadata,
 } from '../types';
 import { DEFAULT_PAGE } from '../utils/erDiagramConstants';
 import type { ERDiagramModel } from '../utils/erDiagramParser';
-import { log } from '../utils/logger';
 import {
   connectionProvider,
   exportProvider,
+  ioProvider,
   queryProvider,
   schemaProvider,
   searchProvider,
@@ -19,6 +17,7 @@ import {
   transactionProvider,
 } from './providers';
 import type { ConnectionInfo, TestConnectionInfo } from './providers/connection';
+import type { Bookmark } from './providers/io';
 import type { CacheStats, QueryHistoryEntry } from './providers/query';
 import type {
   ColumnInfo,
@@ -39,7 +38,6 @@ import type {
   UpdateSettingsInput,
 } from './providers/settings';
 import type { ConnectResultResponse } from './schemas';
-import * as S from './schemas';
 
 // ERImportDialog / erDiagramStore が `import type { ERDiagramParseResult } from '../api/bridge'` で参照しているため、
 // schema.ts に型を移設した後も bridge 経由の互換を維持する目的で再エクスポートする。#527 で旧 Bridge 削除時に整理予定。
@@ -101,10 +99,6 @@ export function toERDiagramModel(
   };
 }
 
-function isIPCResponse(obj: unknown): obj is IPCResponse {
-  return typeof obj === 'object' && obj !== null && 'success' in obj;
-}
-
 type Cardinality = '1:1' | '1:N' | 'N:M';
 
 function toCardinality(value: string): Cardinality {
@@ -119,81 +113,9 @@ function toCardinality(value: string): Cardinality {
 // - Query history / cache / SQL builder (#520 で queryProvider に移管: getQueryHistory /
 //   removeQueryHistory / clearQueryHistory / setQueryHistoryFavorite / getCacheStats / clearCache /
 //   buildDataViewSql / buildWhereClause / buildDmlStatements / uppercaseKeywords)
-// - Schema (#521) / Transaction (#522) / Export (#523) / Settings (#524) / Search (#525):
-//   移管済 (委譲のみ)
-// - IO: 未移管 (#526+)
+// - Schema (#521) / Transaction (#522) / Export (#523) / Settings (#524) / Search (#525) /
+//   IO (#526): 移管済 (委譲のみ)
 class Bridge {
-  private async call<T>(
-    method: string,
-    params: Record<string, unknown>,
-    schema: { parse(data: unknown): T }
-  ): Promise<T> {
-    const request: IPCRequest = {
-      method,
-      params: JSON.stringify(params),
-    };
-
-    if (window.invoke) {
-      const requestStr = JSON.stringify(request);
-      // Skip logging for writeFrontendLog to prevent infinite loop
-      const shouldLog = method !== 'writeFrontendLog';
-
-      if (shouldLog) {
-        log.debug(`[Bridge] Sending request: ${method}`);
-      }
-
-      const responseRaw = await window.invoke(requestStr);
-
-      if (shouldLog) {
-        log.debug(`[Bridge] Received response for ${method} (type: ${typeof responseRaw})`);
-      }
-
-      // If response is already an object, webview may have parsed it
-      let response: IPCResponse;
-      if (typeof responseRaw === 'string') {
-        const parsed: unknown = JSON.parse(responseRaw);
-        if (!isIPCResponse(parsed)) {
-          log.error(`[Bridge] Invalid response structure for ${method}`);
-          throw new Error(`Invalid response structure for ${method}`);
-        }
-        response = parsed;
-      } else if (isIPCResponse(responseRaw)) {
-        response = responseRaw;
-      } else {
-        log.error(`[Bridge] Unexpected response type: ${typeof responseRaw}`);
-        throw new Error(`Unexpected response type: ${typeof responseRaw}`);
-      }
-
-      if (!response.success) {
-        log.error(`[Bridge] Error response for ${method}: ${response.error}`);
-        throw new Error(response.error || 'Unknown error');
-      }
-
-      if (shouldLog) {
-        log.debug(`[Bridge] Successfully processed ${method}`);
-      }
-      return schema.parse(response.data);
-    }
-
-    // Development mode only: dynamically import mock data
-    // Note: mockData types are not strictly validated - this is intentional for dev mode flexibility
-    // Real API calls in production go through proper type checking via IPC response handling above
-    if (import.meta.env.DEV) {
-      const { mockData } = await import('./mockData');
-      // Small delay to simulate network
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      const data = mockData[method];
-      if (data === undefined) {
-        log.warning(`[Bridge DEV] No mock data for method: ${method}`);
-        throw new Error(`[Bridge DEV] No mock data for method: ${method}`);
-      }
-      log.debug(`[Bridge DEV] Returning mock data for ${method}`);
-      return schema.parse(data);
-    }
-
-    throw new Error('Backend not available');
-  }
-
   // Connection methods (→ connectionProvider)
   async connectAsync(connectionInfo: ConnectionInfo): Promise<{ requestId: string }> {
     return connectionProvider.connectAsync(connectionInfo);
@@ -540,40 +462,33 @@ class Bridge {
     return schemaProvider.getTableDDL(connectionId, table);
   }
 
+  // IO methods (→ ioProvider)
   async writeFrontendLog(content: string): Promise<void> {
-    return this.call('writeFrontendLog', { content }, S.writeFrontendLog);
+    return ioProvider.writeFrontendLog(content);
   }
 
-  // File operations
   async saveQueryToFile(content: string, defaultFileName?: string): Promise<{ filePath: string }> {
-    return this.call('saveQueryToFile', { content, defaultFileName }, S.saveQueryToFile);
+    return ioProvider.saveQueryToFile(content, defaultFileName);
   }
 
   async loadQueryFromFile(): Promise<{ filePath: string; content: string }> {
-    return this.call('loadQueryFromFile', {}, S.loadQueryFromFile);
+    return ioProvider.loadQueryFromFile();
   }
 
   async browseFile(filter?: string): Promise<{ filePath: string }> {
-    return this.call('browseFile', { filter }, S.browseFile);
+    return ioProvider.browseFile(filter);
   }
 
-  // Bookmark operations
-  async getBookmarks(): Promise<
-    {
-      id: string;
-      name: string;
-      content: string;
-    }[]
-  > {
-    return this.call('getBookmarks', {}, S.getBookmarks);
+  async getBookmarks(): Promise<Bookmark[]> {
+    return ioProvider.getBookmarks();
   }
 
   async saveBookmark(id: string, name: string, content: string): Promise<void> {
-    return this.call('saveBookmark', { id, name, content }, S.saveBookmark);
+    return ioProvider.saveBookmark(id, name, content);
   }
 
   async deleteBookmark(id: string): Promise<void> {
-    return this.call('deleteBookmark', { id }, S.deleteBookmark);
+    return ioProvider.deleteBookmark(id);
   }
 }
 

--- a/frontend/src/api/providers/index.ts
+++ b/frontend/src/api/providers/index.ts
@@ -2,6 +2,7 @@ import { log } from '../../utils/logger';
 import { type IpcInvoker, WindowIpcInvoker } from '../ipc/ipc-invoker';
 import { type ConnectionProvider, createConnectionProvider } from './connection';
 import { createExportProvider, type ExportProvider } from './export';
+import { createIoProvider, type IoProvider } from './io';
 import { createQueryProvider, type QueryProvider } from './query';
 import { createSchemaProvider, type SchemaProvider } from './schema';
 import { createSearchProvider, type SearchProvider } from './search';
@@ -22,6 +23,7 @@ interface Providers {
   exportData: ExportProvider;
   settings: SettingsProvider;
   search: SearchProvider;
+  io: IoProvider;
 }
 
 function buildProviders(): Providers {
@@ -33,6 +35,7 @@ function buildProviders(): Providers {
     exportData: createExportProvider(invokerInstance, loggerInstance, validatorInstance),
     settings: createSettingsProvider(invokerInstance, loggerInstance, validatorInstance),
     search: createSearchProvider(invokerInstance, loggerInstance, validatorInstance),
+    io: createIoProvider(invokerInstance, loggerInstance, validatorInstance),
   };
 }
 
@@ -58,6 +61,7 @@ export const transactionProvider: TransactionProvider = makeProviderProxy('trans
 export const exportProvider: ExportProvider = makeProviderProxy('exportData');
 export const settingsProvider: SettingsProvider = makeProviderProxy('settings');
 export const searchProvider: SearchProvider = makeProviderProxy('search');
+export const ioProvider: IoProvider = makeProviderProxy('io');
 
 /** テスト専用: invoker を差し替えて全 provider を再構築する */
 export function __setIpcInvokerForTest(invoker: IpcInvoker): void {

--- a/frontend/src/api/providers/io.ts
+++ b/frontend/src/api/providers/io.ts
@@ -1,0 +1,83 @@
+import * as S from '../schemas';
+import type { BridgeLogger, IpcInvoker, ResponseValidator } from './types';
+
+// ============================================================================
+// Bookmark (getBookmarks)
+// ============================================================================
+
+export interface Bookmark {
+  id: string;
+  name: string;
+  content: string;
+}
+
+// ============================================================================
+// Provider IF
+// ============================================================================
+
+export interface IoProvider {
+  writeFrontendLog(content: string): Promise<void>;
+  saveQueryToFile(content: string, defaultFileName?: string): Promise<{ filePath: string }>;
+  loadQueryFromFile(): Promise<{ filePath: string; content: string }>;
+  browseFile(filter?: string): Promise<{ filePath: string }>;
+  getBookmarks(): Promise<Bookmark[]>;
+  saveBookmark(id: string, name: string, content: string): Promise<void>;
+  deleteBookmark(id: string): Promise<void>;
+}
+
+class IoProviderImpl implements IoProvider {
+  constructor(
+    private readonly invoker: IpcInvoker,
+    // 共通シグネチャ維持 (#517 軸③): 現状未使用だが将来 log.info 等を実利用するため
+    private readonly logger: BridgeLogger,
+    private readonly validator: ResponseValidator
+  ) {
+    void this.logger; // TS6138 抑制: 共通シグネチャ維持のため未使用受け取りを許可
+  }
+
+  async writeFrontendLog(content: string): Promise<void> {
+    // 呼出側不在の dead method (utils/logger.ts は #556 で window.invoke 直叩き化、
+    // 他に直接呼ぶ consumer なし)。Issue #526 の facade 完全性のため残置。
+    // 将来 logger 以外から構造化ログ送出が必要になった際の入口として機能する。
+    // schema は zVoid のため parse を省略 (transaction.ts と同方針)。
+    await this.invoker.invoke('writeFrontendLog', { content });
+  }
+
+  async saveQueryToFile(content: string, defaultFileName?: string): Promise<{ filePath: string }> {
+    const raw = await this.invoker.invoke('saveQueryToFile', { content, defaultFileName });
+    return this.validator.parse(S.saveQueryToFile, raw);
+  }
+
+  async loadQueryFromFile(): Promise<{ filePath: string; content: string }> {
+    const raw = await this.invoker.invoke('loadQueryFromFile', {});
+    return this.validator.parse(S.loadQueryFromFile, raw);
+  }
+
+  async browseFile(filter?: string): Promise<{ filePath: string }> {
+    const raw = await this.invoker.invoke('browseFile', { filter });
+    return this.validator.parse(S.browseFile, raw);
+  }
+
+  async getBookmarks(): Promise<Bookmark[]> {
+    const raw = await this.invoker.invoke('getBookmarks', {});
+    return this.validator.parse(S.getBookmarks, raw);
+  }
+
+  async saveBookmark(id: string, name: string, content: string): Promise<void> {
+    // S.saveBookmark は zVoid のため parse を省略
+    await this.invoker.invoke('saveBookmark', { id, name, content });
+  }
+
+  async deleteBookmark(id: string): Promise<void> {
+    // S.deleteBookmark は zVoid のため parse を省略
+    await this.invoker.invoke('deleteBookmark', { id });
+  }
+}
+
+export function createIoProvider(
+  invoker: IpcInvoker,
+  logger: BridgeLogger,
+  validator: ResponseValidator
+): IoProvider {
+  return new IoProviderImpl(invoker, logger, validator);
+}

--- a/frontend/src/tests/api/ioProvider.test.ts
+++ b/frontend/src/tests/api/ioProvider.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockIpcInvoker } from '../../api/ipc/mock-ipc-invoker';
+import { __setIpcInvokerForTest, ioProvider } from '../../api/providers';
+import type { Bookmark } from '../../api/providers/io';
+
+const SAMPLE_BOOKMARKS: Bookmark[] = [
+  { id: 'b1', name: 'list-users', content: 'SELECT * FROM users' },
+  { id: 'b2', name: 'count-orders', content: 'SELECT COUNT(*) FROM orders' },
+];
+
+describe('ioProvider', () => {
+  let mock: MockIpcInvoker;
+
+  beforeEach(() => {
+    mock = new MockIpcInvoker();
+    __setIpcInvokerForTest(mock);
+  });
+
+  describe('writeFrontendLog', () => {
+    it('content を渡し IPC を呼ぶ', async () => {
+      mock.setResponse('writeFrontendLog', null);
+
+      await ioProvider.writeFrontendLog('log entry');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'writeFrontendLog',
+        params: { content: 'log entry' },
+      });
+    });
+  });
+
+  describe('saveQueryToFile', () => {
+    it('defaultFileName 省略時にも IPC を呼び filePath を返す', async () => {
+      mock.setResponse('saveQueryToFile', { filePath: 'C:/tmp/q.sql' });
+
+      const result = await ioProvider.saveQueryToFile('SELECT 1');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'saveQueryToFile',
+        params: { content: 'SELECT 1', defaultFileName: undefined },
+      });
+      expect(result).toEqual({ filePath: 'C:/tmp/q.sql' });
+    });
+
+    it('defaultFileName 明示時にその値を渡す', async () => {
+      mock.setResponse('saveQueryToFile', { filePath: 'C:/tmp/named.sql' });
+
+      await ioProvider.saveQueryToFile('SELECT 1', 'named.sql');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'saveQueryToFile',
+        params: { content: 'SELECT 1', defaultFileName: 'named.sql' },
+      });
+    });
+
+    it('schema 不一致時に throw する', async () => {
+      mock.setResponse('saveQueryToFile', { wrong: 'shape' });
+
+      await expect(ioProvider.saveQueryToFile('SELECT 1')).rejects.toThrow();
+    });
+  });
+
+  describe('loadQueryFromFile', () => {
+    it('引数無しで IPC を呼び filePath と content を返す', async () => {
+      mock.setResponse('loadQueryFromFile', { filePath: 'C:/q.sql', content: 'SELECT 1' });
+
+      const result = await ioProvider.loadQueryFromFile();
+
+      expect(mock.calls[0]).toEqual({ method: 'loadQueryFromFile', params: {} });
+      expect(result).toEqual({ filePath: 'C:/q.sql', content: 'SELECT 1' });
+    });
+
+    it('schema 不一致時に throw する', async () => {
+      mock.setResponse('loadQueryFromFile', { filePath: 'C:/q.sql' });
+
+      await expect(ioProvider.loadQueryFromFile()).rejects.toThrow();
+    });
+  });
+
+  describe('browseFile', () => {
+    it('filter 省略時にも IPC を呼び filePath を返す', async () => {
+      mock.setResponse('browseFile', { filePath: 'C:/key.pem' });
+
+      const result = await ioProvider.browseFile();
+
+      expect(mock.calls[0]).toEqual({
+        method: 'browseFile',
+        params: { filter: undefined },
+      });
+      expect(result).toEqual({ filePath: 'C:/key.pem' });
+    });
+
+    it('filter 明示時にその値を渡す', async () => {
+      mock.setResponse('browseFile', { filePath: 'C:/key.pem' });
+
+      await ioProvider.browseFile('PEM Files (*.pem)|*.pem');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'browseFile',
+        params: { filter: 'PEM Files (*.pem)|*.pem' },
+      });
+    });
+
+    it('schema 不一致時に throw する', async () => {
+      mock.setResponse('browseFile', {});
+
+      await expect(ioProvider.browseFile()).rejects.toThrow();
+    });
+  });
+
+  describe('getBookmarks', () => {
+    it('IPC を呼び Bookmark 配列を返す', async () => {
+      mock.setResponse('getBookmarks', SAMPLE_BOOKMARKS);
+
+      const result = await ioProvider.getBookmarks();
+
+      expect(mock.calls[0]).toEqual({ method: 'getBookmarks', params: {} });
+      expect(result).toEqual(SAMPLE_BOOKMARKS);
+    });
+
+    it('schema 不一致時に throw する', async () => {
+      mock.setResponse('getBookmarks', [{ id: 'b1' }]);
+
+      await expect(ioProvider.getBookmarks()).rejects.toThrow();
+    });
+  });
+
+  describe('saveBookmark', () => {
+    it('id / name / content を渡し IPC を呼ぶ', async () => {
+      mock.setResponse('saveBookmark', null);
+
+      await ioProvider.saveBookmark('b1', 'list-users', 'SELECT * FROM users');
+
+      expect(mock.calls[0]).toEqual({
+        method: 'saveBookmark',
+        params: { id: 'b1', name: 'list-users', content: 'SELECT * FROM users' },
+      });
+    });
+  });
+
+  describe('deleteBookmark', () => {
+    it('id を渡し IPC を呼ぶ', async () => {
+      mock.setResponse('deleteBookmark', null);
+
+      await ioProvider.deleteBookmark('b1');
+
+      expect(mock.calls[0]).toEqual({ method: 'deleteBookmark', params: { id: 'b1' } });
+    });
+  });
+
+  describe('エラー伝播', () => {
+    const cases: [string, () => Promise<unknown>][] = [
+      ['writeFrontendLog', () => ioProvider.writeFrontendLog('x')],
+      ['saveQueryToFile', () => ioProvider.saveQueryToFile('SELECT 1')],
+      ['loadQueryFromFile', () => ioProvider.loadQueryFromFile()],
+      ['browseFile', () => ioProvider.browseFile()],
+      ['getBookmarks', () => ioProvider.getBookmarks()],
+      ['saveBookmark', () => ioProvider.saveBookmark('b1', 'n', 'c')],
+      ['deleteBookmark', () => ioProvider.deleteBookmark('b1')],
+    ];
+
+    it.each(cases)('%s: IPC エラーを呼出側に伝播する', async (method, call) => {
+      mock.setError(method, `${method} failed`);
+
+      await expect(call()).rejects.toThrow(`${method} failed`);
+    });
+  });
+
+  it('メソッドを分割代入してから呼んでも this が失われない', async () => {
+    mock.setResponse('getBookmarks', []);
+    const { getBookmarks } = ioProvider;
+
+    await getBookmarks();
+
+    expect(mock.calls[0]?.method).toBe('getBookmarks');
+  });
+
+  it('__setIpcInvokerForTest 後に再度差し替えると新しい invoker が使われる', async () => {
+    const first = new MockIpcInvoker();
+    first.setResponse('getBookmarks', []);
+    __setIpcInvokerForTest(first);
+
+    const second = new MockIpcInvoker();
+    second.setResponse('getBookmarks', []);
+    __setIpcInvokerForTest(second);
+
+    await ioProvider.getBookmarks();
+
+    expect(second.calls).toHaveLength(1);
+    expect(first.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- bridge.ts の IO 系 7 メソッドを `providers/io.ts` (IoProvider 提供層) に分離
- 全 provider 移管完了に伴い bridge.ts の dead code (`private call` / `S` import / `log` import / IPC 型 / isIPCResponse) を削除
- ioProvider.test.ts 新規 22 cases

## 方針検証

- `premise-questioning: skipped (理由: 既存 #521-#525 と同一の Bridge facade 抽出パターンを踏襲する局所リファクタ。戦略レベル方針は親
  #516 で確定済 / 公開 IF 不変 / 振る舞い不変)`
- `feature-pruning: N/A (機能変更なし)`

## 既知の dead method

`bridge.writeFrontendLog` / `ioProvider.writeFrontendLog` は呼出側不在 (logger.ts は #556 で window.invoke 直叩き)。Issue #526
仕様準拠 + facade 完全性のため残置。

## Test plan

- [x] ioProvider 22/22 PASS
- [x] api テスト全 140 PASS
- [x] frontend 全 1147 PASS
- [x] biome check (4 files) 0 件
- [ ] 実機 WebView2 で bookmark CRUD / saveQueryToFile dialog の起動確認

Closes #526
親: #516