### PR TITLE
feat(pg): add binary protocol decoder library (#579 part 1/2)

### DIFF
--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -24,6 +24,7 @@ set(LIB_SOURCES
     database/sqlserver_dialect.cpp
     database/postgresql_driver.cpp
     database/postgresql_dialect.cpp
+    database/pg_binary_decoder.cpp
     database/copy_from_stdin_handler.cpp
     database/psql_subprocess.cpp
     database/driver_factory.cpp
@@ -98,6 +99,9 @@ set(HEADERS
     database/copy_from_stdin_handler.h
     database/psql_subprocess.h
     database/pg_result_ptr.h
+    database/pg_result_bundle.h
+    database/pg_endian.h
+    database/pg_binary_decoder.h
     database/connection_registry.h
     database/result_cache.h
     database/async_query_executor.h

--- a/backend/database/pg_binary_decoder.cpp
+++ b/backend/database/pg_binary_decoder.cpp
@@ -1,0 +1,400 @@
+#include "pg_binary_decoder.h"
+
+#include "pg_endian.h"
+
+#include <array>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <format>
+#include <stdexcept>
+
+namespace velocitydb::pg_binary {
+
+namespace {
+
+// PostgreSQL OID literals — taken from src/include/catalog/pg_type.dat
+constexpr Oid kOidBool = 16;
+constexpr Oid kOidBytea = 17;
+constexpr Oid kOidInt8 = 20;
+constexpr Oid kOidInt2 = 21;
+constexpr Oid kOidInt4 = 23;
+constexpr Oid kOidText = 25;
+constexpr Oid kOidJson = 114;
+constexpr Oid kOidFloat4 = 700;
+constexpr Oid kOidFloat8 = 701;
+constexpr Oid kOidBpchar = 1042;
+constexpr Oid kOidVarchar = 1043;
+constexpr Oid kOidDate = 1082;
+constexpr Oid kOidTime = 1083;
+constexpr Oid kOidTimestamp = 1114;
+constexpr Oid kOidTimestamptz = 1184;
+constexpr Oid kOidInterval = 1186;
+constexpr Oid kOidNumeric = 1700;
+constexpr Oid kOidUuid = 2950;
+constexpr Oid kOidJsonb = 3802;
+
+[[nodiscard]] bool isPassthroughOid(Oid oid) noexcept {
+    switch (oid) {
+        case kOidText:
+        case kOidVarchar:
+        case kOidBpchar:
+        case kOidBytea:
+        case kOidJson:
+            return true;
+        default:
+            return false;
+    }
+}
+
+// ─── Integer / boolean ────────────────────────────────────────────────────
+
+std::string formatInt64(int64_t v) {
+    std::array<char, 32> buf{};
+    auto [end, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), v);
+    return std::string(buf.data(), end);
+}
+
+// ─── Float ────────────────────────────────────────────────────────────────
+
+template <typename T>
+std::string formatFloat(T v) {
+    std::array<char, 64> buf{};
+    // std::to_chars handles NaN/Inf and never exhausts a 64-byte buffer for
+    // double/float, so the std::errc path is unreachable in practice.
+    auto [end, ec] = std::to_chars(buf.data(), buf.data() + buf.size(), v);
+    return std::string(buf.data(), end);
+}
+
+// ─── Numeric ──────────────────────────────────────────────────────────────
+// Wire layout (PostgreSQL src/backend/utils/adt/numeric.c, numeric_send):
+//   int16 ndigits   // count of base-10000 digits
+//   int16 weight    // weight of first digit in base-10000 places (signed)
+//   int16 sign      // 0x0000 + / 0x4000 - / 0xC000 NaN / 0xD000 +Inf / 0xF000 -Inf
+//   int16 dscale    // number of decimal digits after the point
+//   int16 digits[ndigits]
+
+std::string formatNumeric(const char* data, int len) {
+    if (len < 8)
+        throw std::runtime_error("pg_binary: numeric payload truncated (header)");
+    const int ndigits = pg_endian::loadBE16(data);
+    const int weight = pg_endian::loadBE16(data + 2);
+    const auto signRaw = static_cast<uint16_t>(pg_endian::loadBE16(data + 4));
+    const int dscale = pg_endian::loadBE16(data + 6);
+
+    if (signRaw == 0xC000U)
+        return std::string("NaN");
+    if (signRaw == 0xD000U)
+        return std::string("Infinity");
+    if (signRaw == 0xF000U)
+        return std::string("-Infinity");
+
+    if (ndigits == 0) {
+        // Special case: literal zero. dscale may still request fractional digits.
+        if (dscale <= 0)
+            return std::string("0");
+        std::string out("0.");
+        out.append(static_cast<size_t>(dscale), '0');
+        return out;
+    }
+
+    std::string out;
+    out.reserve(static_cast<size_t>(ndigits) * 4 + static_cast<size_t>(dscale) + 4);
+    if (signRaw == 0x4000U)
+        out.push_back('-');
+
+    int digitIdx = 0;
+    if (weight < 0) {
+        out.push_back('0');
+    } else {
+        // First base-10000 digit is emitted without leading zeros.
+        const int firstDigit = digitIdx < ndigits ? pg_endian::loadBE16(data + 8 + digitIdx * 2) : 0;
+        out += std::to_string(firstDigit);
+        ++digitIdx;
+        for (int i = 1; i <= weight; ++i, ++digitIdx) {
+            const int v = digitIdx < ndigits ? pg_endian::loadBE16(data + 8 + digitIdx * 2) : 0;
+            std::array<char, 5> buf{};
+            // Each base-10000 digit is in [0, 9999] per PG numeric_send.
+            std::format_to_n(buf.data(), 4, "{:04}", v);
+            out.append(buf.data(), 4);
+        }
+    }
+
+    if (dscale > 0) {
+        out.push_back('.');
+        int written = 0;
+        while (written < dscale) {
+            const int v = digitIdx < ndigits ? pg_endian::loadBE16(data + 8 + digitIdx * 2) : 0;
+            std::array<char, 5> buf{};
+            // Each base-10000 digit is in [0, 9999] per PG numeric_send.
+            std::format_to_n(buf.data(), 4, "{:04}", v);
+            const int take = std::min(4, dscale - written);
+            out.append(buf.data(), static_cast<size_t>(take));
+            written += take;
+            ++digitIdx;
+        }
+    }
+    return out;
+}
+
+// ─── Date / time / timestamp ─────────────────────────────────────────────
+// PostgreSQL temporal binary representation assumes integer_datetimes (forced
+// on since 10.0 — float datetimes build is gone). All values are int64 µs (or
+// int32 days for date) since 2000-01-01 00:00:00 UTC.
+
+constexpr int64_t kPgEpochUnixSec = 946684800LL;  // 2000-01-01 UTC in unix seconds
+constexpr int kPgEpochUnixDays = 10957;           // (kPgEpochUnixSec / 86400)
+constexpr int64_t kUsPerSec = 1'000'000LL;
+constexpr int64_t kSecPerDay = 86400LL;
+
+struct YearMonthDay {
+    int year;
+    unsigned month;
+    unsigned day;
+};
+
+[[nodiscard]] YearMonthDay daysToYmd(int64_t unixDays) noexcept {
+    using namespace std::chrono;
+    const sys_days sd{days{unixDays}};
+    const year_month_day ymd{sd};
+    return {static_cast<int>(static_cast<int>(ymd.year())), static_cast<unsigned>(ymd.month()), static_cast<unsigned>(ymd.day())};
+}
+
+std::string formatDate(const char* data, int len) {
+    if (len < 4)
+        throw std::runtime_error("pg_binary: date payload truncated");
+    const int32_t daysSincePgEpoch = pg_endian::loadBE32(data);
+    const int64_t unixDays = static_cast<int64_t>(daysSincePgEpoch) + kPgEpochUnixDays;
+    const auto ymd = daysToYmd(unixDays);
+    return std::format("{:04}-{:02}-{:02}", ymd.year, ymd.month, ymd.day);
+}
+
+std::string formatTime(const char* data, int len) {
+    if (len < 8)
+        throw std::runtime_error("pg_binary: time payload truncated");
+    // PG time (OID 1083) is microseconds within [0, 86400000000); negative or
+    // 24h-over values are protocol violations and not validated here.
+    const int64_t us = pg_endian::loadBE64(data);
+    const int64_t totalSec = us / kUsPerSec;
+    const int64_t fracUs = us - totalSec * kUsPerSec;
+    const int h = static_cast<int>(totalSec / 3600);
+    const int m = static_cast<int>((totalSec / 60) % 60);
+    const int s = static_cast<int>(totalSec % 60);
+    return std::format("{:02}:{:02}:{:02}.{:06}", h, m, s, fracUs);
+}
+
+std::string formatTimestamp(const char* data, int len, bool withTz) {
+    if (len < 8)
+        throw std::runtime_error("pg_binary: timestamp payload truncated");
+    const int64_t usSincePgEpoch = pg_endian::loadBE64(data);
+
+    // Floor-divide microseconds into (seconds, remainder_us) to keep the
+    // remainder non-negative even for pre-epoch values.
+    int64_t sec = usSincePgEpoch / kUsPerSec;
+    int64_t fracUs = usSincePgEpoch - sec * kUsPerSec;
+    if (fracUs < 0) {
+        fracUs += kUsPerSec;
+        sec -= 1;
+    }
+
+    const int64_t unixSec = kPgEpochUnixSec + sec;
+    int64_t unixDays = unixSec / kSecPerDay;
+    int64_t timeInDay = unixSec - unixDays * kSecPerDay;
+    if (timeInDay < 0) {
+        timeInDay += kSecPerDay;
+        unixDays -= 1;
+    }
+
+    const auto ymd = daysToYmd(unixDays);
+    const int h = static_cast<int>(timeInDay / 3600);
+    const int m = static_cast<int>((timeInDay / 60) % 60);
+    const int s = static_cast<int>(timeInDay % 60);
+    return std::format("{:04}-{:02}-{:02} {:02}:{:02}:{:02}.{:06}{}", ymd.year, ymd.month, ymd.day, h, m, s, fracUs, withTz ? "+00" : "");
+}
+
+// ─── Interval ─────────────────────────────────────────────────────────────
+// Wire layout (src/backend/utils/adt/timestamp.c, interval_send):
+//   int64 time   (microseconds within day)
+//   int32 day
+//   int32 month
+
+std::string formatInterval(const char* data, int len) {
+    if (len < 16)
+        throw std::runtime_error("pg_binary: interval payload truncated");
+    const int64_t timeUs = pg_endian::loadBE64(data);
+    const int32_t day = pg_endian::loadBE32(data + 8);
+    const int32_t month = pg_endian::loadBE32(data + 12);
+
+    int64_t sec = timeUs / kUsPerSec;
+    int64_t fracUs = timeUs - sec * kUsPerSec;
+    bool neg = false;
+    if (sec < 0 || (sec == 0 && fracUs < 0)) {
+        neg = true;
+        sec = -sec;
+        if (fracUs < 0) {
+            fracUs = -fracUs;
+        }
+    }
+    const int h = static_cast<int>(sec / 3600);
+    const int m = static_cast<int>((sec / 60) % 60);
+    const int s = static_cast<int>(sec % 60);
+
+    // PostgreSQL EncodeInterval pluralizes mon/mons and day/days (postgres
+    // src/backend/utils/adt/datetime.c).
+    auto pluralize = [](int32_t v, const char* singular, const char* plural) { return (v == 1 || v == -1) ? singular : plural; };
+
+    std::string out;
+    out.reserve(64);
+    if (month != 0)
+        out += std::format("{} {}", month, pluralize(month, "mon", "mons"));
+    if (day != 0) {
+        if (!out.empty())
+            out.push_back(' ');
+        out += std::format("{} {}", day, pluralize(day, "day", "days"));
+    }
+    if (timeUs != 0 || out.empty()) {
+        if (!out.empty())
+            out.push_back(' ');
+        if (neg)
+            out.push_back('-');
+        out += std::format("{:02}:{:02}:{:02}.{:06}", h, m, s, fracUs);
+    }
+    return out;
+}
+
+// ─── UUID ─────────────────────────────────────────────────────────────────
+// Wire layout: 16 raw bytes, printed as 8-4-4-4-12 lowercase hex.
+
+std::string formatUuid(const char* data, int len) {
+    if (len < 16)
+        throw std::runtime_error("pg_binary: uuid payload truncated");
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::string out(36, '-');
+    static constexpr int kDashAt[] = {8, 13, 18, 23};
+    int dashIdx = 0;
+    int outPos = 0;
+    for (int i = 0; i < 16; ++i) {
+        if (dashIdx < 4 && outPos == kDashAt[dashIdx]) {
+            ++outPos;
+            ++dashIdx;
+        }
+        const auto b = static_cast<uint8_t>(data[i]);
+        out[outPos++] = kHex[(b >> 4) & 0xF];
+        out[outPos++] = kHex[b & 0xF];
+        if (dashIdx < 4 && outPos == kDashAt[dashIdx]) {
+            ++outPos;
+            ++dashIdx;
+        }
+    }
+    return out;
+}
+
+}  // namespace
+
+bool isBinarySupported(Oid oid) noexcept {
+    switch (oid) {
+        case kOidBool:
+        case kOidBytea:
+        case kOidInt8:
+        case kOidInt2:
+        case kOidInt4:
+        case kOidText:
+        case kOidJson:
+        case kOidFloat4:
+        case kOidFloat8:
+        case kOidBpchar:
+        case kOidVarchar:
+        case kOidDate:
+        case kOidTime:
+        case kOidTimestamp:
+        case kOidTimestamptz:
+        case kOidInterval:
+        case kOidNumeric:
+        case kOidUuid:
+        case kOidJsonb:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::optional<std::vector<ColumnPlan>> planColumns(PGresult* pg) noexcept {
+    if (!pg)
+        return std::nullopt;
+    const int n = PQnfields(pg);
+    std::vector<ColumnPlan> plan;
+    plan.reserve(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i) {
+        const Oid oid = PQftype(pg, i);
+        if (!isBinarySupported(oid))
+            return std::nullopt;
+        const DecodeKind kind = isPassthroughOid(oid) ? DecodeKind::Passthrough : DecodeKind::Decode;
+        plan.push_back({kind, oid});
+    }
+    return plan;
+}
+
+std::string_view decodeCell(Oid oid, const char* data, int len, std::deque<std::string>& arena) {
+    if (isPassthroughOid(oid)) {
+        // Wire bytes already form a valid UTF-8 / opaque-byte payload.
+        return std::string_view{data, static_cast<size_t>(len < 0 ? 0 : len)};
+    }
+
+    std::string formatted;
+    switch (oid) {
+        case kOidBool:
+            // 1 byte: 0x01 → "t", 0x00 → "f". PG accepts t/f for input.
+            return (len >= 1 && data[0] != 0) ? std::string_view{"t", 1} : std::string_view{"f", 1};
+        case kOidInt2:
+            formatted = formatInt64(len >= 2 ? pg_endian::loadBE16(data) : 0);
+            break;
+        case kOidInt4:
+            formatted = formatInt64(len >= 4 ? pg_endian::loadBE32(data) : 0);
+            break;
+        case kOidInt8:
+            formatted = formatInt64(len >= 8 ? pg_endian::loadBE64(data) : 0);
+            break;
+        case kOidFloat4:
+            formatted = formatFloat(len >= 4 ? pg_endian::loadBEf32(data) : 0.0f);
+            break;
+        case kOidFloat8:
+            formatted = formatFloat(len >= 8 ? pg_endian::loadBEf64(data) : 0.0);
+            break;
+        case kOidNumeric:
+            formatted = formatNumeric(data, len);
+            break;
+        case kOidDate:
+            formatted = formatDate(data, len);
+            break;
+        case kOidTime:
+            formatted = formatTime(data, len);
+            break;
+        case kOidTimestamp:
+            formatted = formatTimestamp(data, len, /*withTz=*/false);
+            break;
+        case kOidTimestamptz:
+            formatted = formatTimestamp(data, len, /*withTz=*/true);
+            break;
+        case kOidInterval:
+            formatted = formatInterval(data, len);
+            break;
+        case kOidUuid:
+            formatted = formatUuid(data, len);
+            break;
+        case kOidJsonb: {
+            // First byte is version (must be 1 per PostgreSQL docs); strip it.
+            const int payloadLen = len > 1 ? len - 1 : 0;
+            formatted.assign(data + 1, static_cast<size_t>(payloadLen));
+            break;
+        }
+        default:
+            // Caller is responsible for filtering via planColumns() — reaching
+            // here means a contract violation upstream.
+            throw std::runtime_error("pg_binary::decodeCell: unsupported OID");
+    }
+
+    arena.emplace_back(std::move(formatted));
+    return std::string_view{arena.back()};
+}
+
+}  // namespace velocitydb::pg_binary

--- a/backend/database/pg_binary_decoder.h
+++ b/backend/database/pg_binary_decoder.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <libpq-fe.h>
+
+#include <cstdint>
+#include <deque>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace velocitydb::pg_binary {
+
+/// Per-column dispatch hint produced once before the row loop.
+enum class DecodeKind : uint8_t {
+    Passthrough,  ///< Wire bytes are a valid UTF-8 / opaque-byte representation; alias directly.
+    Decode,       ///< Requires per-cell decode; output is written into the arena.
+};
+
+struct ColumnPlan {
+    DecodeKind kind;
+    Oid oid;
+};
+
+/// Build a per-column dispatch plan from the PGresult's RowDescription. Returns
+/// std::nullopt if any column's OID is unsupported by the binary decoder
+/// (caller is expected to discard the binary PGresult and re-execute the query
+/// in text protocol mode as a fallback).
+[[nodiscard]] std::optional<std::vector<ColumnPlan>> planColumns(PGresult* pg) noexcept;
+
+/// Decode one binary cell into a string_view. For Passthrough types the
+/// returned view aliases the input pointer directly (no arena write). For
+/// Decode types the formatted text is emplaced into `arena` and the returned
+/// view references that arena entry (stable for the lifetime of the bundle).
+///
+/// Caller invariants:
+///   * `oid` must equal the plan entry produced for this column
+///   * `len` must be the libpq-reported length (PQgetlength); NULL handling is
+///     done by the caller via PQgetisnull
+[[nodiscard]] std::string_view decodeCell(Oid oid, const char* data, int len, std::deque<std::string>& arena);
+
+/// True if this OID has a binary decoder. Exposed for use in fallback judgment
+/// when the caller has only OIDs (not a full RowDescription) in hand.
+[[nodiscard]] bool isBinarySupported(Oid oid) noexcept;
+
+}  // namespace velocitydb::pg_binary

--- a/backend/database/pg_endian.h
+++ b/backend/database/pg_endian.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <bit>
+#include <cstdint>
+#include <cstring>
+
+namespace velocitydb::pg_endian {
+
+// libpq binary wire format is network byte order (big-endian). All multi-byte
+// numeric / temporal fields arrive as raw BE bytes in PGresult buffers. Loaders
+// memcpy the bytes (raw pointer may be unaligned on some platforms) and then
+// byteswap if the host is little-endian. The byteswap is constexpr and lowers
+// to a single `bswap` / `mov` instruction on x86-64.
+
+namespace detail {
+
+template <typename T>
+[[nodiscard]] inline T loadBE(const char* p) noexcept {
+    static_assert(std::is_trivially_copyable_v<T>);
+    T v{};
+    std::memcpy(&v, p, sizeof(T));
+    if constexpr (std::endian::native == std::endian::little) {
+        v = std::byteswap(v);
+    }
+    return v;
+}
+
+}  // namespace detail
+
+[[nodiscard]] inline int16_t loadBE16(const char* p) noexcept {
+    return static_cast<int16_t>(detail::loadBE<uint16_t>(p));
+}
+
+[[nodiscard]] inline int32_t loadBE32(const char* p) noexcept {
+    return static_cast<int32_t>(detail::loadBE<uint32_t>(p));
+}
+
+[[nodiscard]] inline int64_t loadBE64(const char* p) noexcept {
+    return static_cast<int64_t>(detail::loadBE<uint64_t>(p));
+}
+
+[[nodiscard]] inline float loadBEf32(const char* p) noexcept {
+    return std::bit_cast<float>(detail::loadBE<uint32_t>(p));
+}
+
+[[nodiscard]] inline double loadBEf64(const char* p) noexcept {
+    return std::bit_cast<double>(detail::loadBE<uint64_t>(p));
+}
+
+}  // namespace velocitydb::pg_endian

--- a/backend/database/pg_result_bundle.h
+++ b/backend/database/pg_result_bundle.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "pg_result_ptr.h"
+
+#include <deque>
+#include <string>
+
+namespace velocitydb {
+
+/// Storage backing for a binary-protocol PostgreSQL ResultSet.
+///
+/// `result` owns the PGresult (PQclear via PGresultDeleter). Text-shaped types
+/// (text / varchar / bpchar / bytea / json / uuid 系列) are surfaced as
+/// string_view directly into the PGresult buffer (zero-copy).
+///
+/// `arena` holds formatted strings for types whose binary on-wire layout differs
+/// from the displayed text (numerics, timestamps, etc.). std::deque is required
+/// because emplace_back preserves pointer/reference stability of existing
+/// elements — std::vector would relocate on growth and invalidate every
+/// string_view captured into prior ResultRows (issue #579).
+struct PgResultBundle {
+    PGresultPtr result;
+    std::deque<std::string> arena;
+};
+
+}  // namespace velocitydb

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ set(TEST_SOURCES
     parsers/test_sql_linter.cpp
     parsers/test_sql_parser.cpp
     database/test_postgresql_driver.cpp
+    database/test_pg_binary_decoder.cpp
     database/test_psql_subprocess.cpp
     exporters/test_csv_exporter.cpp
     providers/test_lint_provider.cpp

--- a/tests/database/test_pg_binary_decoder.cpp
+++ b/tests/database/test_pg_binary_decoder.cpp
@@ -1,0 +1,437 @@
+#include <gtest/gtest.h>
+
+#include "database/pg_binary_decoder.h"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <string>
+#include <string_view>
+
+namespace velocitydb::pg_binary::test {
+
+namespace {
+
+// PostgreSQL binary wire format is network byte order (big-endian). Helper to
+// pack a big-endian integer into a byte buffer used by the hand-built test
+// payloads below.
+template <typename T>
+void writeBE(std::array<char, 16>& buf, int offset, T v) {
+    using U = std::make_unsigned_t<T>;
+    auto u = static_cast<U>(v);
+    for (int i = static_cast<int>(sizeof(T)) - 1; i >= 0; --i) {
+        buf[static_cast<size_t>(offset + i)] = static_cast<char>(u & 0xFF);
+        u >>= 8;
+    }
+}
+
+}  // namespace
+
+// ─── bool (OID 16) ────────────────────────────────────────────────────────
+
+TEST(PgBinaryDecoder, BoolTrue) {
+    std::deque<std::string> arena;
+    char raw[] = {'\x01'};
+    auto v = decodeCell(16, raw, 1, arena);
+    EXPECT_EQ(v, "t");
+}
+
+TEST(PgBinaryDecoder, BoolFalse) {
+    std::deque<std::string> arena;
+    char raw[] = {'\x00'};
+    auto v = decodeCell(16, raw, 1, arena);
+    EXPECT_EQ(v, "f");
+}
+
+// ─── int2 / int4 / int8 ───────────────────────────────────────────────────
+
+TEST(PgBinaryDecoder, Int2Positive) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int16_t>(buf, 0, 12345);
+    auto v = decodeCell(21, buf.data(), 2, arena);
+    EXPECT_EQ(v, "12345");
+}
+
+TEST(PgBinaryDecoder, Int2Negative) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int16_t>(buf, 0, -1);
+    auto v = decodeCell(21, buf.data(), 2, arena);
+    EXPECT_EQ(v, "-1");
+}
+
+TEST(PgBinaryDecoder, Int4Positive) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int32_t>(buf, 0, 42);
+    auto v = decodeCell(23, buf.data(), 4, arena);
+    EXPECT_EQ(v, "42");
+}
+
+TEST(PgBinaryDecoder, Int4Min) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int32_t>(buf, 0, INT32_MIN);
+    auto v = decodeCell(23, buf.data(), 4, arena);
+    EXPECT_EQ(v, "-2147483648");
+}
+
+TEST(PgBinaryDecoder, Int8Large) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int64_t>(buf, 0, 9'223'372'036'854'775'807LL);
+    auto v = decodeCell(20, buf.data(), 8, arena);
+    EXPECT_EQ(v, "9223372036854775807");
+}
+
+TEST(PgBinaryDecoder, Int8Min) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int64_t>(buf, 0, INT64_MIN);
+    auto v = decodeCell(20, buf.data(), 8, arena);
+    EXPECT_EQ(v, "-9223372036854775808");
+}
+
+// ─── float4 / float8 ──────────────────────────────────────────────────────
+
+TEST(PgBinaryDecoder, Float8Pi) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    const double pi = 3.141592653589793;
+    uint64_t bits = 0;
+    std::memcpy(&bits, &pi, sizeof(double));
+    writeBE<int64_t>(buf, 0, static_cast<int64_t>(bits));
+    auto v = decodeCell(701, buf.data(), 8, arena);
+    // std::to_chars round-trips to shortest representation that re-parses
+    // exactly — assert prefix to avoid platform-specific tail digits.
+    EXPECT_TRUE(std::string(v).starts_with("3.14159265358979"));
+}
+
+TEST(PgBinaryDecoder, Float4Zero) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int32_t>(buf, 0, 0);
+    auto v = decodeCell(700, buf.data(), 4, arena);
+    EXPECT_EQ(v, "0");
+}
+
+// ─── text / varchar / bytea passthrough ───────────────────────────────────
+
+TEST(PgBinaryDecoder, TextZeroCopy) {
+    std::deque<std::string> arena;
+    const char* raw = "hello world";
+    auto v = decodeCell(25, raw, 11, arena);
+    EXPECT_EQ(v, "hello world");
+    // Verify zero-copy: the view must alias the input pointer, not the arena.
+    EXPECT_EQ(v.data(), raw);
+    EXPECT_TRUE(arena.empty());
+}
+
+TEST(PgBinaryDecoder, VarcharZeroCopy) {
+    std::deque<std::string> arena;
+    const char* raw = "varchar value";
+    auto v = decodeCell(1043, raw, 13, arena);
+    EXPECT_EQ(v, "varchar value");
+    EXPECT_EQ(v.data(), raw);
+}
+
+TEST(PgBinaryDecoder, ByteaRawBytes) {
+    std::deque<std::string> arena;
+    char raw[] = {'\x01', '\x02', '\x03'};
+    auto v = decodeCell(17, raw, 3, arena);
+    EXPECT_EQ(v.size(), 3u);
+    EXPECT_EQ(v[0], '\x01');
+    EXPECT_EQ(v[1], '\x02');
+    EXPECT_EQ(v[2], '\x03');
+}
+
+// ─── numeric (OID 1700) ───────────────────────────────────────────────────
+// Header bytes (always 8): ndigits, weight, sign, dscale (each i16 big-endian).
+
+namespace {
+
+// Build a numeric wire payload.
+std::vector<char> buildNumeric(int ndigits, int weight, uint16_t sign, int dscale, std::initializer_list<int> digits) {
+    std::vector<char> out(static_cast<size_t>(8 + ndigits * 2), '\0');
+    auto writeI16 = [&](int off, int v) {
+        out[static_cast<size_t>(off)] = static_cast<char>((v >> 8) & 0xFF);
+        out[static_cast<size_t>(off + 1)] = static_cast<char>(v & 0xFF);
+    };
+    writeI16(0, ndigits);
+    writeI16(2, weight);
+    writeI16(4, static_cast<int16_t>(sign));
+    writeI16(6, dscale);
+    int i = 0;
+    for (int d : digits) {
+        writeI16(8 + i * 2, d);
+        ++i;
+    }
+    return out;
+}
+
+}  // namespace
+
+TEST(PgBinaryDecoder, NumericZero) {
+    std::deque<std::string> arena;
+    auto buf = buildNumeric(0, 0, 0x0000, 0, {});
+    auto v = decodeCell(1700, buf.data(), static_cast<int>(buf.size()), arena);
+    EXPECT_EQ(v, "0");
+}
+
+TEST(PgBinaryDecoder, NumericPositiveOne) {
+    std::deque<std::string> arena;
+    // 1 = ndigits=1, weight=0, sign=+, dscale=0, digits=[1]
+    auto buf = buildNumeric(1, 0, 0x0000, 0, {1});
+    auto v = decodeCell(1700, buf.data(), static_cast<int>(buf.size()), arena);
+    EXPECT_EQ(v, "1");
+}
+
+TEST(PgBinaryDecoder, NumericNegativeOne) {
+    std::deque<std::string> arena;
+    auto buf = buildNumeric(1, 0, 0x4000, 0, {1});
+    auto v = decodeCell(1700, buf.data(), static_cast<int>(buf.size()), arena);
+    EXPECT_EQ(v, "-1");
+}
+
+TEST(PgBinaryDecoder, NumericFractional) {
+    std::deque<std::string> arena;
+    // 1.5 = ndigits=2, weight=0, sign=+, dscale=1, digits=[1, 5000]
+    auto buf = buildNumeric(2, 0, 0x0000, 1, {1, 5000});
+    auto v = decodeCell(1700, buf.data(), static_cast<int>(buf.size()), arena);
+    EXPECT_EQ(v, "1.5");
+}
+
+TEST(PgBinaryDecoder, NumericNaN) {
+    std::deque<std::string> arena;
+    auto buf = buildNumeric(0, 0, 0xC000, 0, {});
+    auto v = decodeCell(1700, buf.data(), static_cast<int>(buf.size()), arena);
+    EXPECT_EQ(v, "NaN");
+}
+
+TEST(PgBinaryDecoder, NumericLargeInteger) {
+    std::deque<std::string> arena;
+    // 12345678 = digits [1234, 5678], weight=1
+    auto buf = buildNumeric(2, 1, 0x0000, 0, {1234, 5678});
+    auto v = decodeCell(1700, buf.data(), static_cast<int>(buf.size()), arena);
+    EXPECT_EQ(v, "12345678");
+}
+
+// ─── date / time / timestamp ──────────────────────────────────────────────
+
+TEST(PgBinaryDecoder, DateEpoch) {
+    // days since 2000-01-01 = 0 → "2000-01-01"
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int32_t>(buf, 0, 0);
+    auto v = decodeCell(1082, buf.data(), 4, arena);
+    EXPECT_EQ(v, "2000-01-01");
+}
+
+TEST(PgBinaryDecoder, DateSpecificDay) {
+    // 2024-01-15 → days_from_2000 = 8780
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int32_t>(buf, 0, 8780);
+    auto v = decodeCell(1082, buf.data(), 4, arena);
+    EXPECT_EQ(v, "2024-01-15");
+}
+
+TEST(PgBinaryDecoder, TimeMidnight) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int64_t>(buf, 0, 0);
+    auto v = decodeCell(1083, buf.data(), 8, arena);
+    EXPECT_EQ(v, "00:00:00.000000");
+}
+
+TEST(PgBinaryDecoder, TimeNoon) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int64_t>(buf, 0, 12LL * 3600 * 1'000'000LL);
+    auto v = decodeCell(1083, buf.data(), 8, arena);
+    EXPECT_EQ(v, "12:00:00.000000");
+}
+
+TEST(PgBinaryDecoder, TimestampEpoch) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int64_t>(buf, 0, 0);
+    auto v = decodeCell(1114, buf.data(), 8, arena);
+    EXPECT_EQ(v, "2000-01-01 00:00:00.000000");
+}
+
+TEST(PgBinaryDecoder, TimestamptzEpoch) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int64_t>(buf, 0, 0);
+    auto v = decodeCell(1184, buf.data(), 8, arena);
+    EXPECT_EQ(v, "2000-01-01 00:00:00.000000+00");
+}
+
+TEST(PgBinaryDecoder, TimestampSpecific) {
+    // 2024-01-15 10:30:45.123456 UTC
+    // = days_from_2000(8780) * 86400 + (10*3600 + 30*60 + 45) sec
+    constexpr int64_t kSecPerDay = 86400LL;
+    constexpr int64_t kUsPerSec = 1'000'000LL;
+    const int64_t sec = 8780LL * kSecPerDay + 10 * 3600 + 30 * 60 + 45;
+    const int64_t us = sec * kUsPerSec + 123456LL;
+
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    writeBE<int64_t>(buf, 0, us);
+    auto v = decodeCell(1114, buf.data(), 8, arena);
+    EXPECT_EQ(v, "2024-01-15 10:30:45.123456");
+}
+
+// ─── interval (OID 1186) ──────────────────────────────────────────────────
+
+TEST(PgBinaryDecoder, IntervalMonthsAndDays) {
+    // 1 month 2 days 03:04:05
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    const int64_t timeUs = (3LL * 3600 + 4 * 60 + 5) * 1'000'000LL;
+    writeBE<int64_t>(buf, 0, timeUs);
+    writeBE<int32_t>(buf, 8, 2);   // days
+    writeBE<int32_t>(buf, 12, 1);  // months
+    auto v = decodeCell(1186, buf.data(), 16, arena);
+    EXPECT_EQ(v, "1 mon 2 days 03:04:05.000000");
+}
+
+TEST(PgBinaryDecoder, IntervalTimeOnly) {
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+    const int64_t timeUs = (1LL * 3600 + 30 * 60) * 1'000'000LL;
+    writeBE<int64_t>(buf, 0, timeUs);
+    writeBE<int32_t>(buf, 8, 0);
+    writeBE<int32_t>(buf, 12, 0);
+    auto v = decodeCell(1186, buf.data(), 16, arena);
+    EXPECT_EQ(v, "01:30:00.000000");
+}
+
+// ─── uuid (OID 2950) ──────────────────────────────────────────────────────
+
+TEST(PgBinaryDecoder, UuidFixed) {
+    // 12345678-9abc-def0-1234-56789abcdef0
+    std::deque<std::string> arena;
+    const std::array<unsigned char, 16> raw = {0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0,
+                                               0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0};
+    auto v = decodeCell(2950, reinterpret_cast<const char*>(raw.data()), 16, arena);
+    EXPECT_EQ(v, "12345678-9abc-def0-1234-56789abcdef0");
+}
+
+TEST(PgBinaryDecoder, UuidZero) {
+    std::deque<std::string> arena;
+    char raw[16] = {};
+    auto v = decodeCell(2950, raw, 16, arena);
+    EXPECT_EQ(v, "00000000-0000-0000-0000-000000000000");
+}
+
+// ─── jsonb (OID 3802) — strip leading version byte ────────────────────────
+
+TEST(PgBinaryDecoder, JsonbStripVersion) {
+    std::deque<std::string> arena;
+    char raw[] = {'\x01', '{', '"', 'a', '"', ':', '1', '}'};
+    auto v = decodeCell(3802, raw, 8, arena);
+    EXPECT_EQ(v, R"({"a":1})");
+}
+
+TEST(PgBinaryDecoder, JsonPassthrough) {
+    std::deque<std::string> arena;
+    const char* raw = R"({"k":"v"})";
+    auto v = decodeCell(114, raw, static_cast<int>(std::strlen(raw)), arena);
+    EXPECT_EQ(v, R"({"k":"v"})");
+    EXPECT_EQ(v.data(), raw);  // zero-copy
+}
+
+// ─── planColumns / isBinarySupported ──────────────────────────────────────
+
+TEST(PgBinaryDecoder, IsBinarySupportedKnownTypes) {
+    EXPECT_TRUE(isBinarySupported(16));    // bool
+    EXPECT_TRUE(isBinarySupported(23));    // int4
+    EXPECT_TRUE(isBinarySupported(25));    // text
+    EXPECT_TRUE(isBinarySupported(1114));  // timestamp
+    EXPECT_TRUE(isBinarySupported(1700));  // numeric
+    EXPECT_TRUE(isBinarySupported(2950));  // uuid
+    EXPECT_TRUE(isBinarySupported(3802));  // jsonb
+}
+
+TEST(PgBinaryDecoder, IsBinarySupportedUnknownTypes) {
+    EXPECT_FALSE(isBinarySupported(1007));  // int4[] (array)
+    EXPECT_FALSE(isBinarySupported(790));   // money
+    EXPECT_FALSE(isBinarySupported(829));   // macaddr
+    EXPECT_FALSE(isBinarySupported(0));
+}
+
+// ─── Empty / null-like inputs (defensive bounds) ─────────────────────────
+
+TEST(PgBinaryDecoder, EmptyTextPassthrough) {
+    std::deque<std::string> arena;
+    const char* raw = "";
+    auto v = decodeCell(25, raw, 0, arena);
+    EXPECT_TRUE(v.empty());
+    EXPECT_TRUE(arena.empty());
+}
+
+// ─── Truncated payload throws (fail-fast contract) ───────────────────────
+
+TEST(PgBinaryDecoder, NumericTruncatedThrows) {
+    std::deque<std::string> arena;
+    char raw[4] = {};
+    EXPECT_THROW(decodeCell(1700, raw, 4, arena), std::runtime_error);
+}
+
+TEST(PgBinaryDecoder, TimestampTruncatedThrows) {
+    std::deque<std::string> arena;
+    char raw[4] = {};
+    EXPECT_THROW(decodeCell(1114, raw, 4, arena), std::runtime_error);
+}
+
+TEST(PgBinaryDecoder, UuidTruncatedThrows) {
+    std::deque<std::string> arena;
+    char raw[8] = {};
+    EXPECT_THROW(decodeCell(2950, raw, 8, arena), std::runtime_error);
+}
+
+TEST(PgBinaryDecoder, DateTruncatedThrows) {
+    std::deque<std::string> arena;
+    char raw[2] = {};
+    EXPECT_THROW(decodeCell(1082, raw, 2, arena), std::runtime_error);
+}
+
+TEST(PgBinaryDecoder, TimeTruncatedThrows) {
+    std::deque<std::string> arena;
+    char raw[4] = {};
+    EXPECT_THROW(decodeCell(1083, raw, 4, arena), std::runtime_error);
+}
+
+TEST(PgBinaryDecoder, IntervalTruncatedThrows) {
+    std::deque<std::string> arena;
+    char raw[8] = {};
+    EXPECT_THROW(decodeCell(1186, raw, 8, arena), std::runtime_error);
+}
+
+TEST(PgBinaryDecoder, ArenaPointerStabilityAcrossInserts) {
+    // Multiple decoded cells must produce string_views that remain valid even
+    // as the arena grows. std::deque does not invalidate references on
+    // emplace_back, so previously returned views must keep matching their
+    // original text. (Regression guard against accidental std::vector swap.)
+    std::deque<std::string> arena;
+    std::array<char, 16> buf{};
+
+    writeBE<int32_t>(buf, 0, 1);
+    auto v1 = decodeCell(23, buf.data(), 4, arena);
+
+    writeBE<int32_t>(buf, 0, 2);
+    auto v2 = decodeCell(23, buf.data(), 4, arena);
+
+    writeBE<int32_t>(buf, 0, 3);
+    auto v3 = decodeCell(23, buf.data(), 4, arena);
+
+    EXPECT_EQ(v1, "1");
+    EXPECT_EQ(v2, "2");
+    EXPECT_EQ(v3, "3");
+}
+
+}  // namespace velocitydb::pg_binary::test


### PR DESCRIPTION
- PostgreSQL の binary wire format をデコードする lib を追加。
- driver 統合は part 2/2 で別 PR。

- pg_endian.h: BE→host endian load helpers (C++23 std::byteswap)
- pg_result_bundle.h: PGresult + deque<string> arena bundle
- pg_binary_decoder.{h,cpp}: 全 OID decoder (bool/int/float/numeric/ date/time/timestamp(tz)/interval/uuid/text/json/jsonb/bytea) + planColumns() dispatch + zero-copy passthrough for text shapes
- test_pg_binary_decoder.cpp: 42 unit tests (round-trip + 境界値 + truncated payload throws)

方針検証:

premise-questioning skipped (issue #579 で確定済、libpq 内 74% の [pg-split] 計測で根拠付け済) / feature-pruning skipped (UI/API 追加なし、内部 driver 改善のみ)

Refs #579 (parent #553).