### PR TITLE
docs(perf): #494 bundle ベースライン値を記録、E2E spec 追加

### DIFF
--- a/docs/PERFORMANCE_VALIDATION.md
+++ b/docs/PERFORMANCE_VALIDATION.md
@@ -258,15 +258,32 @@ Remove-Item Env:VELOCITYDB_BUNDLE_REPORT
 
 #### bundle 構成
 
+計測環境: Docker (`oven/bun:latest`) で `bunx vite build` (production)。raw / gzip は Vite 標準出力、brotli は `brotli -q 11` で別計測。サイズは decimal kB (`bytes / 1000`)。
+
 | chunk | raw (KB) | gzip (KB) | brotli (KB) | 計測日 |
 | ----- | -------- | --------- | ----------- | ------ |
-| `vendor-monaco` | TBD | TBD | TBD | YYYY-MM-DD |
-| `vendor-table` | TBD | TBD | TBD | YYYY-MM-DD |
-| `vendor-reactflow` | TBD | TBD | TBD | YYYY-MM-DD |
-| `vendor-react` | TBD | TBD | TBD | YYYY-MM-DD |
-| `vendor-state` | TBD | TBD | TBD | YYYY-MM-DD |
-| `vendor-sqltools-formatter` | TBD | TBD | TBD | YYYY-MM-DD |
-| entry (`index`) | TBD | TBD | TBD | YYYY-MM-DD |
+| `vendor-monaco` | 4203.27 | 1079.19 | 823.09 | 2026-05-14 |
+| `vendor-table` | 63.10 | 16.74 | 14.96 | 2026-05-14 |
+| `vendor-reactflow` | 173.49 | 55.98 | 48.29 | 2026-05-14 |
+| `vendor-react` | 182.90 | 57.55 | 49.28 | 2026-05-14 |
+| `vendor-state` | 2.37 | 1.15 | 1.05 | 2026-05-14 |
+| `vendor-sqltools-formatter` | 33.05 | 9.46 | 8.18 | 2026-05-14 |
+| entry (`index`) | 40.27 | 12.52 | 10.95 | 2026-05-14 |
+
+参考 (`#501` 等での比較に有用な周辺 chunk):
+
+| chunk | raw (KB) | gzip (KB) |
+| ----- | -------- | --------- |
+| `providers` (dynamic) | 280.31 | 64.47 |
+| `editor.worker` (Monaco worker) | 280.01 | (raw のみ) |
+| `style.css` | 234.86 | 35.73 |
+| `ResultGrid` | 54.80 | 18.01 |
+| `LeftPanel` | 28.01 | 9.54 |
+| `ConnectionDialog` | 20.82 | 5.72 |
+| `queryStore` | 19.60 | 6.63 |
+| `SqlEditor` | 16.15 | 6.02 |
+
+> `vendor-monaco` が全体の **78%** (raw) / **76%** (gzip) / **75%** (brotli) を占める。Monaco の lazy-load 分割は `#501`/`#494` 後続の優先課題候補 (follow-up issue へ)。
 
 ### 本セクションのスコープ外 (follow-up)
 

--- a/frontend/e2e/perf-baseline.spec.ts
+++ b/frontend/e2e/perf-baseline.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * #494 Frontend 計測基盤 — 初回マウント duration ベースライン取得 (自動化)
+ *
+ * useFirstRenderMark (frontend/src/utils/perfMarks.ts) が記録する
+ * `result-grid` / `object-tree` / `sql-editor` の measure entry を取得する。
+ * dev server (Vite) 経由のため duration は production preview / WebView2 と
+ * 一致しない。リグレッション検出の基準値として記録する。
+ */
+
+const MOCK_INVOKE_SCRIPT = `
+  window.invoke = async (requestStr) => {
+    let method = '';
+    try {
+      method = JSON.parse(requestStr).method;
+    } catch (_e) {
+      method = '';
+    }
+    if (method === 'loadSession') {
+      return JSON.stringify({
+        success: true,
+        data: { queries: [], activeQueryId: null, connectionProfiles: [], window: {} },
+      });
+    }
+    return JSON.stringify({ success: true, data: {} });
+  };
+`;
+
+const TARGETS = ['result-grid', 'object-tree', 'sql-editor'] as const;
+
+test.describe('#494 perf baseline', () => {
+  test('useFirstRenderMark の duration を 3 画面で取得', async ({ page }) => {
+    await page.addInitScript(MOCK_INVOKE_SCRIPT);
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+
+    // SqlEditor は新規タブ作成でマウントされる (#391 spec と同じ手法)。
+    await page.keyboard.press('Control+n');
+
+    await page.waitForFunction(
+      (names) =>
+        (names as readonly string[]).every(
+          (n) => performance.getEntriesByName(n, 'measure').length > 0,
+        ),
+      TARGETS,
+      { timeout: 15_000 },
+    );
+
+    const durations = await page.evaluate((names) => {
+      return (names as readonly string[]).map((n) => {
+        const entry = performance.getEntriesByName(n, 'measure')[0];
+        return {
+          name: n,
+          duration_ms: entry ? Number(entry.duration.toFixed(2)) : null,
+        };
+      });
+    }, TARGETS);
+
+    // stdout に集計可能な形で出力 (docs 転記用)。
+    console.log(`[#494 baseline] ${JSON.stringify(durations)}`);
+
+    for (const d of durations) {
+      expect(d.duration_ms).not.toBeNull();
+      expect(d.duration_ms).toBeGreaterThan(0);
+      test
+        .info()
+        .annotations.push({ type: 'perf-baseline', description: `${d.name}=${d.duration_ms}ms` });
+    }
+  });
+});

--- a/frontend/e2e/perf-baseline.spec.ts
+++ b/frontend/e2e/perf-baseline.spec.ts
@@ -41,10 +41,10 @@ test.describe('#494 perf baseline', () => {
     await page.waitForFunction(
       (names) =>
         (names as readonly string[]).every(
-          (n) => performance.getEntriesByName(n, 'measure').length > 0,
+          (n) => performance.getEntriesByName(n, 'measure').length > 0
         ),
       TARGETS,
-      { timeout: 15_000 },
+      { timeout: 15_000 }
     );
 
     const durations = await page.evaluate((names) => {


### PR DESCRIPTION
## Summary

- #494 のうち bundle 構成 TBD を実値で記録 (vendor-monaco が全体の 75-78% を占める知見を追記)
- 初回マウント duration 自動取得用の E2E spec を新規追加 (frontend/e2e/perf-baseline.spec.ts)

## Out of scope (follow-up)

- duration TBD (L252-257): 実機 (WebView2) 計測 or Playwright 実行環境整備後に別コミット
- E2E 実行環境: 現状 oven/bun image + bunx で Playwright TS transform 衝突。mcr/playwright + 別 config (webServer override) が必要 → 別 issue

## Test plan

- [x] `docker run oven/bun:latest 'bunx vite build'` で raw/gzip 取得確認
- [x] `docker run alpine 'brotli -q 11'` で brotli 算出確認
- [ ] PR レビュー後、別 PR で duration TBD を埋めて #494 を CLOSE

## Issue

Refs #494 #479