### PR TITLE
fix(ci): pin action refs to commit SHAs and add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 10
+    # Wait 7 days before proposing newly published versions (supply-chain mitigation)
+    cooldown:
+      default-days: 7
     reviewers:
       - "TakumiOkayasu"
     labels:
@@ -39,6 +42,9 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
+    # Wait 7 days before proposing newly published versions (supply-chain mitigation)
+    cooldown:
+      default-days: 7
     reviewers:
       - "TakumiOkayasu"
     labels:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -23,10 +23,10 @@ jobs:
     name: Backend Benchmarks
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
 
       - name: Install Ninja and ccache
         run: choco install ninja ccache -y
@@ -39,7 +39,7 @@ jobs:
           echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $env:GITHUB_ENV
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~\.ccache
           key: ccache-bench-${{ runner.os }}-${{ inputs.build_type }}-${{ hashFiles('**/*.cpp', '**/*.h') }}
@@ -47,7 +47,7 @@ jobs:
             ccache-bench-${{ runner.os }}-${{ inputs.build_type }}-
 
       - name: Cache CMake build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             build/_deps
@@ -87,10 +87,10 @@ jobs:
     runs-on: windows-latest
     needs: backend-bench
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
 
       - name: Install Ninja and ccache
         run: choco install ninja ccache -y
@@ -103,7 +103,7 @@ jobs:
           echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> $env:GITHUB_ENV
 
       - name: Cache ccache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~\.ccache
           key: ccache-bench-${{ runner.os }}-${{ inputs.build_type }}-${{ hashFiles('**/*.cpp', '**/*.h') }}
@@ -111,13 +111,13 @@ jobs:
             ccache-bench-${{ runner.os }}-${{ inputs.build_type }}-
 
       - name: Setup PostgreSQL
-        uses: ankane/setup-postgres@v1
+        uses: ankane/setup-postgres@e9cd5bc1babecb0e441a640646d782056dbb67f5 # v1
         with:
           postgres-version: 17
           database: postgres
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Load 100万行 fixture (PostgreSQL)
         # Inline the connection string instead of routing through $env:PG_CONN

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.4
 
@@ -29,7 +29,7 @@ jobs:
           bun run build
 
       - name: Upload frontend
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: frontend-dist
           path: frontend/dist/
@@ -40,22 +40,22 @@ jobs:
     name: Build Backend
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.14'
           allow-prereleases: true
 
       - name: Setup MSVC Developer Environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
 
       - name: Install Ninja
         run: choco install ninja -y
 
       - name: Cache CMake build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             build/_deps
@@ -70,7 +70,7 @@ jobs:
           cmake --build build --parallel
 
       - name: Upload backend
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: backend-exe
           path: build/Release/VelocityDB.exe
@@ -85,13 +85,13 @@ jobs:
       contents: write
     steps:
       - name: Download frontend
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: frontend-dist
           path: dist/frontend
 
       - name: Download backend
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: backend-exe
           path: dist
@@ -104,7 +104,7 @@ jobs:
           zip -r "../Velocity-DB-${REF_NAME}.zip" .
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: Velocity-DB-${{ github.ref_name }}.zip
           generate_release_notes: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,10 +26,10 @@ jobs:
       issues: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.14'
           allow-prereleases: true
@@ -52,7 +52,7 @@ jobs:
             . || true
 
       - name: Create Issues from Semgrep Results
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,16 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
 
       - name: Install Ninja
         run: choco install ninja -y
 
       - name: Cache CMake build
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             build/_deps
@@ -49,7 +49,7 @@ jobs:
         run: ctest --test-dir build --output-on-failure --parallel -LE perf
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.4
 
@@ -62,7 +62,7 @@ jobs:
         run: bun run test --run
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: test-build
           path: build/Debug/
@@ -75,10 +75,10 @@ jobs:
     if: inputs.run_integration == true
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: test-build
           path: build/Debug


### PR DESCRIPTION
## Summary

`security-scan.yml` の Semgrep が起票した open issue 6 件にすべて対応する。

### github-actions-mutable-action-tag (#628–#632)

`bench.yml` / `dependabot-auto-merge.yml` / `release.yml` / `security-scan.yml` / `test.yml` の全 `uses:` 参照（計 24 箇所）を、可変タグから 40 桁コミット SHA ピンに変更。既にピン済みの `ci.yml` / `tool-version-upgrade.yml` と同じ `@<sha> # vN` スタイル。SHA は各リポジトリの現行タグを `gh api repos/<owner>/<repo>/commits/<tag>` で解決した値。

### dependabot-missing-cooldown (#627)

`dependabot.yml` の npm / github-actions 両エコシステムに `cooldown: default-days: 7` を追加。公開直後のパッケージ版を 7 日間見送ることでサプライチェーン攻撃を緩和する。

Dependabot は SHA ピンと `# vN` コメントを両方追従して更新するため、更新フローへの影響はない。

Fixes #627
Fixes #628
Fixes #629
Fixes #630
Fixes #631
Fixes #632

## Test plan

- [x] 変更 6 ファイルすべて YAML パース確認済み
- [x] `.github/` 配下に可変タグ (`@vN`) の `uses:` が残っていないことを grep で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)