### PR TITLE
test: `ResultRow::values` の `string_view` ライフタイムをテストで保証

### DIFF
--- a/tests/database/test_result_cache.cpp
+++ b/tests/database/test_result_cache.cpp
@@ -1,12 +1,20 @@
-#include <gtest/gtest.h>
 #include "database/result_cache.h"
+
+#include <deque>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
 
 namespace velocitydb {
 namespace test {
 
 namespace {
 
+// ResultRow::values は string_view なので、本体の std::string を arena に保持し
+// ResultSet::storage 経由で寿命を一致させる (#553 partial fix で導入された契約)。
 ResultSet makeResultSet(int numRows, int numCols) {
+    auto arena = std::make_shared<std::deque<std::string>>();
     ResultSet rs;
     rs.columns.reserve(static_cast<size_t>(numCols));
     for (int c = 0; c < numCols; ++c) {
@@ -18,12 +26,14 @@ ResultSet makeResultSet(int numRows, int numCols) {
         row.values.reserve(static_cast<size_t>(numCols));
         row.nullFlags.reserve(static_cast<size_t>(numCols));
         for (int c = 0; c < numCols; ++c) {
-            row.values.push_back("val_" + std::to_string(r) + "_" + std::to_string(c));
+            arena->emplace_back("val_" + std::to_string(r) + "_" + std::to_string(c));
+            row.values.push_back(arena->back());
             row.nullFlags.push_back(false);
         }
         rs.rows.push_back(std::move(row));
     }
     rs.affectedRows = numRows;
+    rs.storage = arena;
     return rs;
 }
 
@@ -160,9 +170,7 @@ TEST_F(ResultCacheTest, PutMovesRvalueResultSet) {
 TEST_F(ResultCacheTest, GetAndApplyExecutesCallbackUnderLock) {
     cache.put("ref", makeResultSet(2, 2));
 
-    auto result = cache.getAndApply("ref", [](const ResultSet& r) {
-        return std::string(r.rows[0].values[0]);
-    });
+    auto result = cache.getAndApply("ref", [](const ResultSet& r) { return std::string(r.rows[0].values[0]); });
     EXPECT_EQ(result, "val_0_0");
 }
 

--- a/tests/search/test_simd_filter.cpp
+++ b/tests/search/test_simd_filter.cpp
@@ -7,37 +7,39 @@
 
 #include "search/simd_filter.h"
 
-#include <gtest/gtest.h>
-
+#include <deque>
+#include <memory>
 #include <string>
+
+#include <gtest/gtest.h>
 
 namespace velocitydb {
 namespace test {
 
-namespace {
-
-ResultRow makeRow(std::initializer_list<std::string> values) {
-    ResultRow row;
-    for (const auto& v : values) {
-        row.values.push_back(v);
-        row.nullFlags.push_back(false);
-    }
-    return row;
-}
-
-ResultRow makeRowWithNull(size_t nullIndex, std::initializer_list<std::string> values) {
-    auto row = makeRow(values);
-    if (nullIndex < row.nullFlags.size()) {
-        row.nullFlags[nullIndex] = true;
-    }
-    return row;
-}
-
-}  // namespace
-
+// ResultRow::values は string_view なので、本体の std::string を fixture の
+// arena に保持して寿命を保証する (#553 partial fix で導入された契約)。
 class SIMDFilterTest : public ::testing::Test {
 protected:
     SIMDFilter filter;
+    std::shared_ptr<std::deque<std::string>> arena = std::make_shared<std::deque<std::string>>();
+
+    ResultRow makeRow(std::initializer_list<std::string> values) {
+        ResultRow row;
+        for (const auto& v : values) {
+            arena->emplace_back(v);
+            row.values.push_back(arena->back());
+            row.nullFlags.push_back(false);
+        }
+        return row;
+    }
+
+    ResultRow makeRowWithNull(size_t nullIndex, std::initializer_list<std::string> values) {
+        auto row = makeRow(values);
+        if (nullIndex < row.nullFlags.size()) {
+            row.nullFlags[nullIndex] = true;
+        }
+        return row;
+    }
 };
 
 TEST_F(SIMDFilterTest, FilterEquals_MatchesExactValues) {


### PR DESCRIPTION
#553 partial fix (#578) で ResultRow.values が vector<string_view> 化された後、テストヘルパが一時 `std::string` への `dangling view` を作っていたため、
CI で SIMDFilter 4 件 + ResultCache 2 件が失敗していた。

production driver (postgresql/sqlserver) は既に ResultSet::storage に `arena/PGresult` を attach しており contract は満たしていたが、テストが storage 機構を無視して裸の ResultSet を組み立てていた。

- test_result_cache: `makeResultSet` 内で `shared_ptr<deque<string>> arena` を作り `rs.storage` に格納。view は arena の安定 pointer を指す
- test_simd_filter: fixture (SIMDFilterTest) に arena を持たせ `makeRow/ makeRowWithNull` を class メンバ化。fixture が test 終了まで arena 所有

ctest -LE perf で 395/395 pass (CI 失敗 6 件全消)。