### PR TITLE
perf(schema): #512 `schema_provider` キャッシュ網羅 + `getTables` プリフェッチ + `getColumns SQL` 最適化

### DIFF
--- a/backend/database/sqlserver_dialect.cpp
+++ b/backend/database/sqlserver_dialect.cpp
@@ -73,24 +73,29 @@ std::string SqlServerDialect::getTablesQuery() const {
 }
 
 std::string SqlServerDialect::getColumnsQuery(std::string_view schema, std::string_view table) const {
+    // PK 判定は EXISTS 相関で c.object_id に絞る。LEFT JOIN で全テーブルの PK インデックスを
+    // 集約 (sys.indexes 全スキャン) してから JOIN すると、テーブル数の多い DB で初回スキーマ
+    // 取得が重くなる (#512)。相関で当該列の PK のみ評価する。OBJECT_ID を使わないのは、
+    // ' を含む識別子 ([O'Brien] 等) を OBJECT_ID が NULL 解決し PK 判定を壊すため。
     return std::format(R"(
             SELECT
                 c.name AS column_name,
                 t.name AS data_type,
                 c.max_length,
                 c.is_nullable,
-                CASE WHEN pk.column_id IS NOT NULL THEN 1 ELSE 0 END AS is_primary_key,
+                CASE WHEN EXISTS (
+                    SELECT 1
+                    FROM sys.index_columns ic
+                    INNER JOIN sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+                    WHERE i.is_primary_key = 1
+                      AND ic.object_id = c.object_id
+                      AND ic.column_id = c.column_id
+                ) THEN 1 ELSE 0 END AS is_primary_key,
                 CAST(ep.value AS NVARCHAR(MAX)) AS comment
             FROM sys.columns c
             INNER JOIN sys.types t ON c.user_type_id = t.user_type_id
             INNER JOIN sys.objects o ON c.object_id = o.object_id
             INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
-            LEFT JOIN (
-                SELECT ic.object_id, ic.column_id
-                FROM sys.index_columns ic
-                INNER JOIN sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
-                WHERE i.is_primary_key = 1
-            ) pk ON c.object_id = pk.object_id AND c.column_id = pk.column_id
             LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id
                 AND ep.minor_id = c.column_id
                 AND ep.class = 1

--- a/backend/providers/schema_provider.cpp
+++ b/backend/providers/schema_provider.cpp
@@ -12,8 +12,11 @@
 #include "../utils/sql_validation.h"
 #include "simdjson.h"
 
+#include <algorithm>
 #include <charconv>
+#include <expected>
 #include <format>
+#include <functional>
 #include <ranges>
 
 namespace velocitydb {
@@ -61,6 +64,9 @@ struct TableQueryParams {
     auto driverType = connections.getDriverType(connectionId);
     auto formatter = DriverFactory::createSqlFormattable(driverType);
     auto [schema, tbl] = splitSchemaTable(tableName, formatter->defaultSchema());
+    // split 後の schema/tbl はブラケットを剥がした生識別子。ここで isValidIdentifier を再適用すると
+    // [My Table] / [O'Brien] 等の正当な特殊文字名を弾くため行わない。SQL 埋め込み時は各 dialect が
+    // escapeSql ('→'') で文字列リテラルとしてエスケープしインジェクションを防ぐ。
 
     return TableQueryParams{std::move(schema), std::move(tbl), std::move(driver), driverType, std::move(formatter)};
 }
@@ -82,9 +88,42 @@ std::optional<std::string> SchemaProvider::getCached(const std::string& key) {
     return std::nullopt;
 }
 
+void SchemaProvider::evictIfFullLocked() {
+    if (m_schemaCache.size() < MAX_SCHEMA_CACHE_ENTRIES)
+        return;
+    // まず TTL 切れエントリを一掃する。
+    const auto now = std::chrono::steady_clock::now();
+    std::erase_if(m_schemaCache, [now](const auto& entry) { return now - entry.second.timestamp >= SCHEMA_CACHE_TTL; });
+    // それでも上限に達していれば最古エントリを 1 件削除する。
+    if (m_schemaCache.size() >= MAX_SCHEMA_CACHE_ENTRIES) {
+        auto oldest = std::ranges::min_element(m_schemaCache, {}, [](const auto& entry) { return entry.second.timestamp; });
+        if (oldest != m_schemaCache.end())
+            m_schemaCache.erase(oldest);
+    }
+}
+
 void SchemaProvider::putCache(const std::string& key, const std::string& response) {
     std::lock_guard lock(m_cacheMutex);
+    if (!m_schemaCache.contains(key))
+        evictIfFullLocked();
     m_schemaCache[key] = {response, std::chrono::steady_clock::now()};
+}
+
+std::string SchemaProvider::withCache(const std::string& key, const std::function<std::expected<std::string, std::string>()>& produce) {
+    if (auto cached = getCached(key)) {
+        return *cached;
+    }
+    try {
+        auto body = produce();
+        if (!body) {
+            return JsonUtils::errorResponse(body.error());
+        }
+        auto response = JsonUtils::successResponse(*body);
+        putCache(key, response);
+        return response;
+    } catch (const std::exception& e) {
+        return JsonUtils::errorResponse(e.what());
+    }
 }
 
 std::string SchemaProvider::clearSchemaCache(std::string_view) {
@@ -116,49 +155,36 @@ std::string SchemaProvider::getDatabases(std::string_view params) {
 
 std::string SchemaProvider::getTables(std::string_view params) {
     log<LogLevel::DEBUG>(std::format("SchemaProvider::getTables called with params: {}", params));
-    auto cacheKey = "getTables:" + std::string(params);
-    if (auto cached = getCached(cacheKey)) {
-        return *cached;
-    }
-    auto connectionIdResult = extractConnectionId(params);
-    if (!connectionIdResult) {
-        return JsonUtils::errorResponse(connectionIdResult.error());
-    }
-    auto connectionId = *connectionIdResult;
-    try {
+    return withCache("getTables:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
+        auto connectionIdResult = extractConnectionId(params);
+        if (!connectionIdResult) {
+            return std::unexpected(connectionIdResult.error());
+        }
+        auto connectionId = *connectionIdResult;
         auto driver = m_connections.getMetadataDriver(connectionId);
         if (!driver) [[unlikely]] {
-            return JsonUtils::errorResponse(std::format("Connection not found: {}", connectionId));
+            return std::unexpected(std::format("Connection not found: {}", connectionId));
         }
         auto driverType = m_connections.getDriverType(connectionId);
         auto dialect = DriverFactory::createSchemaQueryable(driverType);
         auto sql = dialect->getTablesQuery();
         auto queryResult = driver->execute(sql);
-        auto jsonResponse = JsonUtils::buildRowArray(queryResult.rows, 3, [](std::string& out, const ResultRow& row) {
+        return JsonUtils::buildRowArray(queryResult.rows, 3, [](std::string& out, const ResultRow& row) {
             auto comment = row.values.size() >= 4 ? row.values[3] : std::string{};
             out += std::format(R"({{"schema":"{}","name":"{}","type":"{}","comment":"{}"}})", JsonUtils::escapeString(row.values[0]), JsonUtils::escapeString(row.values[1]),
                                JsonUtils::escapeString(row.values[2]), JsonUtils::escapeString(comment));
         });
-        auto result = JsonUtils::successResponse(jsonResponse);
-        putCache(cacheKey, result);
-        return result;
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+    });
 }
 
 std::string SchemaProvider::getColumns(std::string_view params) {
-    auto cacheKey = "getColumns:" + std::string(params);
-    if (auto cached = getCached(cacheKey)) {
-        return *cached;
-    }
-    try {
+    return withCache("getColumns:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
         if (!extracted) [[unlikely]]
-            return JsonUtils::errorResponse(extracted.error());
+            return std::unexpected(extracted.error());
 
         auto& [schema, tbl, driver, driverType, formatter] = *extracted;
 
@@ -166,7 +192,7 @@ std::string SchemaProvider::getColumns(std::string_view params) {
         auto sql = dialect->getColumnsQuery(schema, tbl);
         auto columnResult = driver->execute(sql);
 
-        auto jsonResponse = JsonUtils::buildRowArray(columnResult.rows, 5, [](std::string& out, const ResultRow& row) {
+        return JsonUtils::buildRowArray(columnResult.rows, 5, [](std::string& out, const ResultRow& row) {
             std::string_view sizeStr = row.values[2];
             int colSize = 0;
             std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), colSize);
@@ -176,22 +202,17 @@ std::string SchemaProvider::getColumns(std::string_view params) {
             out += std::format(R"({{"name":"{}","type":"{}","size":{},"nullable":{},"isPrimaryKey":{},"comment":"{}"}})", JsonUtils::escapeString(row.values[0]),
                                JsonUtils::escapeString(row.values[1]), colSize, nullable, isPk, JsonUtils::escapeString(comment));
         });
-        auto result = JsonUtils::successResponse(jsonResponse);
-        putCache(cacheKey, result);
-        return result;
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+    });
 }
 
 std::string SchemaProvider::getIndexes(std::string_view params) {
-    try {
+    return withCache("getIndexes:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
         if (!extracted) [[unlikely]]
-            return JsonUtils::errorResponse(extracted.error());
+            return std::unexpected(extracted.error());
 
         auto& [schema, tbl, driver, driverType, formatter] = *extracted;
 
@@ -199,7 +220,7 @@ std::string SchemaProvider::getIndexes(std::string_view params) {
         auto sql = dialect->getIndexesQuery(schema, tbl);
         auto queryResult = driver->execute(sql);
 
-        auto json = JsonUtils::buildRowArray(queryResult.rows, 5, [](std::string& out, const ResultRow& row) {
+        return JsonUtils::buildRowArray(queryResult.rows, 5, [](std::string& out, const ResultRow& row) {
             out += "{";
             out += std::format("\"name\":\"{}\",", JsonUtils::escapeString(row.values[0]));
             out += std::format("\"type\":\"{}\",", JsonUtils::escapeString(row.values[1]));
@@ -209,20 +230,17 @@ std::string SchemaProvider::getIndexes(std::string_view params) {
             out += splitCsvToJsonArray(row.values[4]);
             out += "}";
         });
-        return JsonUtils::successResponse(json);
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+    });
 }
 
 std::string SchemaProvider::getConstraints(std::string_view params) {
-    try {
+    return withCache("getConstraints:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
         if (!extracted) [[unlikely]]
-            return JsonUtils::errorResponse(extracted.error());
+            return std::unexpected(extracted.error());
 
         auto& [schema, tbl, driver, driverType, formatter] = *extracted;
 
@@ -230,7 +248,7 @@ std::string SchemaProvider::getConstraints(std::string_view params) {
         auto sql = dialect->getConstraintsQuery(schema, tbl);
         auto queryResult = driver->execute(sql);
 
-        auto json = JsonUtils::buildRowArray(queryResult.rows, 4, [](std::string& out, const ResultRow& row) {
+        return JsonUtils::buildRowArray(queryResult.rows, 4, [](std::string& out, const ResultRow& row) {
             out += "{";
             out += std::format("\"name\":\"{}\",", JsonUtils::escapeString(row.values[0]));
             out += std::format("\"type\":\"{}\",", JsonUtils::escapeString(row.values[1]));
@@ -240,20 +258,17 @@ std::string SchemaProvider::getConstraints(std::string_view params) {
             out += std::format("\"definition\":\"{}\"", JsonUtils::escapeString(row.values[3]));
             out += "}";
         });
-        return JsonUtils::successResponse(json);
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+    });
 }
 
 std::string SchemaProvider::getForeignKeys(std::string_view params) {
-    try {
+    return withCache("getForeignKeys:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
         if (!extracted) [[unlikely]]
-            return JsonUtils::errorResponse(extracted.error());
+            return std::unexpected(extracted.error());
 
         auto& [schema, tbl, driver, driverType, formatter] = *extracted;
 
@@ -261,7 +276,7 @@ std::string SchemaProvider::getForeignKeys(std::string_view params) {
         auto sql = dialect->getForeignKeysQuery(schema, tbl);
         auto queryResult = driver->execute(sql);
 
-        auto json = JsonUtils::buildRowArray(queryResult.rows, 6, [](std::string& out, const ResultRow& row) {
+        return JsonUtils::buildRowArray(queryResult.rows, 6, [](std::string& out, const ResultRow& row) {
             out += "{";
             out += std::format("\"name\":\"{}\",", JsonUtils::escapeString(row.values[0]));
             out += "\"columns\":";
@@ -275,20 +290,17 @@ std::string SchemaProvider::getForeignKeys(std::string_view params) {
             out += std::format("\"onUpdate\":\"{}\"", JsonUtils::escapeString(row.values[5]));
             out += "}";
         });
-        return JsonUtils::successResponse(json);
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+    });
 }
 
 std::string SchemaProvider::getReferencingForeignKeys(std::string_view params) {
-    try {
+    return withCache("getReferencingForeignKeys:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
         if (!extracted) [[unlikely]]
-            return JsonUtils::errorResponse(extracted.error());
+            return std::unexpected(extracted.error());
 
         auto& [schema, tbl, driver, driverType, formatter] = *extracted;
 
@@ -296,7 +308,7 @@ std::string SchemaProvider::getReferencingForeignKeys(std::string_view params) {
         auto sql = dialect->getReferencingForeignKeysQuery(schema, tbl);
         auto queryResult = driver->execute(sql);
 
-        auto json = JsonUtils::buildRowArray(queryResult.rows, 6, [](std::string& out, const ResultRow& row) {
+        return JsonUtils::buildRowArray(queryResult.rows, 6, [](std::string& out, const ResultRow& row) {
             out += "{";
             out += std::format("\"name\":\"{}\",", JsonUtils::escapeString(row.values[0]));
             out += std::format("\"referencingTable\":\"{}\",", JsonUtils::escapeString(row.values[1]));
@@ -310,20 +322,17 @@ std::string SchemaProvider::getReferencingForeignKeys(std::string_view params) {
             out += std::format("\"onUpdate\":\"{}\"", JsonUtils::escapeString(row.values[5]));
             out += "}";
         });
-        return JsonUtils::successResponse(json);
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+    });
 }
 
 std::string SchemaProvider::getTriggers(std::string_view params) {
-    try {
+    return withCache("getTriggers:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
         if (!extracted) [[unlikely]]
-            return JsonUtils::errorResponse(extracted.error());
+            return std::unexpected(extracted.error());
 
         auto& [schema, tbl, driver, driverType, formatter] = *extracted;
 
@@ -331,7 +340,7 @@ std::string SchemaProvider::getTriggers(std::string_view params) {
         auto sql = dialect->getTriggersQuery(schema, tbl);
         auto queryResult = driver->execute(sql);
 
-        auto json = JsonUtils::buildRowArray(queryResult.rows, 5, [](std::string& out, const ResultRow& row) {
+        return JsonUtils::buildRowArray(queryResult.rows, 5, [](std::string& out, const ResultRow& row) {
             out += "{";
             out += std::format("\"name\":\"{}\",", JsonUtils::escapeString(row.values[0]));
             out += std::format("\"type\":\"{}\",", JsonUtils::escapeString(row.values[1]));
@@ -342,20 +351,17 @@ std::string SchemaProvider::getTriggers(std::string_view params) {
             out += std::format("\"definition\":\"{}\"", JsonUtils::escapeString(row.values[4]));
             out += "}";
         });
-        return JsonUtils::successResponse(json);
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+    });
 }
 
 std::string SchemaProvider::getTableMetadata(std::string_view params) {
-    try {
+    return withCache("getTableMetadata:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;
         auto doc = parser.parse(params).value();
 
         auto extracted = extractTableQueryParams(doc, m_connections);
         if (!extracted) [[unlikely]]
-            return JsonUtils::errorResponse(extracted.error());
+            return std::unexpected(extracted.error());
 
         auto& [schema, tbl, driver, driverType, formatter] = *extracted;
 
@@ -364,12 +370,12 @@ std::string SchemaProvider::getTableMetadata(std::string_view params) {
         auto queryResult = driver->execute(sql);
 
         if (queryResult.rows.empty()) {
-            return JsonUtils::errorResponse("Table not found");
+            return std::unexpected("Table not found");
         }
 
         const auto& row = queryResult.rows[0];
         if (row.values.size() < 8) {
-            return JsonUtils::errorResponse("Unexpected column count in metadata result");
+            return std::unexpected("Unexpected column count in metadata result");
         }
         std::string json = "{";
         json += std::format("\"schema\":\"{}\",", JsonUtils::escapeString(row.values[0]));
@@ -381,10 +387,8 @@ std::string SchemaProvider::getTableMetadata(std::string_view params) {
         json += std::format("\"owner\":\"{}\",", JsonUtils::escapeString(row.values[6]));
         json += std::format("\"comment\":\"{}\"", JsonUtils::escapeString(row.values[7]));
         json += "}";
-        return JsonUtils::successResponse(json);
-    } catch (const std::exception& e) {
-        return JsonUtils::errorResponse(e.what());
-    }
+        return json;
+    });
 }
 
 std::string SchemaProvider::getTableDDL(std::string_view params) {

--- a/backend/providers/schema_provider.h
+++ b/backend/providers/schema_provider.h
@@ -3,6 +3,8 @@
 #include "../interfaces/providers/schema_provider.h"
 
 #include <chrono>
+#include <expected>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -45,11 +47,19 @@ private:
     };
 
     static constexpr auto SCHEMA_CACHE_TTL = std::chrono::minutes(5);
+    // キャッシュエントリ数の上限。接続数 × テーブル数 × メソッド数で無制限に増えるのを防ぐ (#512)。
+    static constexpr size_t MAX_SCHEMA_CACHE_ENTRIES = 1024;
     std::unordered_map<std::string, SchemaCacheEntry> m_schemaCache;
     mutable std::mutex m_cacheMutex;
 
     [[nodiscard]] std::optional<std::string> getCached(const std::string& key);
     void putCache(const std::string& key, const std::string& response);
+    void evictIfFullLocked();  // m_cacheMutex を保持した状態で呼ぶ
+
+    // getCached → produce → 成功なら successResponse + putCache、失敗 (unexpected) なら errorResponse で
+    // キャッシュせず返す。produce 内の例外も errorResponse 化する。スキーマ取得メソッドの共通キャッシュ
+    // 制御を集約する (#512)。
+    [[nodiscard]] std::string withCache(const std::string& key, const std::function<std::expected<std::string, std::string>()>& produce);
 };
 
 }  // namespace velocitydb

--- a/frontend/src/store/connectionStore.ts
+++ b/frontend/src/store/connectionStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
-import { connectionProvider } from '../api/providers';
+import { connectionProvider, schemaProvider } from '../api/providers';
 import type { Connection } from '../types';
 import { pollConnection } from './connection/helpers/connectionPolling';
 
@@ -107,6 +107,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         connectRequestId: null,
         connectCancelled: false,
       }));
+
+      // 接続直後に getTables を fire-and-forget で先読みし SchemaProvider キャッシュに乗せる。
+      // ツリー初回描画 (loadTables) がキャッシュ命中で即返り、接続→一覧表示の初回 (実測 ~165ms)
+      // を体感ゼロにする (#512)。Promise.resolve().then で包むことで getTables の同期 throw も
+      // reject に変換し .catch で握る (空 catch を避ける)。主フロー (replaced の返却) には影響しない。
+      // loadTables と二重発行になっても劣化しない — putCache 前なら通常取得に戻り、後なら命中するだけ。
+      void Promise.resolve()
+        .then(() => schemaProvider.getTables(result.connectionId, ''))
+        .catch(() => {});
 
       return oldId ? { replaced: { oldId, newId: result.connectionId } } : {};
     } catch (error) {

--- a/frontend/src/tests/stores/connectionStore.test.ts
+++ b/frontend/src/tests/stores/connectionStore.test.ts
@@ -6,6 +6,7 @@ const mockGetConnectResult = vi.fn();
 const mockCancelConnect = vi.fn();
 const mockDisconnect = vi.fn();
 const mockTestConnection = vi.fn();
+const mockGetTables = vi.fn();
 
 vi.mock('../../api/providers', () => ({
   connectionProvider: {
@@ -14,6 +15,9 @@ vi.mock('../../api/providers', () => ({
     cancelConnect: (...args: unknown[]) => mockCancelConnect(...args),
     disconnect: (...args: unknown[]) => mockDisconnect(...args),
     testConnection: (...args: unknown[]) => mockTestConnection(...args),
+  },
+  schemaProvider: {
+    getTables: (...args: unknown[]) => mockGetTables(...args),
   },
 }));
 
@@ -41,6 +45,7 @@ describe('connectionStore', () => {
       error: null,
     });
     vi.clearAllMocks();
+    mockGetTables.mockResolvedValue({ tables: [], loadTimeMs: 0 });
   });
 
   afterEach(() => {
@@ -55,6 +60,16 @@ describe('connectionStore', () => {
   });
 
   describe('addConnection', () => {
+    it('should prefetch getTables into cache after successful connection (#512)', async () => {
+      mockConnectAsync.mockResolvedValue({ requestId: 'conn_1' });
+      mockGetConnectResult.mockResolvedValue({ status: 'connected', connectionId: 'db_1' });
+
+      await useConnectionStore.getState().addConnection(baseConnection);
+
+      // プリフェッチは Promise.resolve().then で次のマイクロタスクに遅延するため待機する
+      await vi.waitFor(() => expect(mockGetTables).toHaveBeenCalledWith('db_1', ''));
+    });
+
     it('should connect successfully via async polling', async () => {
       mockConnectAsync.mockResolvedValue({ requestId: 'conn_1' });
       mockGetConnectResult.mockResolvedValue({

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ FetchContent_MakeAvailable(googletest)
 # Test sources
 set(TEST_SOURCES
     test_main.cpp
+    database/test_sqlserver_dialect.cpp
     database/test_sqlserver_driver.cpp
     database/test_odbc_unicode.cpp
     database/test_query_history.cpp
@@ -43,6 +44,7 @@ set(TEST_SOURCES
     providers/test_query_result_formatter.cpp
     providers/test_settings_provider.cpp
     providers/test_utility_provider.cpp
+    providers/test_schema_provider.cpp
     search/test_simd_filter.cpp
     utils/test_sql_validation.cpp
     database/test_thread_pool.cpp

--- a/tests/database/test_sqlserver_dialect.cpp
+++ b/tests/database/test_sqlserver_dialect.cpp
@@ -1,0 +1,35 @@
+#include "database/sqlserver_dialect.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using velocitydb::SqlServerDialect;
+
+// 注: 以下は getColumnsQuery が生成する SQL 文字列の部分一致検証であり、SQL の意味論
+// (PK 判定の正確性等) までは検証しない。SchemaProvider のキャッシュ動作テストは
+// IConnectionProvider/IDatabaseDriver の mock 基盤を要するため別途対応する (W5/W7)。
+
+// #512: getColumns の PK 判定が c.object_id 相関で当該テーブルに絞られることを保証する。
+// 相関が外れると sys.indexes 全体 (DB 内全テーブルの PK) スキャンに戻り初回スキーマ取得が
+// 重くなる回帰を防ぐ。OBJECT_ID を使わないため ' を含む識別子でも PK 判定が壊れない。
+TEST(SqlServerDialectTest, ColumnsQueryScopesPrimaryKeySubqueryToTable) {
+    SqlServerDialect dialect;
+
+    const auto sql = dialect.getColumnsQuery("dbo", "Users");
+
+    EXPECT_NE(sql.find("ic.object_id = c.object_id"), std::string::npos);
+    EXPECT_EQ(sql.find("OBJECT_ID("), std::string::npos);
+}
+
+// #512 の最適化が表示列 (型 / PK / comment) を削っていないことの回帰防止。
+TEST(SqlServerDialectTest, ColumnsQueryRetainsCommentAndPrimaryKeyColumns) {
+    SqlServerDialect dialect;
+
+    const auto sql = dialect.getColumnsQuery("dbo", "Users");
+
+    EXPECT_NE(sql.find("AS data_type"), std::string::npos);
+    EXPECT_NE(sql.find("AS is_primary_key"), std::string::npos);
+    EXPECT_NE(sql.find("AS comment"), std::string::npos);
+    EXPECT_NE(sql.find("sys.extended_properties"), std::string::npos);
+}

--- a/tests/providers/test_schema_provider.cpp
+++ b/tests/providers/test_schema_provider.cpp
@@ -1,0 +1,141 @@
+#include "providers/schema_provider.h"
+
+#include "database/connection_types.h"
+#include "database/driver_interface.h"
+#include "interfaces/providers/connection_provider.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using velocitydb::DatabaseConnectionParams;
+using velocitydb::DriverType;
+using velocitydb::IConnectionProvider;
+using velocitydb::IDatabaseDriver;
+using velocitydb::ResultRow;
+using velocitydb::ResultSet;
+using velocitydb::SchemaProvider;
+
+// #512: SchemaProvider のキャッシュ動作 (2 回目命中・clear で無効化・error 非キャッシュ) を
+// driver->execute の呼び出し回数で検証する。実 DB を要さず、IConnectionProvider /
+// IDatabaseDriver を gmock 化して注入する。withCache リファクタ (W5) の振る舞い同等性を守る
+// 特性テストでもある。
+
+namespace {
+
+class MockDatabaseDriver : public IDatabaseDriver {
+public:
+    MOCK_METHOD(bool, connect, (std::string_view), (override));
+    MOCK_METHOD(void, disconnect, (), (override));
+    MOCK_METHOD(bool, isConnected, (), (const, noexcept, override));
+    MOCK_METHOD(ResultSet, execute, (std::string_view), (override));
+    MOCK_METHOD(void, cancel, (), (override));
+    MOCK_METHOD(void, setQueryTimeout, (std::chrono::seconds), (override));
+    MOCK_METHOD(std::chrono::seconds, queryTimeout, (), (const, noexcept, override));
+    MOCK_METHOD(std::string, getLastError, (), (const, override));
+    MOCK_METHOD(DriverType, getType, (), (const, noexcept, override));
+};
+
+class MockConnectionProvider : public IConnectionProvider {
+public:
+    MOCK_METHOD(std::string, connectAsync, (std::string_view), (override));
+    MOCK_METHOD(std::string, getConnectResult, (std::string_view), (override));
+    MOCK_METHOD(std::string, cancelConnect, (std::string_view), (override));
+    MOCK_METHOD(std::string, disconnect, (std::string_view), (override));
+    MOCK_METHOD(std::string, testConnection, (std::string_view), (override));
+    MOCK_METHOD(std::shared_ptr<IDatabaseDriver>, getQueryDriver, (std::string_view), (override));
+    MOCK_METHOD(std::shared_ptr<IDatabaseDriver>, getMetadataDriver, (std::string_view), (override));
+    MOCK_METHOD(DriverType, getDriverType, (std::string_view), (const, override));
+    MOCK_METHOD(std::optional<DatabaseConnectionParams>, getConnectionParams, (std::string_view), (const, override));
+    MOCK_METHOD(void, setDefaultQueryTimeoutSeconds, (int), (override));
+};
+
+// ResultSet の string_view は ResultSet::storage が所有するメモリを指す。テスト用にセル文字列を
+// arena (storage) に保持し、その string を string_view で参照させて寿命を保証する。
+ResultSet makeResultSet(std::vector<std::vector<std::string>> cells) {
+    auto arena = std::make_shared<std::vector<std::vector<std::string>>>(std::move(cells));
+    ResultSet result;
+    result.storage = arena;
+    result.rows.reserve(arena->size());
+    for (const auto& row : *arena) {
+        ResultRow resultRow;
+        resultRow.values.reserve(row.size());
+        for (const auto& cell : row) {
+            resultRow.values.emplace_back(cell);
+        }
+        result.rows.push_back(std::move(resultRow));
+    }
+    return result;
+}
+
+// getIndexes が要求する 5 列 (name/type/isUnique/isPrimaryKey/columns) を持つ 1 行。
+ResultSet singleIndexRow() {
+    return makeResultSet({{"PK_Users", "CLUSTERED", "1", "1", "Id"}});
+}
+
+}  // namespace
+
+class SchemaProviderCacheTest : public ::testing::Test {
+protected:
+    ::testing::NiceMock<MockConnectionProvider> connections;
+    std::shared_ptr<::testing::NiceMock<MockDatabaseDriver>> driver =
+        std::make_shared<::testing::NiceMock<MockDatabaseDriver>>();
+
+    void resolveDriverByDefault() {
+        ON_CALL(connections, getMetadataDriver(::testing::_)).WillByDefault(::testing::Return(driver));
+        ON_CALL(connections, getDriverType(::testing::_)).WillByDefault(::testing::Return(DriverType::SQLServer));
+    }
+};
+
+// 同一 params の 2 回目呼び出しはキャッシュ命中し、driver->execute は 1 回しか呼ばれない。
+TEST_F(SchemaProviderCacheTest, GetIndexesSecondCallHitsCacheWithoutReExecuting) {
+    resolveDriverByDefault();
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(singleIndexRow()));
+
+    SchemaProvider provider(connections);
+    const std::string params = R"({"connectionId":"db_1","table":"Users"})";
+
+    const auto first = provider.getIndexes(params);
+    const auto second = provider.getIndexes(params);
+
+    EXPECT_EQ(first, second);
+    EXPECT_NE(first.find("PK_Users"), std::string::npos);
+}
+
+// clearSchemaCache 後はキャッシュが無効化され、driver->execute が再度呼ばれる。
+TEST_F(SchemaProviderCacheTest, ClearSchemaCacheForcesReExecute) {
+    resolveDriverByDefault();
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(2).WillRepeatedly(::testing::Return(singleIndexRow()));
+
+    SchemaProvider provider(connections);
+    const std::string params = R"({"connectionId":"db_1","table":"Users"})";
+
+    provider.getIndexes(params);
+    provider.clearSchemaCache("");
+    provider.getIndexes(params);
+}
+
+// エラー応答はキャッシュされない。1 回目で driver 解決に失敗してエラーを返しても、2 回目で driver が
+// 解決できれば execute が走り正しい結果が返る (errorResponse 非キャッシュの不変条件)。
+TEST_F(SchemaProviderCacheTest, ErrorResponseIsNotCached) {
+    EXPECT_CALL(connections, getMetadataDriver(::testing::_))
+        .WillOnce(::testing::Return(nullptr))
+        .WillRepeatedly(::testing::Return(driver));
+    ON_CALL(connections, getDriverType(::testing::_)).WillByDefault(::testing::Return(DriverType::SQLServer));
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(singleIndexRow()));
+
+    SchemaProvider provider(connections);
+    const std::string params = R"({"connectionId":"db_1","table":"Users"})";
+
+    const auto firstError = provider.getIndexes(params);
+    const auto secondOk = provider.getIndexes(params);
+
+    EXPECT_NE(firstError.find("Connection not found"), std::string::npos);
+    EXPECT_NE(secondOk.find("PK_Users"), std::string::npos);
+}


### PR DESCRIPTION
- schema_provider の 6 メソッドにキャッシュ展開し withCache で DRY化、上限 1024 + LRU eviction を追加
- `sqlserver_dialect` の `getColumnsQuery` を `OBJECT_ID` から `EXISTS` 相関に変更 (`'` を含む識別子の `PK` 判定回帰を回避)
- 接続直後に `getTables` を `fire-and-forget` プリフェッチ
- 回帰テスト追加: SqlServerDialectTest 2 + SchemaProviderCacheTest 3

初回コストの主因は SQL Server 側バッファプールの cold cache。本変更は 2 回目以降の再訪問 0 化と接続直後プリフェッチに効果を限定する。

## 実機計測の結論

初回スキーマ取得コスト (getColumns 94〜447ms) の主因は SQL Server 側メタデータのコールドキャッシュであることを実機計測で確認 (計測ごとに乱高下)。アプリ側のSQL最適化・キャッシュ・プリフェッチでは初回コストを根本的には下げられない。
本PRの確実な成果は「再訪問の0化 (キャッシュ網羅)」と「ツリー初回描画の高速化 (getTables プリフェッチ)」。 `getColumns` 初回削減はサーバ要因のため別アプローチ (サーバウォームアップ等) が必要だが効果不確実なため本PR対象外。

Closes #512