### PR TITLE
feat(perf): 計測 hook に startup / er-diagram-50 を追加 (#494)

### DIFF
--- a/docs/PERFORMANCE_VALIDATION.md
+++ b/docs/PERFORMANCE_VALIDATION.md
@@ -198,13 +198,18 @@ uv run scripts/pdg.py test backend
 
 ### 計測対象と計測機構
 
-| 対象 | ファイル | 計測 mark 名 |
-| ---- | -------- | ------------ |
-| ResultGrid | `frontend/src/components/grid/ResultGrid.tsx` | `result-grid` |
-| ObjectTree | `frontend/src/components/tree/ObjectTree.tsx` | `object-tree` |
-| SqlEditor (Monaco) | `frontend/src/components/editor/SqlEditor.tsx` | `sql-editor` |
+| 対象 | ファイル | 計測 mark 名 | 対応 README 目標 |
+| ---- | -------- | ------------ | ---------------- |
+| App ルート | `frontend/src/App.tsx` | `startup` | #1 起動 < 0.3s |
+| ResultGrid | `frontend/src/components/grid/ResultGrid.tsx` | `result-grid` | #4 結果表示開始 < 100ms |
+| ObjectTree | `frontend/src/components/tree/ObjectTree.tsx` | `object-tree` | — |
+| SqlEditor (Monaco) | `frontend/src/components/editor/SqlEditor.tsx` | `sql-editor` | — |
+| ERDiagram (50 テーブル以上) | `frontend/src/components/diagram/ERDiagram.tsx` | `er-diagram-50` | #9 ER 図 50 テーブル < 500ms (spec は #9 サブ issue で追加) |
 
 各コンポーネントは `useFirstRenderMark` (`frontend/src/utils/perfMarks.ts`) で初回マウントの `${name}:start` / `${name}:end` mark を打ち、`${name}` の measure entry を Performance API に記録する。再レンダリングでは記録しない (初回マウントのみ)。
+
+- `useStartupMark()` は `useFirstRenderMark('startup')` のラッパー (App ルート専用)。
+- `useERDiagramRenderMark(tableCount, threshold=50)` は `tableCount` が `threshold` 以上に達した最初のレンダリング時のみ mark を打つ条件付き hook。閾値未達の ER 図 (例: 49 テーブル) では mark が記録されない仕様。
 
 ### 初回レンダリング時間の取得手順
 
@@ -226,9 +231,22 @@ uv run scripts/pdg.py test backend
 
 ```js
 performance.getEntriesByType('measure')
-  .filter(e => ['result-grid', 'object-tree', 'sql-editor'].includes(e.name))
+  .filter(e => ['startup', 'result-grid', 'object-tree', 'sql-editor', 'er-diagram-50'].includes(e.name))
   .map(e => ({ name: e.name, duration_ms: e.duration.toFixed(2) }));
 ```
+
+### Docker 経由の Playwright 自動取得
+
+`frontend/e2e/perf-baseline.spec.ts` は dev server (Vite) で `startup` / `result-grid` / `object-tree` / `sql-editor` の 4 mark を取得し、`[#494 baseline] <JSON>` 形式で stdout に出力する。WebView2 / production preview とは値が一致しない (Vite の HMR + source map を含むため) が、リグレッション検出の基準値として使用できる。
+
+```bash
+docker run --rm -v "C:/prog/Velocity-DB://app" \
+  --mount "type=volume,target=//app/frontend/node_modules" \
+  -w "//app/frontend" oven/bun:latest \
+  sh -c 'bun install && bunx playwright install --with-deps chromium && bunx playwright test perf-baseline'
+```
+
+`er-diagram-50` (#9) はフィクスチャ (50 テーブル以上の ER 図ファイル) が別タスクのため、本 spec では取得しない。実機で ER 図ファイルを読み込んだ後、上記の DevTools Console コマンドで取得する。
 
 ### bundle サイズレポートの取得手順
 
@@ -251,10 +269,15 @@ Remove-Item Env:VELOCITYDB_BUNDLE_REPORT
 
 | 対象 | 計測条件 | duration (ms) | 計測日 | 環境 |
 | ---- | -------- | ------------- | ------ | ---- |
+| startup (App) | `page.goto('/')` 直後 | TBD | YYYY-MM-DD | TBD |
+| ResultGrid | 空配列 (mock invoke) | TBD | YYYY-MM-DD | TBD |
 | ResultGrid | 1000 行 × 10 列 | TBD | YYYY-MM-DD | TBD |
 | ResultGrid | 10000 行 × 10 列 | TBD | YYYY-MM-DD | TBD |
 | ObjectTree | 接続プロファイル 1 件展開 (テーブル 50 件) | TBD | YYYY-MM-DD | TBD |
 | SqlEditor | 新規タブ初期化 | TBD | YYYY-MM-DD | TBD |
+| ERDiagram (50 テーブル) | サンプル A5:ER ファイル読込 | TBD | YYYY-MM-DD | TBD |
+
+> 上記表のうち `startup` / `ResultGrid 空配列` / `ObjectTree` / `SqlEditor` は `frontend/e2e/perf-baseline.spec.ts` で自動取得可。`ResultGrid 1000/10000 行` と `ERDiagram 50 テーブル` はフィクスチャ不在のため別タスク (#501 / 新規 #9 サブ issue 想定)。
 
 #### bundle 構成
 

--- a/frontend/e2e/perf-baseline.spec.ts
+++ b/frontend/e2e/perf-baseline.spec.ts
@@ -27,10 +27,17 @@ const MOCK_INVOKE_SCRIPT = `
   };
 `;
 
-const TARGETS = ['result-grid', 'object-tree', 'sql-editor'] as const;
+/**
+ * `startup` は App ルート (`frontend/src/App.tsx`) 初回マウント時に
+ * `useStartupMark()` が打つ measure。README #1 (起動 < 0.3s) ベースライン用。
+ *
+ * `er-diagram-50` (README #9) は 50 テーブル以上のフィクスチャ用意が
+ * 別タスクのため本 spec では取得しない。
+ */
+const TARGETS = ['startup', 'result-grid', 'object-tree', 'sql-editor'] as const;
 
 test.describe('#494 perf baseline', () => {
-  test('useFirstRenderMark の duration を 3 画面で取得', async ({ page }) => {
+  test('useFirstRenderMark の duration を 4 mark で取得', async ({ page }) => {
     await page.addInitScript(MOCK_INVOKE_SCRIPT);
     await page.goto('/');
     await page.waitForLoadState('networkidle');

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,8 +5,11 @@ import { MainLayout } from './components/layout/MainLayout';
 import { useSuppressNativeSelectAll } from './hooks/useSuppressNativeSelectAll';
 import { useConnectionStore } from './store/connectionStore';
 import { useQueryStore } from './store/queryStore';
+import { useStartupMark } from './utils/perfMarks';
 
 function App() {
+  useStartupMark();
+
   const activeQueryConnectionId = useQueryStore((state) => {
     const query = state.queries.find((q) => q.id === state.activeQueryId);
     return query?.connectionId ?? null;

--- a/frontend/src/components/diagram/ERDiagram.tsx
+++ b/frontend/src/components/diagram/ERDiagram.tsx
@@ -16,6 +16,7 @@ import { useERDiagramContext } from '../../hooks/useERDiagramContext';
 import { useERDiagramStore } from '../../store/erDiagramStore';
 import type { ERRelationEdge, ERShapeNode, ERTableNode } from '../../types';
 import { ALL_PAGES, DEFAULT_PAGE, GRID_LAYOUT } from '../../utils/erDiagramConstants';
+import { useERDiagramRenderMark } from '../../utils/perfMarks';
 import styles from './ERDiagram.module.css';
 import { ERDiagramSearch } from './ERDiagramSearch';
 import { ShapeNode } from './ShapeNode';
@@ -278,6 +279,8 @@ export function ERDiagram({ onTableClick, onOpenImportDialog }: ERDiagramProps) 
 
   const allTables = useERDiagramStore((s) => s.tables);
   const hasData = totalTableCount > 0;
+
+  useERDiagramRenderMark(totalTableCount);
 
   // 「すべて」タブ時はグリッド再配置（ページ間で座標が重複するため）
   const layoutTables = useMemo(

--- a/frontend/src/tests/utils/perfMarks.test.ts
+++ b/frontend/src/tests/utils/perfMarks.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { useFirstRenderMark } from '../../utils/perfMarks';
+import { useERDiagramRenderMark, useFirstRenderMark, useStartupMark } from '../../utils/perfMarks';
 
 describe('useFirstRenderMark', () => {
   afterEach(() => {
@@ -44,5 +44,75 @@ describe('useFirstRenderMark', () => {
 
     const measures = performance.getEntriesByName('manual-target', 'measure');
     expect(measures.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('useStartupMark', () => {
+  afterEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  it('records a startup measure on mount', () => {
+    renderHook(() => useStartupMark());
+
+    const measures = performance.getEntriesByName('startup', 'measure');
+    expect(measures).toHaveLength(1);
+  });
+});
+
+describe('useERDiagramRenderMark', () => {
+  afterEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
+
+  it('records start/end marks and a measure once threshold is reached', () => {
+    const { rerender } = renderHook(({ count }) => useERDiagramRenderMark(count), {
+      initialProps: { count: 0 },
+    });
+
+    expect(performance.getEntriesByName('er-diagram-50:start', 'mark')).toHaveLength(0);
+    expect(performance.getEntriesByName('er-diagram-50', 'measure')).toHaveLength(0);
+
+    rerender({ count: 50 });
+
+    expect(performance.getEntriesByName('er-diagram-50:start', 'mark')).toHaveLength(1);
+    expect(performance.getEntriesByName('er-diagram-50:end', 'mark')).toHaveLength(1);
+    expect(performance.getEntriesByName('er-diagram-50', 'measure')).toHaveLength(1);
+  });
+
+  it('does not record additional measures on subsequent renders above threshold', () => {
+    const { rerender } = renderHook(({ count }) => useERDiagramRenderMark(count), {
+      initialProps: { count: 60 },
+    });
+
+    rerender({ count: 70 });
+    rerender({ count: 80 });
+
+    expect(performance.getEntriesByName('er-diagram-50', 'measure')).toHaveLength(1);
+  });
+
+  it('does not record any measure when count stays below threshold', () => {
+    const { rerender } = renderHook(({ count }) => useERDiagramRenderMark(count), {
+      initialProps: { count: 10 },
+    });
+
+    rerender({ count: 49 });
+
+    expect(performance.getEntriesByName('er-diagram-50:start', 'mark')).toHaveLength(0);
+    expect(performance.getEntriesByName('er-diagram-50', 'measure')).toHaveLength(0);
+  });
+
+  it('honors a custom threshold parameter', () => {
+    const { rerender } = renderHook(({ count, t }) => useERDiagramRenderMark(count, t), {
+      initialProps: { count: 5, t: 10 },
+    });
+
+    expect(performance.getEntriesByName('er-diagram-10', 'measure')).toHaveLength(0);
+
+    rerender({ count: 10, t: 10 });
+
+    expect(performance.getEntriesByName('er-diagram-10', 'measure')).toHaveLength(1);
   });
 });

--- a/frontend/src/utils/perfMarks.ts
+++ b/frontend/src/utils/perfMarks.ts
@@ -25,3 +25,42 @@ export function useFirstRenderMark(target: string): void {
     performance.measure(target, `${target}:start`, `${target}:end`);
   }, []);
 }
+
+/**
+ * アプリ起動時刻 (App ルート初回マウント) を `startup` measure として記録する。
+ * README #1 (起動 < 0.3s) ベースライン計測用。
+ */
+export function useStartupMark(): void {
+  useFirstRenderMark('startup');
+}
+
+/**
+ * ER 図のテーブル数が閾値を満たした最初のレンダリングを measure として記録する。
+ * 閾値未達のレンダリングでは mark を打たず、達成した時点で start、その直後の effect で end と measure を記録する。
+ * README #9 (ER 図 50 テーブル < 500ms) ベースライン計測用。
+ */
+export function useERDiagramRenderMark(tableCount: number, threshold = 50): void {
+  const target = `er-diagram-${threshold}`;
+  const startMarked = useRef(false);
+  const measured = useRef(false);
+
+  if (!startMarked.current && tableCount >= threshold) {
+    performance.mark(`${target}:start`);
+    startMarked.current = true;
+  }
+
+  // Fire after every commit; the `measured` ref gates the body so end+measure run at most
+  // once. The threshold logic lives in the render-phase block above (which reads
+  // tableCount), so this effect intentionally has no deps — biome would flag [tableCount]
+  // as unused here.
+  useEffect(() => {
+    if (measured.current || !startMarked.current) return;
+
+    const hasStart = performance.getEntriesByName(`${target}:start`, 'mark').length > 0;
+    if (!hasStart) return;
+
+    measured.current = true;
+    performance.mark(`${target}:end`);
+    performance.measure(target, `${target}:start`, `${target}:end`);
+  });
+}


### PR DESCRIPTION
## Summary

#494 (Frontend 計測基盤整備) の残作業の一部として、README #1 / #9 (未カバー目標) のベースライン計測 hook を先行整備する。

- `useStartupMark()` — App ルート初回マウントを `startup` measure として記録 (README #1)
- `useERDiagramRenderMark(tableCount, threshold=50)` — ER 図テーブル数が閾値以上に達した最初のレンダリングを `er-diagram-50` measure として記録 (README #9)
- `frontend/e2e/perf-baseline.spec.ts` TARGETS に `startup` 追加 (3→4 mark)
- `docs/PERFORMANCE_VALIDATION.md` に計測対象表 / Docker Playwright 実行手順 / ベースライン表 3 行を追記

## Why

#479 親 issue 本文の「STL/constexpr 多用で線形時間に」は推測ベース (`optimize` skill 違反) のため踏み込まない方針。代わりに既存
#494/#508 計測基盤ブロッカー構造を尊重し、ベースライン取得点の **追加** に集中する。

- `useERDiagramRenderMark` は render-phase で閾値判定して条件付き start mark を打つ構造。ER 図は外部データロードで 0→N 変動するため `useFirstRenderMark` 方式 (完全初回マウント) では閾値達成タイミングを捕捉できない。`measured` ref で多重 measure を防ぐ。
- `er-diagram-50` 取得 spec はフィクスチャ準備が別タスクのため本 PR では追加せず、README #9 用の新規サブ issue で対応 (本 PR説明後にユーザー側で `gh issue create`)。

## 方針検証

- `premise-questioning`: ✅ 採用 (簡易) — `.claude/progress.md` 判断ログ参照
- `feature-pruning`: skipped (理由: 計測点追加のみ、機能粒度の棚卸し対象外)

## Test plan

- [x] biome check (5 ファイル) PASS
- [x] Vitest `perfMarks.test.ts` 8 件 PASS (新規 5 件 + 既存 3 件)
- [ ] Playwright `perf-baseline.spec.ts` を実機 / CI で 1 回実行し `[#494 baseline]` annotation を確認 (Docker 環境ではPlaywright 1.58.2 + bun の preflight 問題で起動失敗、CI 必須)
- [ ] WebView2 production で DevTools Console から各 measure の duration を取得し `docs/PERFORMANCE_VALIDATION.md` の TBD を埋める(別タスク)

## 関連

- 親: #479 (パフォーマンスリファクタ親 / 中間親 #495)
- 直接: #494 (Frontend 計測基盤)
- 後続 (新規 issue 化予定): #1 起動時間 / #9 ER 図 50 テーブル — 本 PR で hook を先行整備済
- 未実施 (別タスク): #2 / #6 / #8 (backend、新規 issue 化予定)
