### PR TITLE
feat(perf): SQL formatter ベンチ追加、#6 達成判定 ✅ (#595)

### DIFF
--- a/docs/PERFORMANCE_VALIDATION.md
+++ b/docs/PERFORMANCE_VALIDATION.md
@@ -16,7 +16,7 @@
 | 3 | SELECT (100万行) < 500ms | ✅ | ✅ | ❌ | 🔍 未実測 |
 | 4 | 結果表示開始 < 100ms | ✅ | ✅ | ⚠️ 部分 | 🔍 未実測 |
 | 5 | 仮想スクロール 60fps | ✅ | ❌ | ⚠️ 部分 | 🔍 未実測 |
-| 6 | SQL フォーマット < 50ms | ✅ | ❌ | ❌ | 🔍 未実測 |
+| 6 | SQL フォーマット < 50ms | ✅ | ✅ | ✅ | ✅ 中 1ms / 大 40ms |
 | 7 | CSV エクスポート (10万行) < 2s | ✅ | ✅ | ✅ | 🔍 未実測 |
 | 8 | A5:ER ロード (100テーブル) < 1s | ✅ | ❌ | ❌ | 🔍 未実測 |
 | 9 | ER 図レンダリング (50テーブル) < 500ms | ✅ | ❌ | ❌ | 🔍 未実測 |
@@ -86,9 +86,11 @@
 | ------ | ------ |
 | 実装ファイル | `backend/parsers/sql_formatter.h:11-40`, `backend/parsers/sql_formatter.cpp` |
 | 実装手法 | `unordered_set` でキーワード判定 (O(1))、文字単位ストリーミングパース |
-| 計測機構 | なし |
-| 計測手段 | `tests/parsers/test_sql_formatter.cpp` に `std::chrono::steady_clock` ベースの計測アサートを追加 |
-| 達成判定 | **未実測**。ローカル実測が容易な項目 |
+| 計測機構 | あり (`tests/perf/test_sql_formatter_bench.cpp`) |
+| 既存ベンチマーク | `tests/perf/test_sql_formatter_bench.cpp` (小 JOIN-heavy / 中 500 行 / 大 10000 行、5 反復で mean/median/max を出力) で中サイズ mean < 50ms を `EXPECT_LT` |
+| 計測手段 | `ctest --preset release -L perf` で実行 |
+| 達成判定 | **✅ 達成**。中サイズ (500 行 / 40KB) で mean=1ms、大 (10000 行 / 826KB) で mean=40ms (target 50ms 圏内、2026-05-15 ローカル Release) |
+| ベースライン値 (2026-05-15) | 小 JOIN-heavy (3648 chars): mean=0ms / median=0ms / max=0ms<br>中 500行 (40219 chars): mean=1ms / median=1ms / max=2ms<br>大 10000行 (826769 chars): mean=40ms / median=41ms / max=41ms |
 
 ### #7. CSV エクスポート (10万行) < 2s
 
