### PR TITLE
feat(perf): pg/mssql で env-gated profiler を DRY 化、mssql 版を追加

### DIFF
--- a/backend/database/postgresql_driver.cpp
+++ b/backend/database/postgresql_driver.cpp
@@ -1,12 +1,11 @@
 #include "postgresql_driver.h"
 
-#include "../utils/logger.h"
 #include "copy_from_stdin_handler.h"
 #include "pg_result_ptr.h"
+#include "profile_gate.h"
 
 #include <charconv>
 #include <chrono>
-#include <cstdlib>
 #include <cstring>
 #include <format>
 #include <stdexcept>
@@ -14,23 +13,17 @@
 
 namespace velocitydb {
 
-namespace {
+/// Env var for the [pg-prof] gate. Kept resident so future SELECT-100万行
+/// perf regressions can be split into libpq-internal vs driver-loop time
+/// without rebuilding (see #579 close: binary protocol was infeasible
+/// because libpq fetch alone was 4.7s for the bench fixture, 5x text mode —
+/// the split needs to be re-checkable at any time). Lives in a named
+/// namespace (external linkage) so it can be passed as a template NTTP to
+/// profile::isEnabledOnce without relying on the C++20 P1907 relaxation
+/// for internal-linkage pointer NTTPs.
+inline constexpr char kPgProfileEnv[] = "VELOCITYDB_PG_PROFILE";
 
-/// Profile gate. Set the env var VELOCITYDB_PG_PROFILE=1 (or any non-empty,
-/// non-"0" value) to emit a "[pg-prof] fetch=Xms loop=Yms rows=N cols=M" line
-/// via the global logger for each text-mode query in execute(). Kept resident
-/// so future SELECT-100万行 perf regressions can be split into libpq-internal
-/// vs driver-loop time without rebuilding (see #579 close: binary protocol
-/// was infeasible because libpq fetch alone was 4.7s for the bench fixture,
-/// 5x text mode — the split needs to be re-checkable at any time). The gate
-/// is evaluated once on first call; default OFF keeps log output quiet.
-[[nodiscard]] bool isPgProfileEnabled() noexcept {
-    static const auto enabled = []() {
-        const auto* env = std::getenv("VELOCITYDB_PG_PROFILE");
-        return env != nullptr && env[0] != '\0' && env[0] != '0';
-    }();
-    return enabled;
-}
+namespace {
 
 /// Convert PostgreSQL OID to human-readable type name. Returns string_view
 /// into a static literal for known OIDs (no allocation); the caller copies
@@ -249,10 +242,10 @@ ResultSet PostgreSqlDriver::execute(std::string_view sql) {
         }
         const auto loopEnd = std::chrono::steady_clock::now();
 
-        if (isPgProfileEnabled()) [[unlikely]] {
+        if (profile::isEnabledOnce<kPgProfileEnv>()) [[unlikely]] {
             const auto fetchMs = std::chrono::duration_cast<std::chrono::milliseconds>(fetchEnd - fetchStart).count();
             const auto loopMs = std::chrono::duration_cast<std::chrono::milliseconds>(loopEnd - loopStart).count();
-            get_logger().log<LogLevel::INFO>(std::format("[pg-prof] fetch={}ms loop={}ms rows={} cols={}", fetchMs, loopMs, numRows, numCols));
+            profile::emit("[pg-prof] fetch={}ms loop={}ms rows={} cols={}", fetchMs, loopMs, numRows, numCols);
         }
 
         result.affectedRows = numRows;

--- a/backend/database/profile_gate.h
+++ b/backend/database/profile_gate.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "../utils/logger.h"
+
+#include <cstdlib>
+#include <format>
+#include <utility>
+
+namespace velocitydb::profile {
+
+/// Resolve an env-gated boolean flag, evaluated **once per (EnvName, process)**.
+/// Default OFF: returns false unless the variable is set to a non-empty,
+/// non-"0" value. EnvName must be a NUL-terminated string literal with
+/// external linkage — passing it as a template parameter materializes a
+/// dedicated static cache at each instantiation site, so the hot path is
+/// just a load of an already-resolved bool (no getenv, no map lookup).
+template <const char* EnvName>
+[[nodiscard]] inline bool isEnabledOnce() noexcept {
+    static const auto enabled = []() {
+        const auto* env = std::getenv(EnvName);
+        return env != nullptr && env[0] != '\0' && env[0] != '0';
+    }();
+    return enabled;
+}
+
+/// Format and emit one INFO log line, swallowing format/log exceptions.
+/// Profiling is observational: a 1M-row query that survived the hot loop
+/// must not fail because the profile-line allocation failed. The format
+/// call lives inside the try block since std::format itself can throw
+/// (bad_alloc / format_error).
+template <typename... Args>
+inline void emit(std::format_string<Args...> fmt, Args&&... args) noexcept {
+    try {
+        get_logger().log<LogLevel::INFO>(std::format(fmt, std::forward<Args>(args)...));
+    } catch (...) {
+        // swallow: profiler is observational, never load-bearing
+    }
+}
+
+}  // namespace velocitydb::profile

--- a/backend/database/sqlserver_driver.cpp
+++ b/backend/database/sqlserver_driver.cpp
@@ -1,11 +1,13 @@
 #include "sqlserver_driver.h"
 
 #include "odbc_helpers.h"
+#include "profile_gate.h"
 
 #include <algorithm>
 #include <array>
 #include <chrono>
 #include <deque>
+#include <format>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -13,6 +15,14 @@
 #include <vector>
 
 namespace velocitydb {
+
+/// Env var for the [mssql-prof] gate. SQL Server counterpart of [pg-prof]
+/// (#583) so #553 follow-up perf work can split ODBC-internal (SQLExecDirectW
+/// returning all rows) vs driver loop (SQLFetch + SQLGetData + UTF-16→UTF-8)
+/// time without rebuilding. Lives in a named namespace (external linkage)
+/// so it can be passed as a template NTTP to profile::isEnabledOnce without
+/// relying on the C++20 P1907 relaxation for internal-linkage pointer NTTPs.
+inline constexpr char kMssqlProfileEnv[] = "VELOCITYDB_MSSQL_PROFILE";
 
 SQLServerDriver::SQLServerDriver() {
     m_env = odbc::allocateEnvironment();
@@ -101,7 +111,9 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
     SQLSetStmtAttr(stmt, SQL_ATTR_QUERY_TIMEOUT, toSqlPointer(queryTimeout), 0);
 
     auto wideSql = utf8ToWide(sql);
+    const auto execStart = std::chrono::steady_clock::now();
     ret = SQLExecDirectW(stmt, toSqlWchar(wideSql.data()), SQL_NTS);
+    const auto execEnd = std::chrono::steady_clock::now();
     if (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO && ret != SQL_NO_DATA) [[unlikely]] {
         m_lastError = odbc::getDiagnosticMessage(ret, SQL_HANDLE_STMT, stmt);
         throw std::runtime_error(m_lastError);
@@ -159,6 +171,7 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
         row.nullFlags.push_back(false);
     };
 
+    const auto loopStart = std::chrono::steady_clock::now();
     while ((ret = SQLFetch(stmt)) == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
         ResultRow row;
         row.values.reserve(static_cast<size_t>(numCols));
@@ -193,6 +206,13 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
             }
         }
         result.rows.push_back(std::move(row));
+    }
+    const auto loopEnd = std::chrono::steady_clock::now();
+
+    if (profile::isEnabledOnce<kMssqlProfileEnv>()) [[unlikely]] {
+        const auto execMs = std::chrono::duration_cast<std::chrono::milliseconds>(execEnd - execStart).count();
+        const auto loopMs = std::chrono::duration_cast<std::chrono::milliseconds>(loopEnd - loopStart).count();
+        profile::emit("[mssql-prof] exec={}ms loop={}ms rows={} cols={}", execMs, loopMs, result.rows.size(), numCols);
     }
 
     // Hand arena ownership to the ResultSet so the string_views above stay


### PR DESCRIPTION
- backend/database/profile_gate.h を新設 (isEnabledOnce<EnvName> / emit)
- pg/mssql driver を helper に置換、mssql は [mssql-prof] 出力を新規追加
- env: VELOCITYDB_MSSQL_PROFILE で SQLExecDirectW vs SQLFetch ループを分配計測
- #553 SQL Server サブ向け計測手段 (#583 [pg-prof] の対称設計)