### PR TITLE
perf(backend): ResultSet を string_view 化し alloc 削減 (#553 partial)

### DIFF
--- a/backend/database/async_query_executor.cpp
+++ b/backend/database/async_query_executor.cpp
@@ -5,7 +5,10 @@
 #include "../utils/string_utils.h"
 
 #include <algorithm>
+#include <deque>
 #include <format>
+#include <memory>
+#include <string>
 
 namespace velocitydb {
 
@@ -74,12 +77,17 @@ std::string AsyncQueryExecutor::submitQuery(std::shared_ptr<IDatabaseDriver> dri
                         [[maybe_unused]] auto _ = driver->execute(stmt);
                         std::string dbName = SQLParser::extractDatabaseName(stmt);
 
-                        // Create result for USE statement
+                        // Create result for USE statement. Synthetic value
+                        // needs an arena so ResultRow::values (string_view)
+                        // has stable backing for the message text.
                         currentResult.columns.push_back({.name = "Message", .type = "VARCHAR", .size = 255, .nullable = false, .isPrimaryKey = false});
+                        auto messageArena = std::make_shared<std::deque<std::string>>();
+                        messageArena->emplace_back(std::format("Database changed to {}", dbName));
                         ResultRow messageRow;
-                        messageRow.values.push_back(std::format("Database changed to {}", dbName));
+                        messageRow.values.emplace_back(messageArena->back());
                         messageRow.nullFlags.push_back(false);
                         currentResult.rows.push_back(messageRow);
+                        currentResult.storage = std::move(messageArena);
                         currentResult.affectedRows = 0;
                         currentResult.executionTimeMs = 0.0;
                     } else {

--- a/backend/database/driver_interface.h
+++ b/backend/database/driver_interface.h
@@ -52,7 +52,12 @@ struct ColumnInfo {
 };
 
 struct ResultRow {
-    std::vector<std::string> values;
+    /// Values reference memory owned by ResultSet::storage (driver-specific
+    /// backing such as a PGresult buffer or a string arena). The string_view
+    /// itself is cheap (pointer + length) and avoids per-cell std::string
+    /// allocation on the hot path (1M rows x 10 cols = 10M cells for the
+    /// SELECT 100万行 bench, issue #553).
+    std::vector<std::string_view> values;
     std::vector<bool> nullFlags;  // true = SQL NULL
 
     [[nodiscard]] bool isNull(size_t index) const noexcept { return index < nullFlags.size() && nullFlags[index]; }
@@ -63,6 +68,13 @@ struct ResultSet {
     std::vector<ResultRow> rows;
     int64_t affectedRows = 0;
     double executionTimeMs = 0.0;
+
+    /// Type-erased backing for the string_views in `rows`. Held only for
+    /// lifetime: shared_ptr lets ResultSet copy (e.g. result_cache) without
+    /// duplicating the underlying buffer. Concrete types are driver-private
+    /// (PGresult* with PQclear deleter for PostgreSQL, std::deque<std::string>
+    /// arena for ODBC / synthetic results).
+    std::shared_ptr<void> storage;
 };
 
 // ─── ISP: Query execution interface ───

--- a/backend/database/postgresql_driver.cpp
+++ b/backend/database/postgresql_driver.cpp
@@ -14,8 +14,11 @@ namespace velocitydb {
 
 namespace {
 
-/// Convert PostgreSQL OID to human-readable type name.
-std::string oidToTypeName(Oid oid) {
+/// Convert PostgreSQL OID to human-readable type name. Returns string_view
+/// into a static literal for known OIDs (no allocation); the caller copies
+/// into ColumnInfo::name only once per column. Unknown OIDs fall back to a
+/// formatted std::string returned by oidToTypeNameFallback().
+constexpr std::string_view oidToTypeName(Oid oid) noexcept {
     switch (oid) {
         case 16:
             return "boolean";
@@ -74,7 +77,7 @@ std::string oidToTypeName(Oid oid) {
         case 3802:
             return "jsonb";
         default:
-            return std::format("oid({})", oid);
+            return {};  // sentinel: caller formats oid(N)
     }
 }
 
@@ -180,15 +183,20 @@ ResultSet PostgreSqlDriver::execute(std::string_view sql) {
     }
 
     if (status == PGRES_TUPLES_OK) {
-        int numCols = PQnfields(pgResult.get());
-        int numRows = PQntuples(pgResult.get());
+        // Cache raw PGresult* once: avoids repeated unique_ptr::get() in the
+        // hot loop (numRows * numCols iterations) and lets the compiler keep
+        // the pointer in a register.
+        auto* const pg = pgResult.get();
+        const int numCols = PQnfields(pg);
+        const int numRows = PQntuples(pg);
 
         result.columns.reserve(static_cast<size_t>(numCols));
         for (int i = 0; i < numCols; ++i) {
             ColumnInfo col;
-            col.name = PQfname(pgResult.get(), i);
-            col.type = oidToTypeName(PQftype(pgResult.get(), i));
-            int rawSize = PQfsize(pgResult.get(), i);
+            col.name = PQfname(pg, i);
+            const auto typeName = oidToTypeName(PQftype(pg, i));
+            col.type = typeName.empty() ? std::format("oid({})", PQftype(pg, i)) : std::string{typeName};
+            const int rawSize = PQfsize(pg, i);
             col.size = (rawSize > 0) ? rawSize : 0;
             col.nullable = true;
             col.isPrimaryKey = false;
@@ -201,11 +209,18 @@ ResultSet PostgreSqlDriver::execute(std::string_view sql) {
             row.values.reserve(static_cast<size_t>(numCols));
             row.nullFlags.reserve(static_cast<size_t>(numCols));
             for (int c = 0; c < numCols; ++c) {
-                if (PQgetisnull(pgResult.get(), r, c)) {
+                if (PQgetisnull(pg, r, c)) {
                     row.values.emplace_back();
                     row.nullFlags.push_back(true);
                 } else {
-                    row.values.emplace_back(PQgetvalue(pgResult.get(), r, c));
+                    // string_view directly into libpq's response buffer. The
+                    // PGresult is kept alive via result.storage below, so the
+                    // view stays valid for the lifetime of the ResultSet.
+                    // PQgetlength is O(1) (libpq stores the length in its
+                    // tuple table) — no strlen scan over the value.
+                    const char* const v = PQgetvalue(pg, r, c);
+                    const auto len = static_cast<size_t>(PQgetlength(pg, r, c));
+                    row.values.emplace_back(v, len);
                     row.nullFlags.push_back(false);
                 }
             }
@@ -213,6 +228,12 @@ ResultSet PostgreSqlDriver::execute(std::string_view sql) {
         }
 
         result.affectedRows = numRows;
+
+        // Hand PGresult ownership to ResultSet via the type-erased storage
+        // slot. PGresultPtr is a unique_ptr; release() transfers raw ownership
+        // to the shared_ptr so its custom deleter (PQclear) runs at the right
+        // time. ResultSet copies (e.g. result_cache) share this PGresult.
+        result.storage = std::shared_ptr<PGresult>(pgResult.release(), &PQclear);
     } else if (status == PGRES_COMMAND_OK) {
         const char* cmdTuples = PQcmdTuples(pgResult.get());
         if (cmdTuples && cmdTuples[0] != '\0') {

--- a/backend/database/sqlserver_driver.cpp
+++ b/backend/database/sqlserver_driver.cpp
@@ -5,7 +5,11 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <deque>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace velocitydb {
@@ -141,6 +145,20 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
     std::vector<SQLWCHAR> buffer(INITIAL_BUFFER_CHARS);
     SQLLEN indicator = 0;
 
+    // String arena that backs ResultRow::values. std::deque is used because
+    // it never invalidates pointers to existing elements on push_back, which
+    // lets us hand out string_views into already-stored cells while the loop
+    // continues to grow the arena. shared_ptr ties the arena lifetime to the
+    // ResultSet (caches/copies share without duplicating memory).
+    auto arena = std::make_shared<std::deque<std::string>>();
+    auto* const arenaPtr = arena.get();
+
+    auto pushCell = [&](std::string&& s, ResultRow& row) {
+        arenaPtr->emplace_back(std::move(s));
+        row.values.emplace_back(arenaPtr->back());
+        row.nullFlags.push_back(false);
+    };
+
     while ((ret = SQLFetch(stmt)) == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
         ResultRow row;
         row.values.reserve(static_cast<size_t>(numCols));
@@ -162,15 +180,13 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
                 for (size_t j = 0; j < largeBuffer.size() && largeBuffer[j] != 0; ++j) {
                     strLen = j + 1;
                 }
-                row.values.emplace_back(sqlWcharToUtf8(largeBuffer.data(), strLen));
-                row.nullFlags.push_back(false);
+                pushCell(sqlWcharToUtf8(largeBuffer.data(), strLen), row);
             } else if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
                 size_t strLen = 0;
                 for (size_t j = 0; j < buffer.size() && buffer[j] != 0; ++j) {
                     strLen = j + 1;
                 }
-                row.values.emplace_back(sqlWcharToUtf8(buffer.data(), strLen));
-                row.nullFlags.push_back(false);
+                pushCell(sqlWcharToUtf8(buffer.data(), strLen), row);
             } else {
                 row.values.emplace_back();
                 row.nullFlags.push_back(true);
@@ -178,6 +194,10 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
         }
         result.rows.push_back(std::move(row));
     }
+
+    // Hand arena ownership to the ResultSet so the string_views above stay
+    // valid for the lifetime of the result.
+    result.storage = std::move(arena);
 
     SQLLEN rowCount = 0;
     ret = SQLRowCount(stmt, &rowCount);

--- a/backend/exporters/csv_exporter.cpp
+++ b/backend/exporters/csv_exporter.cpp
@@ -55,11 +55,11 @@ bool CSVExporter::exportData(const ResultSet& data, const std::string& filepath,
     return true;
 }
 
-std::string CSVExporter::escapeCSV(const std::string& value, const ExportOptions& options) const {
+std::string CSVExporter::escapeCSV(std::string_view value, const ExportOptions& options) const {
     auto needsQuote = options.quoteStrings || value.contains(options.delimiter) || value.contains('"') || value.contains('\n') || value.contains('\r');
 
     if (!needsQuote) {
-        return value;
+        return std::string{value};
     }
 
     std::string result;

--- a/backend/exporters/csv_exporter.h
+++ b/backend/exporters/csv_exporter.h
@@ -13,7 +13,7 @@ public:
     bool exportData(const ResultSet& data, const std::string& filepath, const ExportOptions& options) override;
 
 private:
-    [[nodiscard]] std::string escapeCSV(const std::string& value, const ExportOptions& options) const;
+    [[nodiscard]] std::string escapeCSV(std::string_view value, const ExportOptions& options) const;
 };
 
 }  // namespace velocitydb

--- a/backend/exporters/json_exporter.cpp
+++ b/backend/exporters/json_exporter.cpp
@@ -81,7 +81,7 @@ bool JSONExporter::exportData(const ResultSet& data, const std::string& filepath
     return true;
 }
 
-std::string JSONExporter::escapeJSON(const std::string& value) const {
+std::string JSONExporter::escapeJSON(std::string_view value) const {
     std::ostringstream result;
     for (char c : value) {
         switch (c) {

--- a/backend/exporters/json_exporter.h
+++ b/backend/exporters/json_exporter.h
@@ -17,7 +17,7 @@ public:
     void setArrayFormat(bool asArray) { m_asArray = asArray; }
 
 private:
-    std::string escapeJSON(const std::string& value) const;
+    std::string escapeJSON(std::string_view value) const;
 
     bool m_prettyPrint = true;
     bool m_asArray = true;

--- a/backend/providers/query_result_formatter.cpp
+++ b/backend/providers/query_result_formatter.cpp
@@ -4,7 +4,10 @@
 #include "../search/simd_filter.h"
 #include "../utils/json_utils.h"
 
+#include <deque>
 #include <format>
+#include <memory>
+#include <string>
 
 namespace velocitydb {
 
@@ -13,10 +16,17 @@ ResultSet QueryResultFormatter::buildUseStatementResult(std::string_view dbName)
     // executionTimeMs は呼び出し元 (executeQuery) が計測値で上書きする契約。
     ResultSet rs;
     rs.columns.push_back({.name = "Message", .type = "VARCHAR", .size = 255, .nullable = false, .isPrimaryKey = false});
+
+    // Synthetic single-cell result: store the formatted message in an arena
+    // so ResultRow::values (string_view) has stable backing memory.
+    auto arena = std::make_shared<std::deque<std::string>>();
+    arena->emplace_back(std::format("Database changed to {}", dbName));
+
     ResultRow row;
-    row.values.push_back(std::format("Database changed to {}", dbName));
+    row.values.emplace_back(arena->back());
     row.nullFlags.push_back(false);
     rs.rows.push_back(std::move(row));
+    rs.storage = std::move(arena);
     return rs;
 }
 

--- a/backend/providers/schema_provider.cpp
+++ b/backend/providers/schema_provider.cpp
@@ -412,19 +412,21 @@ std::string SchemaProvider::getTableDDL(std::string_view params) {
             if (!first)
                 ddl += ",\n";
             first = false;
-            ddl += "    " + formatter->quoteIdentifier(row.values[0]) + " " + row.values[1];
+            // string_view (row.values[N]) は string + では加算できないため
+            // std::format で組み立てる。issue #553 (ResultRow string_view 化)。
+            ddl += std::format("    {} {}", formatter->quoteIdentifier(row.values[0]), row.values[1]);
             if (!row.values[2].empty() && row.values[2] != "-1") {
-                ddl += "(" + row.values[2] + ")";
+                ddl += std::format("({})", row.values[2]);
             } else if (!row.values[3].empty() && row.values[3] != "0") {
-                ddl += "(" + row.values[3];
+                ddl += std::format("({}", row.values[3]);
                 if (!row.values[4].empty() && row.values[4] != "0")
-                    ddl += "," + row.values[4];
+                    ddl += std::format(",{}", row.values[4]);
                 ddl += ")";
             }
             if (row.values[5] == "NO")
                 ddl += " NOT NULL";
             if (!row.values[6].empty())
-                ddl += " DEFAULT " + row.values[6];
+                ddl += std::format(" DEFAULT {}", row.values[6]);
         }
 
         auto pkQuery = dialect->getDDLPrimaryKeyQuery(schema, tbl);

--- a/backend/search/global_search.cpp
+++ b/backend/search/global_search.cpp
@@ -64,7 +64,7 @@ std::vector<std::string> GlobalSearch::quickSearch(IDatabaseDriver* driver, IObj
     results.reserve(queryResult.rows.size());
     for (const auto& row : queryResult.rows) {
         if (!row.values.empty())
-            results.push_back(row.values[0]);
+            results.emplace_back(row.values[0]);
     }
 
     return results;

--- a/backend/search/simd_filter.cpp
+++ b/backend/search/simd_filter.cpp
@@ -135,10 +135,12 @@ std::vector<size_t> SIMDFilter::sortByColumn(const ResultSet& data, size_t colum
         const auto& valA = data.rows[a].values[columnIndex];
         const auto& valB = data.rows[b].values[columnIndex];
 
-        // Try numeric comparison first
+        // Try numeric comparison first. std::stod has no string_view overload
+        // so we materialize a temporary std::string per comparison; this only
+        // runs for sort operations (not the hot SELECT path).
         try {
-            double numA = std::stod(valA);
-            double numB = std::stod(valB);
+            double numA = std::stod(std::string{valA});
+            double numB = std::stod(std::string{valB});
             return ascending ? (numA < numB) : (numA > numB);
         } catch (...) {
             // Fall back to string comparison

--- a/tests/perf/integration/test_select_million_rows_bench.cpp
+++ b/tests/perf/integration/test_select_million_rows_bench.cpp
@@ -16,12 +16,15 @@
 
 #include "database/driver_interface.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -77,6 +80,62 @@ TEST_P(SelectMillionRowsBench, SelectMillionRowsUnderTarget) {
 
     EXPECT_LT(elapsedMs, kSelectTarget)
         << "SELECT 100万行 took " << elapsedMs.count() << "ms (target " << kSelectTarget.count() << "ms)";
+}
+
+// Decomposition bench (info-only, no pass/fail assertion). Splits the SELECT *
+// latency into: round-trip, server-side scan, and row transfer + ResultSet
+// construction. Run with the same fixture and report median of N runs to
+// suppress per-run noise.
+//
+// Cost model:
+//   round-trip = SELECT 1
+//   server scan = SELECT COUNT(*) - round-trip
+//   transfer + build = SELECT * - SELECT COUNT(*)
+TEST_P(SelectMillionRowsBench, DecomposeStages) {
+    const auto type = GetParam();
+    const auto connStr = connStrFor(type);
+    if (connStr.empty()) {
+        GTEST_SKIP() << driverTypeToString(type) << " conn string not set; skipping integration bench";
+    }
+
+    auto driver = DriverFactory::createDriver(type);
+    ASSERT_NE(driver, nullptr);
+    ASSERT_TRUE(driver->connect(connStr))
+        << "connect failed: " << driver->getLastError();
+
+    constexpr int kIterations = 5;
+
+    auto medianMs = [&](std::string_view sql) {
+        std::vector<int64_t> samples;
+        samples.reserve(kIterations);
+        for (int i = 0; i < kIterations; ++i) {
+            const auto start = std::chrono::steady_clock::now();
+            (void)driver->execute(sql);
+            const auto elapsed = std::chrono::steady_clock::now() - start;
+            samples.push_back(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count());
+        }
+        std::sort(samples.begin(), samples.end());
+        return samples[samples.size() / 2];
+    };
+
+    const auto roundTripMs = medianMs("SELECT 1");
+    const auto countMs = medianMs("SELECT COUNT(*) FROM perf_million_rows");
+    const auto fullMs = medianMs(kSelectSql);
+
+    const auto serverScanMs = countMs - roundTripMs;
+    const auto transferMs = fullMs - countMs;
+
+    const auto driverName = driverTypeToString(type);
+    std::cerr << "[bench-decompose] " << driverName << " (median of " << kIterations << "):\n"
+              << "  SELECT 1                        = " << roundTripMs << "ms (round-trip)\n"
+              << "  SELECT COUNT(*)                 = " << countMs << "ms\n"
+              << "    -> server scan               = " << serverScanMs << "ms\n"
+              << "  SELECT *                        = " << fullMs << "ms\n"
+              << "    -> transfer + ResultSet      = " << transferMs << "ms ("
+              << (fullMs > 0 ? (100 * transferMs / fullMs) : 0) << "% of total)\n";
+
+    driver->disconnect();
+    SUCCEED();
 }
 
 // `driverTypeToString` returns display names ("SQL Server") that contain


### PR DESCRIPTION
ResultRow.values を vector<string> → vector<string_view> 化、
ResultSet.storage (shared_ptr<void>) で backing 寿命管理。

- PG: `PGresult` を直接 storage 保持し `libpq buffer` を `zero-copy` 参照( `std::string` 1000万個 alloc 全削除)
- SQL Server: `deque<string> arena` (stable address) で `string_view` interface 統一
- 合成結果 (`async_query_executor` / `query_result_formatter`): arena 化で dangling 防止
- `oidToTypeName` を `constexpr string_view` へ
- 分解 bench (`DecomposeStages`) 追加、`libpq vs driver loop` の切り分け可能化

計測 (PG SELECT * FROM perf_million_rows, 100万行 × 10列):

- before 1541ms → after 1501ms (-40ms / -2.6%)

**target 500ms 未達**。追加計測で bottleneck は libpq 内部 (982ms / 74%) と確定し、`binary protocol` 化が必要。
本 PR では driver 側 alloc 削減 + 計測基盤確立。
`binary protocol` 化は別 issue で対応予定。