### PR TITLE
feat(frontend): 計測基盤と bundle analyzer を導入 (#494)

### DIFF
--- a/docs/PERFORMANCE_VALIDATION.md
+++ b/docs/PERFORMANCE_VALIDATION.md
@@ -192,8 +192,90 @@ uv run scripts/pdg.py test backend
    - 「高速」(#11) のように定量的でない記述を、具体値もしくは相対値 (例: 「非 SIMD 比 N 倍」) に置き換え
    - 計測条件 (CPU、メモリ、DB ロケーション) の前提を README に併記
 
+## フロントエンド計測ベースライン (#494)
+
+`#479` パフォーマンスリファクタの起点として、フロントエンド主要画面の初回マウント時間と本番 bundle 構成を計測する仕組みを整備した (`#494`)。後続の `#501` (ResultGrid 最適化) / `#505` (selector 最適化) / `#504` (store 分割) は本セクションのベースライン値を起点に効果を判定する。
+
+### 計測対象と計測機構
+
+| 対象 | ファイル | 計測 mark 名 |
+| ---- | -------- | ------------ |
+| ResultGrid | `frontend/src/components/grid/ResultGrid.tsx` | `result-grid` |
+| ObjectTree | `frontend/src/components/tree/ObjectTree.tsx` | `object-tree` |
+| SqlEditor (Monaco) | `frontend/src/components/editor/SqlEditor.tsx` | `sql-editor` |
+
+各コンポーネントは `useFirstRenderMark` (`frontend/src/utils/perfMarks.ts`) で初回マウントの `${name}:start` / `${name}:end` mark を打ち、`${name}` の measure entry を Performance API に記録する。再レンダリングでは記録しない (初回マウントのみ)。
+
+### 初回レンダリング時間の取得手順
+
+1. dev server 起動:
+
+   ```powershell
+   uv run scripts/pdg.py dev
+   ```
+
+2. Chrome / Edge で `http://localhost:5173/` を開く
+3. DevTools → Performance タブで Record 開始
+4. 操作:
+   - ResultGrid: 任意のクエリを実行して結果を表示
+   - ObjectTree: 接続プロファイルを開いてスキーマを展開
+   - SqlEditor: 新規タブを開いて Monaco を初期化
+5. Record 停止 → Timings レーンの `result-grid` / `object-tree` / `sql-editor` measure entry の duration を読み取り
+
+または DevTools → Console で以下を実行:
+
+```js
+performance.getEntriesByType('measure')
+  .filter(e => ['result-grid', 'object-tree', 'sql-editor'].includes(e.name))
+  .map(e => ({ name: e.name, duration_ms: e.duration.toFixed(2) }));
+```
+
+### bundle サイズレポートの取得手順
+
+`rollup-plugin-visualizer` v7.0.1 (Vite 8 / rolldown 対応) を opt-in で組み込んでいる。`VELOCITYDB_BUNDLE_REPORT=1` を設定したビルド時のみ `frontend/dist/bundle-report.html` を生成する。
+
+```powershell
+$env:VELOCITYDB_BUNDLE_REPORT = '1'
+uv run scripts/pdg.py build frontend
+# → frontend/dist/bundle-report.html をブラウザで開く
+Remove-Item Env:VELOCITYDB_BUNDLE_REPORT
+```
+
+`gzipSize` / `brotliSize` を有効にしているため、各 chunk の raw / gzip / brotli サイズを併記レポートする。
+
+### ベースライン値テーブル (要追記)
+
+> 計測者は実機で取得した値を以下の表に追記してください。計測環境 (OS / CPU / WebView2 Runtime version) も併記すること。
+
+#### 初回マウント時間
+
+| 対象 | 計測条件 | duration (ms) | 計測日 | 環境 |
+| ---- | -------- | ------------- | ------ | ---- |
+| ResultGrid | 1000 行 × 10 列 | TBD | YYYY-MM-DD | TBD |
+| ResultGrid | 10000 行 × 10 列 | TBD | YYYY-MM-DD | TBD |
+| ObjectTree | 接続プロファイル 1 件展開 (テーブル 50 件) | TBD | YYYY-MM-DD | TBD |
+| SqlEditor | 新規タブ初期化 | TBD | YYYY-MM-DD | TBD |
+
+#### bundle 構成
+
+| chunk | raw (KB) | gzip (KB) | brotli (KB) | 計測日 |
+| ----- | -------- | --------- | ----------- | ------ |
+| `vendor-monaco` | TBD | TBD | TBD | YYYY-MM-DD |
+| `vendor-table` | TBD | TBD | TBD | YYYY-MM-DD |
+| `vendor-reactflow` | TBD | TBD | TBD | YYYY-MM-DD |
+| `vendor-react` | TBD | TBD | TBD | YYYY-MM-DD |
+| `vendor-state` | TBD | TBD | TBD | YYYY-MM-DD |
+| `vendor-sqltools-formatter` | TBD | TBD | TBD | YYYY-MM-DD |
+| entry (`index`) | TBD | TBD | TBD | YYYY-MM-DD |
+
+### 本セクションのスコープ外 (follow-up)
+
+- `web-vitals` ライブラリ導入による LCP / CLS / INP の自動取得 — WebView2 file:// 配信での挙動が未確認のため別 issue 化
+- Lighthouse CI 自動実行 — 同上
+- Playwright + Chrome DevTools Protocol での measure 自動取得 — `#5` (60fps 検証) と統合検討
+
 ## 参考
 
 - [README.md - パフォーマンス目標と実装](../README.md#パフォーマンス目標と実装)
 - [docs/ARCHITECTURE.md](./ARCHITECTURE.md)
-- 関連 issue: #418 (パフォーマンス向上)、#416 (本検証)
+- 関連 issue: #418 (パフォーマンス向上)、#416 (本検証)、#479 (perf リファクタ親)、#494 (フロントエンド計測基盤)

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -29,6 +29,7 @@
         "esbuild": "^0.28.0",
         "jsdom": "^29.0.0",
         "lightningcss": "^1.32.0",
+        "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "^6.0.2",
         "vite": "^8.0.0",
         "vitest": "^4.0.18",
@@ -346,9 +347,13 @@
 
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -378,6 +383,12 @@
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -386,11 +397,15 @@
 
     "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
 
+    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
@@ -400,6 +415,10 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
@@ -408,7 +427,15 @@
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-in-ssh": ["is-in-ssh@1.0.0", "", {}, "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw=="],
+
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
@@ -466,6 +493,8 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
+
     "parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -479,6 +508,8 @@
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "powershell-utils": ["powershell-utils@0.1.0", "", {}, "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A=="],
 
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
@@ -498,6 +529,10 @@
 
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
+    "rollup-plugin-visualizer": ["rollup-plugin-visualizer@7.0.1", "", { "dependencies": { "open": "^11.0.0", "picomatch": "^4.0.2", "source-map": "^0.7.4", "yargs": "^18.0.0" }, "peerDependencies": { "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc", "rollup": "2.x || 3.x || 4.x" }, "optionalPeers": ["rolldown", "rollup"], "bin": { "rollup-plugin-visualizer": "dist/bin/cli.js" } }, "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
@@ -506,6 +541,8 @@
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
@@ -513,6 +550,10 @@
     "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -558,9 +599,19 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
+
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yargs": ["yargs@18.0.0", "", { "dependencies": { "cliui": "^9.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "string-width": "^7.2.0", "y18n": "^5.0.5", "yargs-parser": "^22.0.0" } }, "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg=="],
+
+    "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
@@ -584,7 +635,11 @@
 
     "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.9", "", {}, "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw=="],
 
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@bramus/specificity/css-tree/mdn-data": ["mdn-data@2.12.2", "", {}, "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "esbuild": "^0.28.0",
     "jsdom": "^29.0.0",
     "lightningcss": "^1.32.0",
