### PR TITLE
perf(store): queries.find() の残存箇所を queriesById[id] に統一 + 整合性テスト追加 (#501)

### DIFF
--- a/frontend/src/store/query/helpers/queriesMap.ts
+++ b/frontend/src/store/query/helpers/queriesMap.ts
@@ -1,0 +1,9 @@
+import type { Query } from '../../../types';
+
+export function toQueriesById(queries: Query[]): Record<string, Query> {
+  const map: Record<string, Query> = {};
+  for (const q of queries) {
+    map[q.id] = q;
+  }
+  return map;
+}

--- a/frontend/src/store/query/queryStore.ts
+++ b/frontend/src/store/query/queryStore.ts
@@ -53,6 +53,7 @@ const abortAdapter: AbortRegistrable = {
 export const useQueryStore = create<QueryState>((set, get) => ({
   // Shared state
   queries: [],
+  queriesById: {},
   activeQueryId: null,
   results: {},
   executingQueryIds: new Set<string>(),
@@ -75,23 +76,16 @@ export const useQueryStore = create<QueryState>((set, get) => ({
 export const useQueries = () => useQueryStore(useShallow((state) => state.queries));
 
 export const useActiveQuery = () =>
-  useQueryStore((state) => {
-    const query = state.queries.find((q) => q.id === state.activeQueryId);
-    return query ?? null;
-  });
+  useQueryStore((state) => state.queriesById[state.activeQueryId ?? ''] ?? null);
 
 export const useIsActiveDataView = () =>
-  useQueryStore(
-    (state) => state.queries.find((q) => q.id === state.activeQueryId)?.isDataView === true
-  );
+  useQueryStore((state) => state.queriesById[state.activeQueryId ?? '']?.isDataView === true);
 
 export const useIsActiveERDiagram = () =>
-  useQueryStore(
-    (state) => state.queries.find((q) => q.id === state.activeQueryId)?.isERDiagram === true
-  );
+  useQueryStore((state) => state.queriesById[state.activeQueryId ?? '']?.isERDiagram === true);
 
 export const useQueryById = (queryId: string | null | undefined) =>
-  useQueryStore((state) => (queryId ? state.queries.find((q) => q.id === queryId) : undefined));
+  useQueryStore((state) => (queryId ? state.queriesById[queryId] : undefined));
 
 export const useQueryResult = (queryId: string | null | undefined) =>
   useQueryStore((state) => (queryId ? (state.results[queryId] ?? null) : null));

--- a/frontend/src/store/query/slices/dataViewSlice.ts
+++ b/frontend/src/store/query/slices/dataViewSlice.ts
@@ -11,6 +11,7 @@ import {
 } from '../helpers/executionState';
 import { fetchTableWithComments, PAGE_SIZE, toBaseSql } from '../helpers/fetchTable';
 import { fetchAndUpdateRowCount } from '../helpers/paginationHelper';
+import { toQueriesById } from '../helpers/queriesMap';
 import type { AbortRegistrable } from '../interfaces/AbortRegistrable';
 import type { ColumnBridgeable } from '../interfaces/ColumnBridgeable';
 import type { DataViewable } from '../interfaces/DataViewable';
@@ -101,11 +102,15 @@ export function createDataViewSlice(
 
         log.info(`[QueryStore] Creating new query tab: ${id} for table ${tableName}`);
 
-        set((state) => ({
-          ...startExecution(state, id),
-          queries: [...state.queries, newQuery],
-          activeQueryId: id,
-        }));
+        set((state) => {
+          const newQueries = [...state.queries, newQuery];
+          return {
+            ...startExecution(state, id),
+            queries: newQueries,
+            queriesById: toQueriesById(newQueries),
+            activeQueryId: id,
+          };
+        });
 
         log.debug(`[QueryStore] Fetching table data for ${tableName}`);
         const fetchStart = performance.now();
@@ -150,7 +155,7 @@ export function createDataViewSlice(
     },
 
     applyWhereFilter: async (id, connectionId, whereClause): Promise<string | null> => {
-      const query = get().queries.find((q) => q.id === id);
+      const query = get().queriesById[id];
       if (!query?.sourceTable) return null;
 
       const controller = new AbortController();
@@ -164,12 +169,16 @@ export function createDataViewSlice(
           whereClause.trim() || undefined
         );
 
-        set((state) => ({
-          ...startExecution(state, id),
-          queries: state.queries.map((q) =>
+        set((state) => {
+          const newQueries = state.queries.map((q) =>
             q.id === id ? { ...q, content: sql, whereClause: whereClause.trim(), isDirty: true } : q
-          ),
-        }));
+          );
+          return {
+            ...startExecution(state, id),
+            queries: newQueries,
+            queriesById: toQueriesById(newQueries),
+          };
+        });
 
         const resultSet = await fetchTableWithComments(
           bridge,
@@ -211,7 +220,7 @@ export function createDataViewSlice(
     },
 
     refreshDataView: async (id, connectionId) => {
-      const query = get().queries.find((q) => q.id === id);
+      const query = get().queriesById[id];
       if (!query?.sourceTable) return;
 
       log.info(`[QueryStore] Refreshing data view: ${query.sourceTable}`);

--- a/frontend/src/store/query/slices/erDiagramSlice.ts
+++ b/frontend/src/store/query/slices/erDiagramSlice.ts
@@ -1,5 +1,6 @@
 import type { Query } from '../../../types';
 import { generateQueryId } from '../helpers/executionState';
+import { toQueriesById } from '../helpers/queriesMap';
 import type { ERDiagrammable } from '../interfaces/ERDiagrammable';
 import type { GetState, SetState } from '../types';
 
@@ -23,10 +24,10 @@ export function createERDiagramSlice(set: SetState, get: GetState): ERDiagrammab
         isERDiagram: true,
       };
 
-      set((state) => ({
-        queries: [...state.queries, newQuery],
-        activeQueryId: id,
-      }));
+      set((state) => {
+        const newQueries = [...state.queries, newQuery];
+        return { queries: newQueries, queriesById: toQueriesById(newQueries), activeQueryId: id };
+      });
 
       return id;
     },

--- a/frontend/src/store/query/slices/fileIOSlice.ts
+++ b/frontend/src/store/query/slices/fileIOSlice.ts
@@ -1,4 +1,5 @@
 import { log } from '../../../utils/logger';
+import { toQueriesById } from '../helpers/queriesMap';
 import type { FileBridgeable } from '../interfaces/FileBridgeable';
 import type { FileIOable } from '../interfaces/FileIOable';
 import type { GetState, SetState } from '../types';
@@ -24,11 +25,12 @@ export function createFileIOSlice(set: SetState, get: GetState, deps: FileIOSlic
 
         log.info(`[QueryStore] Saved query to file: ${result.filePath}`);
 
-        set((state) => ({
-          queries: state.queries.map((q) =>
+        set((state) => {
+          const newQueries = state.queries.map((q) =>
             q.id === id ? { ...q, filePath: result.filePath, isDirty: false } : q
-          ),
-        }));
+          );
+          return { queries: newQueries, queriesById: toQueriesById(newQueries) };
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to save file';
         if (!message.includes('cancelled')) {
@@ -43,13 +45,14 @@ export function createFileIOSlice(set: SetState, get: GetState, deps: FileIOSlic
 
         log.info(`[QueryStore] Loaded query from file: ${result.filePath}`);
 
-        set((state) => ({
-          queries: state.queries.map((q) =>
+        set((state) => {
+          const newQueries = state.queries.map((q) =>
             q.id === id
               ? { ...q, content: result.content, filePath: result.filePath, isDirty: false }
               : q
-          ),
-        }));
+          );
+          return { queries: newQueries, queriesById: toQueriesById(newQueries) };
+        });
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to load file';
         if (!message.includes('cancelled')) {

--- a/frontend/src/store/query/slices/formatSlice.ts
+++ b/frontend/src/store/query/slices/formatSlice.ts
@@ -1,5 +1,6 @@
 import { formatSQL } from '../../../utils/sqlFormat';
 import { useToastStore } from '../../toastStore';
+import { toQueriesById } from '../helpers/queriesMap';
 import type { Formattable } from '../interfaces/Formattable';
 import type { GetState, SetState } from '../types';
 
@@ -11,11 +12,12 @@ export function createFormatSlice(set: SetState, get: GetState): Formattable {
 
       try {
         const formatted = await formatSQL(query.content);
-        set((state) => ({
-          queries: state.queries.map((q) =>
+        set((state) => {
+          const newQueries = state.queries.map((q) =>
             q.id === id ? { ...q, content: formatted, isDirty: true } : q
-          ),
-        }));
+          );
+          return { queries: newQueries, queriesById: toQueriesById(newQueries) };
+        });
       } catch (error) {
         const reason = error instanceof Error ? error.message : 'Failed to format SQL';
         useToastStore.getState().addToast(`フォーマットできません: ${reason}`, 'error');

--- a/frontend/src/store/query/slices/queryExecuteSlice.ts
+++ b/frontend/src/store/query/slices/queryExecuteSlice.ts
@@ -269,7 +269,7 @@ export function createExecuteSlice(
 
   return {
     executeQuery: async (id, connectionId) => {
-      const query = get().queries.find((q) => q.id === id);
+      const query = get().queriesById[id];
       if (!query || !query.content.trim()) return;
       clearPagination(id);
       await executeAsync(id, connectionId, query.content);

--- a/frontend/src/store/query/slices/queryManageSlice.ts
+++ b/frontend/src/store/query/slices/queryManageSlice.ts
@@ -1,5 +1,6 @@
 import type { Query } from '../../../types';
 import { generateQueryId, getQueryCounter } from '../helpers/executionState';
+import { toQueriesById } from '../helpers/queriesMap';
 import type { AbortRegistrable } from '../interfaces/AbortRegistrable';
 import type { Manageable } from '../interfaces/Manageable';
 import type { GetState, SetState } from '../types';
@@ -14,7 +15,10 @@ export function createManageSlice(set: SetState, get: GetState, deps: ManageSlic
   const appendQuery = (name: string, content: string, connectionId: string | null = null) => {
     const id = generateQueryId();
     const newQuery: Query = { id, name, content, connectionId, isDirty: false };
-    set((state) => ({ queries: [...state.queries, newQuery], activeQueryId: id }));
+    set((state) => {
+      const newQueries = [...state.queries, newQuery];
+      return { queries: newQueries, queriesById: toQueriesById(newQueries), activeQueryId: id };
+    });
   };
 
   return {
@@ -47,6 +51,7 @@ export function createManageSlice(set: SetState, get: GetState, deps: ManageSlic
 
       set({
         queries: newQueries,
+        queriesById: toQueriesById(newQueries),
         activeQueryId: newActiveId,
         results: newResults,
         errors: newErrors,
@@ -57,21 +62,26 @@ export function createManageSlice(set: SetState, get: GetState, deps: ManageSlic
     },
 
     updateQuery: (id, content) => {
-      set((state) => ({
-        queries: state.queries.map((q) => (q.id === id ? { ...q, content, isDirty: true } : q)),
-      }));
+      set((state) => {
+        const newQueries = state.queries.map((q) =>
+          q.id === id ? { ...q, content, isDirty: true } : q
+        );
+        return { queries: newQueries, queriesById: toQueriesById(newQueries) };
+      });
     },
 
     updateQueryConnection: (id, connectionId) => {
-      set((state) => ({
-        queries: state.queries.map((q) => (q.id === id ? { ...q, connectionId } : q)),
-      }));
+      set((state) => {
+        const newQueries = state.queries.map((q) => (q.id === id ? { ...q, connectionId } : q));
+        return { queries: newQueries, queriesById: toQueriesById(newQueries) };
+      });
     },
 
     renameQuery: (id, name) => {
-      set((state) => ({
-        queries: state.queries.map((q) => (q.id === id ? { ...q, name } : q)),
-      }));
+      set((state) => {
+        const newQueries = state.queries.map((q) => (q.id === id ? { ...q, name } : q));
+        return { queries: newQueries, queriesById: toQueriesById(newQueries) };
+      });
     },
 
     setActive: (id) => {
@@ -79,11 +89,12 @@ export function createManageSlice(set: SetState, get: GetState, deps: ManageSlic
     },
 
     migrateConnection: (oldId, newId) => {
-      set((state) => ({
-        queries: state.queries.map((q) =>
+      set((state) => {
+        const newQueries = state.queries.map((q) =>
           q.connectionId === oldId ? { ...q, connectionId: newId } : q
-        ),
-      }));
+        );
+        return { queries: newQueries, queriesById: toQueriesById(newQueries) };
+      });
     },
 
     addQueryFromFile: appendQuery,
@@ -101,7 +112,7 @@ export function createManageSlice(set: SetState, get: GetState, deps: ManageSlic
         const newQueries = [...state.queries];
         const [moved] = newQueries.splice(fromIndex, 1);
         newQueries.splice(toIndex, 0, moved);
-        return { queries: newQueries };
+        return { queries: newQueries, queriesById: state.queriesById };
       });
     },
   };

--- a/frontend/src/store/query/types.ts
+++ b/frontend/src/store/query/types.ts
@@ -25,6 +25,7 @@ export interface QueryState
     Formattable,
     ERDiagrammable {
   queries: Query[];
+  queriesById: Record<string, Query>;
   activeQueryId: string | null;
   results: Record<string, QueryResult>;
   executingQueryIds: Set<string>;

--- a/frontend/src/tests/stores/queryStore.test.ts
+++ b/frontend/src/tests/stores/queryStore.test.ts
@@ -30,6 +30,7 @@ describe('queryStore', () => {
     // Reset stores before each test
     useQueryStore.setState({
       queries: [],
+      queriesById: {},
       activeQueryId: null,
       results: {},
       executingQueryIds: new Set<string>(),
@@ -50,10 +51,12 @@ describe('queryStore', () => {
 
       addQuery('conn_1');
 
-      const { queries, activeQueryId } = useQueryStore.getState();
+      const { queries, activeQueryId, queriesById } = useQueryStore.getState();
       expect(queries).toHaveLength(1);
       expect(queries[0].connectionId).toBe('conn_1');
       expect(activeQueryId).toBe(queries[0].id);
+      expect(Object.keys(queriesById)).toEqual(queries.map((q) => q.id));
+      expect(queriesById[queries[0].id]).toBe(queries[0]);
     });
 
     it('should generate unique query ids', () => {
@@ -92,6 +95,7 @@ describe('queryStore', () => {
       const state = useQueryStore.getState();
       expect(state.queries).toHaveLength(0);
       expect(state.results[queryId]).toBeUndefined();
+      expect(Object.keys(state.queriesById)).toEqual(state.queries.map((q) => q.id));
     });
   });
 
@@ -105,9 +109,12 @@ describe('queryStore', () => {
 
       updateQuery(queryId, 'SELECT * FROM users');
 
-      const updated = useQueryStore.getState().queries[0];
+      const state = useQueryStore.getState();
+      const updated = state.queries[0];
       expect(updated.content).toBe('SELECT * FROM users');
       expect(updated.isDirty).toBe(true);
+      expect(Object.keys(state.queriesById)).toEqual(state.queries.map((q) => q.id));
+      expect(state.queriesById[queryId]).toBe(updated);
     });
   });
 


### PR DESCRIPTION
Closes #501