@@ -182,7 +184,7 @@ uv run scripts/pdg.py test backend
 1. **ベンチマークテスト群の追加** (別 issue / PR)
    - ✅ バックエンド基盤: `tests/perf/` 新設、`VelocityDBPerfTests` 実行ファイル、`perf` ctest ラベル (#425)
    - ✅ `scripts/pdg.py` に `bench` サブコマンド (`pdg bench backend` で `ctest -L perf`)
-   - 🔍 個別目標 (#3 SELECT / #6 SQL フォーマット / #10 履歴検索 / #11 SIMD) の計測テスト追加は別 PR
+   - 🔍 個別目標 (#3 SELECT / #11 SIMD) の計測テスト追加は別 PR (#6 #10 は対応済)
    - 🔍 フロントエンド: Vitest での `performance.now()` ベース計測 + Playwright での E2E 計測 (未着手)
 2. **CI への組み込み**
    - ✅ 通常テスト workflow (`ci.yml` / `test.yml`) は `ctest -LE perf` で perf を除外

--- a/tests/perf/CMakeLists.txt
+++ b/tests/perf/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PERF_TEST_SOURCES
     test_simd_filter_bench.cpp
     test_csv_exporter_bench.cpp
     test_result_cache_bench.cpp
+    test_sql_formatter_bench.cpp
     integration/test_select_million_rows_bench.cpp
 )
 

--- a/tests/perf/test_sql_formatter_bench.cpp
+++ b/tests/perf/test_sql_formatter_bench.cpp
@@ -1,0 +1,125 @@
+// PERFORMANCE_VALIDATION.md #6: SQLFormatter target — 中サイズで mean < 50ms。
+//
+// SQLFormatter は unordered_set ベースのキーワード判定 (O(1)) + 文字単位
+// ストリーミングパースで、入力長 N に対し O(N) で動作する想定。小 (JOIN-heavy
+// 短文) / 中 (500 行) / 大 (10000 行) の 3 段階で計測し、中サイズの mean を
+// 50ms target で assert する。
+//
+// 計測は 5 反復 → mean / median / max を出力。Plan は「平均・p95」だが、5
+// サンプルでは percentile が安定しないため median + max (worst case) に置換。
+// max は冷キャッシュ初回 + 外れ値検出用。中サイズの mean のみ assert し、
+// 小/大は情報出力のみ (大は非線形リグレッション検出のためのウォッチ枠)。
+
+#include "parsers/sql_formatter.h"
+
+#include <algorithm>
+#include <chrono>
+#include <format>
+#include <iostream>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace velocitydb {
+namespace {
+
+constexpr size_t kRepeatCount = 5;
+constexpr auto FORMAT_TARGET = std::chrono::milliseconds(50);
+
+// 1 unit SELECT を unitCount 回 UNION ALL で連結し長い SQL を生成。各 unit に
+// キーワード / 識別子 / リテラルを含めて formatter の主要分岐を網羅する。
+[[nodiscard]] std::string buildLongSql(size_t unitCount) {
+    std::string sql;
+    sql.reserve(unitCount * 80);
+    for (size_t i = 0; i < unitCount; ++i) {
+        if (i > 0) sql.append(" UNION ALL ");
+        sql.append(std::format(
+            "SELECT id, name, value FROM tbl_{} WHERE id = {} AND name = 'row_{}'",
+            i % 100, i, i));
+    }
+    return sql;
+}
+
+// 100 行相当の JOIN-heavy SELECT (実用的な複合クエリの再現)。
+[[nodiscard]] std::string buildJoinHeavySql() {
+    std::string sql = "SELECT u.id, u.name, o.order_date, o.total, p.product_name, "
+                      "c.category_name, w.warehouse_code "
+                      "FROM users u "
+                      "JOIN orders o ON u.id = o.user_id "
+                      "LEFT JOIN order_items oi ON o.id = oi.order_id "
+                      "LEFT JOIN products p ON oi.product_id = p.id "
+                      "LEFT JOIN categories c ON p.category_id = c.id "
+                      "LEFT JOIN warehouses w ON p.warehouse_id = w.id "
+                      "WHERE ";
+    for (size_t i = 0; i < 100; ++i) {
+        if (i > 0) sql.append(" OR ");
+        sql.append(std::format("(u.id = {} AND o.total > {})", i, i * 10));
+    }
+    sql.append(" ORDER BY o.order_date DESC, u.name ASC");
+    return sql;
+}
+
+struct BenchStats {
+    std::chrono::milliseconds mean;
+    std::chrono::milliseconds median;
+    std::chrono::milliseconds max;
+};
+
+[[nodiscard]] BenchStats measureFormat(SQLFormatter& formatter, std::string_view sql) {
+    std::vector<std::chrono::milliseconds> samples;
+    samples.reserve(kRepeatCount);
+    for (size_t i = 0; i < kRepeatCount; ++i) {
+        const auto start = std::chrono::steady_clock::now();
+        const auto formatted = formatter.format(sql);
+        const auto elapsed = std::chrono::steady_clock::now() - start;
+        // 最適化で format() 呼び出しが除去されないよう結果を参照
+        (void)formatted.size();
+        samples.push_back(
+            std::chrono::duration_cast<std::chrono::milliseconds>(elapsed));
+    }
+    std::sort(samples.begin(), samples.end());
+    const auto sum = std::accumulate(samples.begin(), samples.end(),
+                                     std::chrono::milliseconds(0));
+    return {
+        sum / kRepeatCount,
+        samples[samples.size() / 2],
+        samples.back(),
+    };
+}
+
+void reportStats(std::string_view label, const BenchStats& s) {
+    std::cerr << std::format("[bench] SQLFormatter {}: mean={}ms median={}ms max={}ms\n",
+                             label, s.mean.count(), s.median.count(), s.max.count());
+}
+
+class SQLFormatterBench : public ::testing::Test {
+protected:
+    SQLFormatter formatter;
+};
+
+TEST_F(SQLFormatterBench, SmallJoinHeavyInformational) {
+    const auto sql = buildJoinHeavySql();
+    const auto stats = measureFormat(formatter, sql);
+    reportStats(std::format("small-join-heavy({} chars)", sql.size()), stats);
+}
+
+TEST_F(SQLFormatterBench, MediumUnder50ms) {
+    const auto sql = buildLongSql(500);
+    const auto stats = measureFormat(formatter, sql);
+    reportStats(std::format("medium-500lines({} chars)", sql.size()), stats);
+    EXPECT_LT(stats.mean, FORMAT_TARGET)
+        << "format(500 lines) mean=" << stats.mean.count() << "ms exceeded target "
+        << FORMAT_TARGET.count() << "ms";
+}
+
+TEST_F(SQLFormatterBench, LargeInformational) {
+    const auto sql = buildLongSql(10000);
+    const auto stats = measureFormat(formatter, sql);
+    reportStats(std::format("large-10000lines({} chars)", sql.size()), stats);
+}
+
+}  // namespace
+}  // namespace velocitydb


### PR DESCRIPTION
tests/perf/test_sql_formatter_bench.cpp を新規追加し、小 (JOIN-heavy ~3.6KB) / 中 (500行 ~40KB) / 大 (10000行 ~826KB) の 3 段階で 5 反復計測(mean/median/max)。
中サイズに EXPECT_LT(mean, 50ms) を設定し、PERFORMANCE_VALIDATION.md#6 行の達成判定を 🔍未実測 → ✅ に更新。

実測ベースライン (2026-05-15 ローカル Release):

- 小 (3648 chars): mean=0ms
- 中 (40219 chars): mean=1ms (target 50ms 大幅余裕)
- 大 (826769 chars): mean=40ms (target 50ms 圏内)

設計判断:

- 入力 SQL は UNION ALL 連結で生成 (`stored procedure` 構文は方言依存、`formatter` は方言中立のため)
- 統計は mean/median/max (5 サンプルでは p95 が不安定)
- 中のみ assert、小/大は情報出力 (大は非線形リグレッション watchdog)

Closes #595