+    "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "^6.0.2",
     "vite": "^8.0.0",
     "vitest": "^4.0.18"

--- a/frontend/src/components/editor/SqlEditor.tsx
+++ b/frontend/src/components/editor/SqlEditor.tsx
@@ -15,6 +15,7 @@ import {
   setSqlMarkers,
 } from '../../utils/editorMarkers';
 import { log } from '../../utils/logger';
+import { useFirstRenderMark } from '../../utils/perfMarks';
 import { formatSQL } from '../../utils/sqlFormat';
 import { createCompletionProvider } from './completionProvider';
 import { createInlayHintProvider } from './inlayHintProvider';
@@ -46,6 +47,7 @@ function useApplyMarkers(
 }
 
 export function SqlEditor() {
+  useFirstRenderMark('sql-editor');
   const { queries, activeQueryId, updateQuery } = useQueryStore();
   const activeQuery = queries.find((q) => q.id === activeQueryId);
   const queryConnectionId = activeQuery?.connectionId ?? null;

--- a/frontend/src/components/grid/ResultGrid.tsx
+++ b/frontend/src/components/grid/ResultGrid.tsx
@@ -27,6 +27,7 @@ import { type ColumnMeta, type GridViewMode, isNumericType, type RowData } from 
 import { parseErrorMessage } from '../../utils/errorParser';
 import { lazyWithRetry } from '../../utils/lazyWithRetry';
 import { log } from '../../utils/logger';
+import { useFirstRenderMark } from '../../utils/perfMarks';
 import { getStatementType } from '../../utils/sql/statement-type';
 import { QueryConfirmDialog } from '../dialogs/QueryConfirmDialog';
 import { GridFilterBar } from './GridFilterBar';
@@ -75,6 +76,7 @@ interface ResultGridProps {
 }
 
 function ResultGridInner({ queryId, excludeDataView = false }: ResultGridProps = {}) {
+  useFirstRenderMark('result-grid');
   // --- Store subscriptions ---
   const activeQueryId = useQueryStore((state) => state.activeQueryId);
   const isActiveDataView = useIsActiveDataView();

--- a/frontend/src/components/tree/ObjectTree.tsx
+++ b/frontend/src/components/tree/ObjectTree.tsx
@@ -10,6 +10,7 @@ import {
   type SavedConnectionProfile,
 } from '../../types';
 import { groupProfilesByFolder, type ProfileGroup } from '../../utils/groupProfilesByFolder';
+import { useFirstRenderMark } from '../../utils/perfMarks';
 import { pruneCollapsedFolders } from '../../utils/pruneCollapsedFolders';
 import type { ExpandableType } from '../../utils/treeNode';
 import { DialogOverlay } from '../common/DialogOverlay';
@@ -60,6 +61,7 @@ interface ObjectTreeProps {
 }
 
 export function ObjectTree({ filter, onTableOpen }: ObjectTreeProps) {
+  useFirstRenderMark('object-tree');
   const { connections, profileVersion } = useConnectionStore(
     useShallow((state) => ({
       connections: state.connections,

--- a/frontend/src/tests/utils/perfMarks.test.ts
+++ b/frontend/src/tests/utils/perfMarks.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useFirstRenderMark } from '../../utils/perfMarks';
+
+describe('useFirstRenderMark', () => {
+  afterEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  it('records start and end marks plus a measure on first mount', () => {
+    renderHook(() => useFirstRenderMark('test-target'));
+
+    const starts = performance.getEntriesByName('test-target:start', 'mark');
+    const ends = performance.getEntriesByName('test-target:end', 'mark');
+    const measures = performance.getEntriesByName('test-target', 'measure');
+
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+    expect(measures).toHaveLength(1);
+  });
+
+  it('does not record additional marks or measures on rerender', () => {
+    const { rerender } = renderHook(() => useFirstRenderMark('rerender-target'));
+    rerender();
+    rerender();
+
+    const starts = performance.getEntriesByName('rerender-target:start', 'mark');
+    const ends = performance.getEntriesByName('rerender-target:end', 'mark');
+    const measures = performance.getEntriesByName('rerender-target', 'measure');
+
+    expect(starts).toHaveLength(1);
+    expect(ends).toHaveLength(1);
+    expect(measures).toHaveLength(1);
+  });
+
+  it('skips end mark when start has been cleared before effect runs', () => {
+    performance.mark('manual-target:start');
+    performance.clearMarks('manual-target:start');
+    renderHook(() => {
+      performance.clearMarks('manual-target:start');
+      useFirstRenderMark('manual-target');
+    });
+
+    const measures = performance.getEntriesByName('manual-target', 'measure');
+    expect(measures.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/frontend/src/utils/perfMarks.ts
+++ b/frontend/src/utils/perfMarks.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * 初回マウント時のレンダリング時間を Performance API に記録する。
+ * DevTools Performance タブで `target` の measure entry として観察できる。
+ */
+export function useFirstRenderMark(target: string): void {
+  const startMarked = useRef(false);
+  const measured = useRef(false);
+
+  if (!startMarked.current) {
+    performance.mark(`${target}:start`);
+    startMarked.current = true;
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: initial mount only
+  useEffect(() => {
+    if (measured.current) return;
+    measured.current = true;
+
+    const hasStart = performance.getEntriesByName(`${target}:start`, 'mark').length > 0;
+    if (!hasStart) return;
+
+    performance.mark(`${target}:end`);
+    performance.measure(target, `${target}:start`, `${target}:end`);
+  }, []);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import react from '@vitejs/plugin-react';
-import { defineConfig, type Plugin } from 'vite';
+import { visualizer } from 'rollup-plugin-visualizer';
+import { defineConfig, type Plugin, type PluginOption } from 'vite';
 
 /**
  * Prevents Vite from bundling unused Monaco language workers (css, html, json, typescript).
@@ -25,8 +26,24 @@ function monacoWorkerExcludePlugin(): Plugin {
   };
 }
 
+const BUNDLE_REPORT_ENABLED = process.env.VELOCITYDB_BUNDLE_REPORT === '1';
+
 export default defineConfig({
-  plugins: [react(), monacoWorkerExcludePlugin()],
+  plugins: [
+    react(),
+    monacoWorkerExcludePlugin(),
+    ...(BUNDLE_REPORT_ENABLED
+      ? [
+          visualizer({
+            filename: 'dist/bundle-report.html',
+            template: 'treemap',
+            gzipSize: true,
+            brotliSize: true,
+            sourcemap: true,
+          }) as PluginOption,
+        ]
+      : []),
+  ],
   base: './', // Use relative paths for file:// protocol
   resolve: {
     alias: {


### PR DESCRIPTION
#479 perf リファクタの起点として、Frontend 主要 3 画面 (ResultGrid / ObjectTree / SqlEditor) の初回マウント時間を `Performance API` で記録する `useFirstRenderMark` フックを追加。
また `env-gated` (`VELOCITYDB_BUNDLE_REPORT=1`) で `rollup-plugin-visualizer` による bundle サイズレポートを生成可能にし、計測手順とベースライン記録テーブルテンプレを `docs/PERFORMANCE_VALIDATION.md` に追記。

後続の #501 / #504 / #505 はここで取るベースライン値を起点に改善幅を判定する