### PR TITLE
perf(frontend): tsc を tsgo に置換し build を 53% 高速化 (#573)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -23,6 +23,7 @@
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@typescript/native-preview": "7.0.0-dev.20260421.2",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.0.18",
         "esbuild": "^0.28.0",
@@ -294,6 +295,22 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260421.2", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260421.2", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260421.2", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260421.2", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260421.2", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260421.2", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260421.2", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260421.2" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2", "", { "os": "linux", "cpu": "arm" }, "sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2", "", { "os": "linux", "cpu": "x64" }, "sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2", "", { "os": "win32", "cpu": "x64" }, "sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
-    "typecheck": "tsc --noEmit",
+    "build": "tsgo --noEmit && vite build",
+    "typecheck": "tsgo --noEmit",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
@@ -35,6 +35,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.0.18",
     "esbuild": "^0.28.0",


### PR DESCRIPTION
  ## Summary

  - `tsc --noEmit` を `tsgo --noEmit` (Microsoft TypeScript Native Port, `@typescript/native-preview`) に置換
  - `frontend/package.json` の `typecheck` / `build` script のみ変更、typescript 本体は残置
  - Y2 PoC 結果は #573 issuecomment-4438092164 を参照

  ## Performance (Docker bun:latest, 3 回中央値)

  | 操作 | tsc | tsgo | 短縮 |
  |---|---:|---:|---:|
  | typecheck (--noEmit) | 12,772 ms | 2,374 ms | **-81.4%** (5.38×) |
  | build (typecheck + vite) | 20,211 ms | 9,481 ms | **-53.1%** (2.13×) |

  vite 単体 ~6.3s は変化なし、tsc 部分が削減源。

  ## Compatibility

  - ✅ 1150 vitest tests / 109 files PASS
  - ✅ biome check (362 files) PASS
  - ✅ vite build 成果物ハッシュ tsc 版と同一 (`errorParser-lqRkXZ9B.js`)
  - ✅ 型エラー差分 0 件 (strict / noUnusedLocals / noUnusedParameters / paths `@/*` 動作)

  ## Version pinning

  - `@typescript/native-preview@7.0.0-dev.20260421.2` (beta tag, 2026-04-21) を完全固定
  - bun.lock に 7 platform binary の sha512 記録済
  - CI は `bun install --frozen-lockfile` で固定保証 (`ci.yml` / `test.yml` / `release.yml`)
  - `latest` tag は 1 年前 (2025-05-12) で古いため beta を採用

  ## Test plan

  - [x] Docker bun:latest で 3 回中央値計測 (本ブランチで実施済)
  - [x] frontend 1150 tests / lint / build PASS
  - [x] CI (GitHub Actions) 通過確認
  - [x] ローカル `uv run scripts/pdg.py build frontend` 動作確認 (Python ラッパー側は package.json script 経由なので無変更)

  ## Risk / Revert

  `@typescript/native-preview` は preview/alpha 表記の dev 日次ビルド。失敗時は package.json の `tsgo` を `tsc` に戻すだけで完全 revert
   (typescript 本体は残置)。

  Closes #573
  Refs #571