### PR TITLE
perf(mssql): SQLGetData NUL 終端探索を indicator ベース O(1) 算出に置換 (#589)

### DIFF
--- a/backend/database/odbc_unicode.h
+++ b/backend/database/odbc_unicode.h
@@ -24,6 +24,20 @@ inline std::string sqlWcharToUtf8(const SQLWCHAR* buf, size_t len) {
     return wideToUtf8(toWchar(buf), len);
 }
 
+/// Convert an ODBC `SQLGetData(SQL_C_WCHAR)` indicator (bytes, exclusive of
+/// NUL terminator per the Microsoft ODBC spec) into a WCHAR count. Returns 0
+/// for sentinel codes such as SQL_NULL_DATA / SQL_NO_TOTAL so callers can
+/// treat negative indicators as "no payload" without an extra branch.
+///
+/// Used by SQLServerDriver to skip the O(buffer_size) NUL-terminator scan on
+/// every fetched cell — see issue #589.
+[[nodiscard]] inline size_t wcharCountFromIndicator(SQLLEN indicatorBytes) noexcept {
+    if (indicatorBytes <= 0) {
+        return 0;
+    }
+    return static_cast<size_t>(indicatorBytes) / sizeof(SQLWCHAR);
+}
+
 // UTF-8 string → std::wstring, ready for ODBC W APIs via toSqlWchar(result.data())
 using ::velocitydb::utf8ToWide;
 

--- a/backend/database/sqlserver_driver.cpp
+++ b/backend/database/sqlserver_driver.cpp
@@ -179,26 +179,40 @@ ResultSet SQLServerDriver::execute(std::string_view sql) {
 
         for (SQLSMALLINT i = 1; i <= numCols; ++i) {
             ret = SQLGetData(stmt, i, SQL_C_WCHAR, buffer.data(), buffer.size() * sizeof(SQLWCHAR), &indicator);
-            if (indicator == SQL_NULL_DATA) {
+            if (indicator == SQL_NULL_DATA || indicator == SQL_NO_TOTAL) {
+                // SQL_NO_TOTAL: driver cannot report data length (rare;
+                // typically max-size LOB without length metadata). Emit
+                // NULL rather than fabricating an empty string from the
+                // pre-NUL prefix of `buffer`, which would lose the
+                // "length unknown" signal once the NUL-scan was removed.
                 row.values.emplace_back();
                 row.nullFlags.push_back(true);
             } else if (ret == SQL_SUCCESS_WITH_INFO && indicator > static_cast<SQLLEN>((buffer.size() - 1) * sizeof(SQLWCHAR))) {
-                size_t requiredChars = (static_cast<size_t>(indicator) / sizeof(SQLWCHAR)) + 1;
-                std::vector<SQLWCHAR> largeBuffer(requiredChars);
-                size_t alreadyReadChars = buffer.size() - 1;
+                // Truncation path: the first call wrote (buffer.size() - 1)
+                // WCHARs plus a NUL; `indicator` holds the FULL payload
+                // length in bytes (NUL excluded) per ODBC SQLGetData spec.
+                // Use it to size the spill buffer in O(1) — no NUL scan.
+                const size_t totalChars = wcharCountFromIndicator(indicator);
+                std::vector<SQLWCHAR> largeBuffer(totalChars + 1);  // +1 for ODBC-written NUL
+                const size_t alreadyReadChars = buffer.size() - 1;
                 std::copy(buffer.begin(), buffer.begin() + static_cast<ptrdiff_t>(alreadyReadChars), largeBuffer.begin());
                 SQLLEN remainingIndicator = 0;
-                ret = SQLGetData(stmt, i, SQL_C_WCHAR, largeBuffer.data() + alreadyReadChars, (requiredChars - alreadyReadChars) * sizeof(SQLWCHAR), &remainingIndicator);
-                size_t strLen = 0;
-                for (size_t j = 0; j < largeBuffer.size() && largeBuffer[j] != 0; ++j) {
-                    strLen = j + 1;
+                ret = SQLGetData(stmt, i, SQL_C_WCHAR, largeBuffer.data() + alreadyReadChars, (largeBuffer.size() - alreadyReadChars) * sizeof(SQLWCHAR), &remainingIndicator);
+                if (ret != SQL_SUCCESS && ret != SQL_SUCCESS_WITH_INFO) [[unlikely]] {
+                    // Spill fetch failed mid-cell: without the NUL-scan
+                    // guard we would otherwise hand `totalChars` of partly
+                    // uninitialised data to the UTF-8 converter. Treat as
+                    // NULL so the row stays consistent.
+                    row.values.emplace_back();
+                    row.nullFlags.push_back(true);
+                } else {
+                    pushCell(sqlWcharToUtf8(largeBuffer.data(), totalChars), row);
                 }
-                pushCell(sqlWcharToUtf8(largeBuffer.data(), strLen), row);
             } else if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
-                size_t strLen = 0;
-                for (size_t j = 0; j < buffer.size() && buffer[j] != 0; ++j) {
-                    strLen = j + 1;
-                }
+                // Normal path: `indicator` is the payload length in bytes
+                // (NUL excluded). Replaces the per-cell NUL-scan loop that
+                // dominated the SELECT 100万行 fetch loop — see issue #589.
+                const size_t strLen = wcharCountFromIndicator(indicator);
                 pushCell(sqlWcharToUtf8(buffer.data(), strLen), row);
             } else {
                 row.values.emplace_back();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ FetchContent_MakeAvailable(googletest)
 set(TEST_SOURCES
     test_main.cpp
     database/test_sqlserver_driver.cpp
+    database/test_odbc_unicode.cpp
     database/test_query_history.cpp
     database/test_sql_builder.cpp
     database/test_transaction_manager.cpp

--- a/tests/database/test_odbc_unicode.cpp
+++ b/tests/database/test_odbc_unicode.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include "database/odbc_unicode.h"
+
+#include <sqlext.h>  // SQL_NO_TOTAL (not in <sql.h>)
+
+namespace velocitydb {
+namespace test {
+
+// ODBC `SQLGetData(SQL_C_WCHAR, ..., &indicator)` returns the length of the
+// data available **in bytes, exclusive of any NUL terminator** (Microsoft
+// Learn: SQLGetData Function). `wcharCountFromIndicator` converts that byte
+// count to a WCHAR count so the SQL Server driver can size strings in O(1)
+// instead of scanning the buffer for a NUL terminator (issue #589).
+
+TEST(WcharCountFromIndicator, ZeroBytesIsEmptyString) {
+    EXPECT_EQ(wcharCountFromIndicator(0), 0u);
+}
+
+TEST(WcharCountFromIndicator, NegativeIsTreatedAsEmpty) {
+    // SQL_NULL_DATA (-1) and SQL_NO_TOTAL (-4) reach this helper only if a
+    // caller forgets to short-circuit them. Returning 0 keeps callers from
+    // treating sentinel codes as huge unsigned counts.
+    EXPECT_EQ(wcharCountFromIndicator(SQL_NULL_DATA), 0u);
+    EXPECT_EQ(wcharCountFromIndicator(SQL_NO_TOTAL), 0u);
+    EXPECT_EQ(wcharCountFromIndicator(-1), 0u);
+}
+
+TEST(WcharCountFromIndicator, BytesDividedBySqlWcharSize) {
+    static_assert(sizeof(SQLWCHAR) == 2, "test assumes 2-byte SQLWCHAR on Windows");
+    EXPECT_EQ(wcharCountFromIndicator(2), 1u);          // 1 WCHAR
+    EXPECT_EQ(wcharCountFromIndicator(10), 5u);         // "Hello" length
+    EXPECT_EQ(wcharCountFromIndicator(8190), 4095u);    // initial-buffer edge
+}
+
+TEST(WcharCountFromIndicator, LargeIndicatorForOneMillionRowsScenario) {
+    // A varchar(max) column returning a 1MB payload would yield indicator =
+    // 1'000'000 bytes; the helper must not overflow or truncate inadvertently.
+    EXPECT_EQ(wcharCountFromIndicator(1'000'000), 500'000u);
+}
+
+}  // namespace test
+}  // namespace velocitydb


### PR DESCRIPTION
Closes #589