### PR TITLE
feat(cache): 非同期/ページネーション経路への ResultCache 共有と DML 無効化

### DIFF
--- a/backend/contexts/system_context.cpp
+++ b/backend/contexts/system_context.cpp
@@ -3,6 +3,7 @@
 #include "../accessors/session_accessor.h"
 #include "../accessors/settings_accessor.h"
 #include "../database/query_history.h"
+#include "../database/result_cache.h"
 #include "../providers/async_query_provider.h"
 #include "../providers/connection_provider.h"
 #include "../providers/export_provider.h"
@@ -41,8 +42,11 @@ SystemContext::SystemContext() {
     m_connections = std::make_unique<ConnectionProvider>();
     m_queryHistory = makeQueryHistory(*settingsAccessor);
     m_settings = std::make_unique<SettingsProvider>(std::move(settingsAccessor), std::move(sessionAccessor), m_connections.get(), *m_queryHistory);
-    m_queries = std::make_unique<QueryProvider>(*m_connections, *m_queryHistory);
-    m_asyncQueries = std::make_unique<AsyncQueryProvider>(*m_connections, *m_queryHistory);
+    // 同期/非同期の両クエリ経路で ResultCache を共有する (#511)。従来は非同期経路 (フロントエンドの
+    // 主経路) がキャッシュに一切触れず、ヒット率が構造的にゼロだった
+    auto sharedResultCache = std::make_shared<ResultCache>();
+    m_queries = std::make_unique<QueryProvider>(*m_connections, *m_queryHistory, sharedResultCache);
+    m_asyncQueries = std::make_unique<AsyncQueryProvider>(*m_connections, *m_queryHistory, std::move(sharedResultCache));
     m_schema = std::make_unique<SchemaProvider>(*m_connections);
     m_transactions = std::make_unique<TransactionProvider>(*m_connections);
     m_exports = std::make_unique<ExportProvider>(*m_connections);

--- a/backend/database/result_cache.cpp
+++ b/backend/database/result_cache.cpp
@@ -48,6 +48,23 @@ void ResultCache::invalidate(std::string_view key) {
     }
 }
 
+void ResultCache::invalidatePrefix(std::string_view prefix) {
+    std::lock_guard lock(m_mutex);
+
+    if (prefix.empty()) {
+        return;
+    }
+    for (auto it = m_cache.begin(); it != m_cache.end();) {
+        if (it->first.starts_with(prefix)) {
+            m_currentSizeBytes -= it->second.sizeBytes;
+            m_lruList.erase(it->second.lruIt);
+            it = m_cache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
 void ResultCache::clear() {
     std::lock_guard lock(m_mutex);
     m_cache.clear();

--- a/backend/database/result_cache.h
+++ b/backend/database/result_cache.h
@@ -36,6 +36,16 @@ struct CacheStats {
     }
 };
 
+/// キャッシュキーのレイアウトは connectionId + '\0' + <payload>。この接頭辞で
+/// invalidatePrefix すると接続単位の一括無効化になる (#511)
+[[nodiscard]] inline std::string makeConnectionCachePrefix(std::string_view connectionId) {
+    std::string prefix;
+    prefix.reserve(connectionId.size() + 1);
+    prefix.append(connectionId);
+    prefix.push_back('\0');
+    return prefix;
+}
+
 class ResultCache {
 public:
     explicit ResultCache(size_t maxSizeBytes = 100 * 1024 * 1024) : m_maxSizeBytes(maxSizeBytes) {}
@@ -61,6 +71,9 @@ public:
 
     [[nodiscard]] bool contains(std::string_view key);
     void invalidate(std::string_view key);
+    /// Remove all entries whose key starts with prefix (#511: 接続単位の DML/USE 無効化用。
+    /// キーは connectionId + '\0' + ... 形式のため、接続プレフィックスで一括無効化できる)
+    void invalidatePrefix(std::string_view prefix);
     void clear();
 
     [[nodiscard]] size_t getCurrentSize() const;

--- a/backend/providers/async_query_provider.cpp
+++ b/backend/providers/async_query_provider.cpp
@@ -4,17 +4,21 @@
 #include "../database/driver_interface.h"
 #include "../database/psql_subprocess.h"
 #include "../database/query_history.h"
+#include "../database/result_cache.h"
 #include "../interfaces/providers/connection_provider.h"
 #include "../parsers/copy_block_detector.h"
+#include "../parsers/split_utils.h"
+#include "../parsers/sql_parser.h"
 #include "../utils/json_utils.h"
 #include "simdjson.h"
 
 #include <format>
+#include <optional>
 
 namespace velocitydb {
 
-AsyncQueryProvider::AsyncQueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory)
-    : m_connections(connections), m_queryHistory(queryHistory), m_asyncExecutor(std::make_unique<AsyncQueryExecutor>()) {}
+AsyncQueryProvider::AsyncQueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory, std::shared_ptr<ResultCache> resultCache)
+    : m_connections(connections), m_queryHistory(queryHistory), m_resultCache(std::move(resultCache)), m_asyncExecutor(std::make_unique<AsyncQueryExecutor>()) {}
 
 AsyncQueryProvider::~AsyncQueryProvider() = default;
 
@@ -44,6 +48,10 @@ std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
             if (!connParams) {
                 return JsonUtils::errorResponse("Connection parameters not found for psql delegation");
             }
+            if (m_resultCache) {
+                // COPY は書き込みのため接続単位でキャッシュ無効化 (#511)
+                m_resultCache->invalidatePrefix(makeConnectionCachePrefix(connectionId));
+            }
             auto connInfo = toPsqlConnectionInfo(*connParams);
             queryId = m_asyncExecutor->submitTask([connInfo = std::move(connInfo), sqlCopy = std::string(sqlQuery)](const std::atomic<bool>& cancelled) -> QueryResultVariant {
                 auto result = executePsql(connInfo, sqlCopy, cancelled);
@@ -53,10 +61,32 @@ std::string AsyncQueryProvider::executeAsyncQuery(std::string_view params) {
             });
         }
 
+        // 単文の読み取り専用クエリは QueryProvider と共有の ResultCache を利用する (#511)。
+        // ヒット時は DB を叩かず、キャッシュ済み ResultSet を返すタスクを積んで既存の
+        // ポーリング契約 (getAsyncQueryResult) をそのまま満たす。
+        std::string cacheKey;
+        bool fromCache = false;
+        if (queryId.empty() && m_resultCache) {
+            auto statements = splitStatementsForDriver(sqlQuery, driverType);
+            if (statements.size() == 1 && SQLParser::isReadOnlyQuery(sqlQuery)) {
+                cacheKey = makeConnectionCachePrefix(connectionId);
+                cacheKey += SQLParser::normalizeForCacheKey(sqlQuery);
+                auto cached = m_resultCache->getAndApply(cacheKey, [](const ResultSet& rs) { return std::optional<ResultSet>(rs); });
+                if (cached.has_value()) {
+                    fromCache = true;
+                    cacheKey.clear();  // ヒット結果を再 put しない
+                    queryId = m_asyncExecutor->submitTask([rs = std::move(*cached)](const std::atomic<bool>&) -> QueryResultVariant { return rs; });
+                }
+            } else {
+                // 書き込みの可能性がある (複文 or 非 SELECT) ため安全側で接続単位無効化 (#511)
+                m_resultCache->invalidatePrefix(makeConnectionCachePrefix(connectionId));
+            }
+        }
+
         if (queryId.empty())
             queryId = m_asyncExecutor->submitQuery(driver, sqlQuery);
 
-        m_queryMeta[queryId] = {.connectionId = std::string(connectionId), .sql = truncateHistorySql(sqlQuery)};
+        m_queryMeta[queryId] = {.connectionId = std::string(connectionId), .sql = truncateHistorySql(sqlQuery), .cacheKey = std::move(cacheKey), .skipHistory = fromCache};
         return JsonUtils::successResponse(std::format(R"({{"queryId":"{}"}})", queryId));
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
@@ -125,7 +155,11 @@ std::string AsyncQueryProvider::getAsyncQueryResult(std::string_view params) {
         // Record history on completion/failure; erase meta on any terminal status to prevent leaks
         if (auto metaIt = m_queryMeta.find(queryId); metaIt != m_queryMeta.end()) {
             bool terminal = asyncResult.status == QueryStatus::Completed || asyncResult.status == QueryStatus::Failed || asyncResult.status == QueryStatus::Cancelled;
-            if (asyncResult.status == QueryStatus::Completed || asyncResult.status == QueryStatus::Failed) {
+            // 完了した単文 SELECT の結果を共有キャッシュへ格納 (#511)。meta 消去前の一度きり
+            if (asyncResult.status == QueryStatus::Completed && m_resultCache && !metaIt->second.cacheKey.empty() && !asyncResult.multipleResults && asyncResult.result.has_value()) {
+                m_resultCache->put(metaIt->second.cacheKey, ResultSet(*asyncResult.result));
+            }
+            if (!metaIt->second.skipHistory && (asyncResult.status == QueryStatus::Completed || asyncResult.status == QueryStatus::Failed)) {
                 double totalExecMs = 0.0;
                 int64_t totalAffected = 0;
                 if (asyncResult.result.has_value()) {

--- a/backend/providers/async_query_provider.h
+++ b/backend/providers/async_query_provider.h
@@ -12,11 +12,13 @@ namespace velocitydb {
 class IConnectionProvider;
 class AsyncQueryExecutor;
 class QueryHistory;
+class ResultCache;
 
 /// Provider for asynchronous query execution
 class AsyncQueryProvider : public IAsyncQueryProvider {
 public:
-    AsyncQueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory);
+    /// resultCache は QueryProvider と共有される (#511)。nullptr の場合キャッシュ無効 (テスト用)
+    AsyncQueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory, std::shared_ptr<ResultCache> resultCache = nullptr);
     ~AsyncQueryProvider() override;
 
     AsyncQueryProvider(const AsyncQueryProvider&) = delete;
@@ -34,10 +36,13 @@ private:
     struct QueryMeta {
         std::string connectionId;
         std::string sql;
+        std::string cacheKey;      // 空でなければ完了時に結果をキャッシュへ格納する (#511)
+        bool skipHistory = false;  // キャッシュヒット由来の完了は履歴に記録しない (同期経路と整合)
     };
 
     IConnectionProvider& m_connections;
     QueryHistory& m_queryHistory;
+    std::shared_ptr<ResultCache> m_resultCache;
     std::unique_ptr<AsyncQueryExecutor> m_asyncExecutor;
     // Accessed only from WebView2 UI thread (IPC calls are serialized). No mutex needed.
     std::unordered_map<std::string, QueryMeta> m_queryMeta;

--- a/backend/providers/query_provider.cpp
+++ b/backend/providers/query_provider.cpp
@@ -43,7 +43,8 @@ template <typename T>
 
 }  // namespace
 
-QueryProvider::QueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory) : m_connections(connections), m_resultCache(std::make_unique<ResultCache>()), m_queryHistory(queryHistory) {}
+QueryProvider::QueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory, std::shared_ptr<ResultCache> resultCache)
+    : m_connections(connections), m_resultCache(resultCache ? std::move(resultCache) : std::make_shared<ResultCache>()), m_queryHistory(queryHistory) {}
 
 QueryProvider::~QueryProvider() = default;
 
@@ -132,6 +133,9 @@ std::string QueryProvider::executeQuery(std::string_view params) {
                 if (wrapTransaction)
                     (void)driver->execute("COMMIT");
 
+                // 複文には DML/DDL が含まれうるため接続単位でキャッシュ無効化 (#511)
+                m_resultCache->invalidatePrefix(makeConnectionCachePrefix(connectionId));
+
                 // Record history
                 double totalExecMs = 0.0;
                 int64_t totalAffected = 0;
@@ -162,6 +166,8 @@ std::string QueryProvider::executeQuery(std::string_view params) {
         if (SQLParser::isUseStatement(sqlQuery)) {
             try {
                 [[maybe_unused]] auto _ = driver->execute(sqlQuery);
+                // DB コンテキストが変わると同一 SQL でも結果が変わるため無効化 (#511)
+                m_resultCache->invalidatePrefix(makeConnectionCachePrefix(connectionId));
                 auto useResult = QueryResultFormatter::buildUseStatementResult(SQLParser::extractDatabaseName(sqlQuery));
                 recordHistory(sqlQuery, connectionId, 0.0, true);
                 return JsonUtils::successResponse(JsonUtils::serializeResultSet(useResult, false));
@@ -201,6 +207,10 @@ std::string QueryProvider::executeQuery(std::string_view params) {
             m_resultCache->put(cacheKey, std::move(queryResult));
             recordHistory(sqlQuery, connectionId, execTimeMs, true, {}, affectedRows);
         } else {
+            if (!selectQuery) {
+                // DML/DDL 成功後は同一接続のキャッシュ済み SELECT が陳腐化するため無効化 (#511)
+                m_resultCache->invalidatePrefix(makeConnectionCachePrefix(connectionId));
+            }
             recordHistory(sqlQuery, connectionId, queryResult.executionTimeMs, true, {}, queryResult.affectedRows);
         }
 
@@ -264,8 +274,28 @@ std::string QueryProvider::executeQueryPaginated(std::string_view params) {
             paginatedQuery = formatter->paginateQuery(std::string(sqlQuery) + orderByClause, startRow, endRow - startRow);
         }
 
+        // グリッドのスクロール往復で同一ページを再取得するため、読み取り専用クエリはページ単位で
+        // キャッシュする。DML/USE 時は接続プレフィックスごと無効化される (#511)
+        bool cacheable = SQLParser::isReadOnlyQuery(sqlQuery);
+        std::string cacheKey;
+        if (cacheable) {
+            cacheKey = makeConnectionCachePrefix(connectionId);
+            cacheKey += "pg:";
+            cacheKey += SQLParser::normalizeForCacheKey(sqlQuery);
+            cacheKey.push_back('\0');
+            cacheKey += orderByClause;
+            cacheKey += std::format("\x01{}-{}", startRow, endRow);
+            if (auto cachedJson = m_resultCache->getAndApply(cacheKey, [](const ResultSet& rs) { return JsonUtils::serializeResultSet(rs, false); }); !cachedJson.empty()) {
+                return JsonUtils::successResponse(cachedJson);
+            }
+        }
+
         auto queryResult = driver->execute(paginatedQuery);
-        return JsonUtils::successResponse(JsonUtils::serializeResultSet(queryResult, false));
+        std::string jsonResponse = JsonUtils::serializeResultSet(queryResult, false);
+        if (cacheable) {
+            m_resultCache->put(cacheKey, std::move(queryResult));
+        }
+        return JsonUtils::successResponse(jsonResponse);
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
     }
@@ -292,6 +322,24 @@ std::string QueryProvider::getRowCount(std::string_view params) {
         auto driverType = m_connections.getDriverType(connectionId);
         auto formatter = DriverFactory::createSqlFormattable(driverType);
         auto countQuery = formatter->rowCountQuery(sqlQuery);
+
+        // COUNT はグリッド初期化毎に呼ばれるためキャッシュする (DML/USE で接続単位無効化) (#511)
+        bool cacheable = SQLParser::isReadOnlyQuery(sqlQuery);
+        std::string cacheKey;
+        if (cacheable) {
+            cacheKey = makeConnectionCachePrefix(connectionId);
+            cacheKey += "cnt:";
+            cacheKey += SQLParser::normalizeForCacheKey(sqlQuery);
+            auto cachedJson = m_resultCache->getAndApply(cacheKey, [](const ResultSet& rs) -> std::string {
+                if (rs.rows.empty() || rs.rows[0].values.empty())
+                    return {};
+                return std::format("{{\"rowCount\":{}}}", rs.rows[0].values[0]);
+            });
+            if (!cachedJson.empty()) {
+                return JsonUtils::successResponse(cachedJson);
+            }
+        }
+
         auto queryResult = driver->execute(countQuery);
 
         if (queryResult.rows.empty() || queryResult.rows[0].values.empty()) {
@@ -299,7 +347,11 @@ std::string QueryProvider::getRowCount(std::string_view params) {
         }
 
         auto rowCount = queryResult.rows[0].values[0];
-        return JsonUtils::successResponse(std::format("{{\"rowCount\":{}}}", rowCount));
+        auto jsonResponse = std::format("{{\"rowCount\":{}}}", rowCount);
+        if (cacheable) {
+            m_resultCache->put(cacheKey, std::move(queryResult));
+        }
+        return JsonUtils::successResponse(jsonResponse);
     } catch (const std::exception& e) {
         return JsonUtils::errorResponse(e.what());
     }

--- a/backend/providers/query_provider.h
+++ b/backend/providers/query_provider.h
@@ -15,7 +15,9 @@ class QueryHistory;
 /// Provider for query execution, cache, history, and filtering
 class QueryProvider : public IQueryProvider {
 public:
-    QueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory);
+    /// resultCache を省略した場合は自前で生成する (テスト用)。本番では SystemContext が
+    /// AsyncQueryProvider と共有する ResultCache を注入する (#511)
+    QueryProvider(IConnectionProvider& connections, QueryHistory& queryHistory, std::shared_ptr<ResultCache> resultCache = nullptr);
     ~QueryProvider() override;
 
     QueryProvider(const QueryProvider&) = delete;
@@ -44,7 +46,7 @@ private:
     void recordHistory(std::string_view sql, std::string_view connectionId, double execTimeMs, bool success, std::string_view errorMsg = {}, int64_t affectedRows = 0);
 
     IConnectionProvider& m_connections;
-    std::unique_ptr<ResultCache> m_resultCache;
+    std::shared_ptr<ResultCache> m_resultCache;
     QueryHistory& m_queryHistory;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,8 @@ set(TEST_SOURCES
     providers/test_settings_provider.cpp
     providers/test_utility_provider.cpp
     providers/test_schema_provider.cpp
+    providers/test_async_query_provider.cpp
+    providers/test_query_provider_cache.cpp
     search/test_simd_filter.cpp
     utils/test_sql_validation.cpp
     database/test_thread_pool.cpp

--- a/tests/database/test_result_cache.cpp
+++ b/tests/database/test_result_cache.cpp
@@ -238,6 +238,50 @@ TEST_F(ResultCacheTest, ClearKeepsCumulativeStats) {
     EXPECT_EQ(stats.currentSizeBytes, 0u);
 }
 
+// #17 (#511): invalidatePrefix は接頭辞一致のエントリのみ削除する
+TEST_F(ResultCacheTest, InvalidatePrefixRemovesOnlyMatchingEntries) {
+    auto keyA1 = makeConnectionCachePrefix("connA") + "SELECT 1";
+    auto keyA2 = makeConnectionCachePrefix("connA") + "SELECT 2";
+    auto keyB = makeConnectionCachePrefix("connB") + "SELECT 1";
+    cache.put(keyA1, makeResultSet(1, 1));
+    cache.put(keyA2, makeResultSet(1, 1));
+    cache.put(keyB, makeResultSet(1, 1));
+
+    cache.invalidatePrefix(makeConnectionCachePrefix("connA"));
+
+    EXPECT_FALSE(cache.contains(keyA1));
+    EXPECT_FALSE(cache.contains(keyA2));
+    EXPECT_TRUE(cache.contains(keyB));
+}
+
+// #18 (#511): invalidatePrefix 後もサイズ追跡と LRU が整合する
+TEST_F(ResultCacheTest, InvalidatePrefixKeepsSizeAndLruConsistent) {
+    auto keyA = makeConnectionCachePrefix("connA") + "SELECT 1";
+    auto keyB = makeConnectionCachePrefix("connB") + "SELECT 1";
+    cache.put(keyA, makeResultSet(1, 1));
+    cache.put(keyB, makeResultSet(1, 1));
+    auto sizeBoth = cache.getCurrentSize();
+
+    cache.invalidatePrefix(makeConnectionCachePrefix("connA"));
+
+    EXPECT_LT(cache.getCurrentSize(), sizeBoth);
+    EXPECT_GT(cache.getCurrentSize(), 0u);
+    // 残った B は取得でき、再 put/evict 経路が壊れていない
+    auto colCount = cache.getAndApply(keyB, [](const ResultSet& r) { return r.columns.size(); });
+    EXPECT_EQ(colCount, 1u);
+    cache.put(keyA, makeResultSet(1, 1));
+    EXPECT_TRUE(cache.contains(keyA));
+}
+
+// #19 (#511): 空プレフィックスは全消しにならない (誤用ガード)
+TEST_F(ResultCacheTest, InvalidateEmptyPrefixIsNoop) {
+    cache.put("key1", makeResultSet(1, 1));
+
+    cache.invalidatePrefix("");
+
+    EXPECT_TRUE(cache.contains("key1"));
+}
+
 // #16 (#511): 統計スナップショットにサイズ情報が含まれる
 TEST_F(ResultCacheTest, StatsSnapshotIncludesSizes) {
     auto stats = cache.getStats();

--- a/tests/providers/test_async_query_provider.cpp
+++ b/tests/providers/test_async_query_provider.cpp
@@ -1,0 +1,194 @@
+#include "providers/async_query_provider.h"
+
+#include "database/connection_types.h"
+#include "database/driver_interface.h"
+#include "database/query_history.h"
+#include "database/result_cache.h"
+#include "interfaces/providers/connection_provider.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <deque>
+#include <format>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+using velocitydb::AsyncQueryProvider;
+using velocitydb::DatabaseConnectionParams;
+using velocitydb::DriverType;
+using velocitydb::IConnectionProvider;
+using velocitydb::IDatabaseDriver;
+using velocitydb::QueryHistory;
+using velocitydb::ResultCache;
+using velocitydb::ResultRow;
+using velocitydb::ResultSet;
+
+// #511: 非同期クエリ経路と QueryProvider の ResultCache 共有の振る舞いを、実 DB なしで
+// gmock 注入により検証する。ヒット時は driver->execute が呼ばれないこと、DML で接続単位
+// 無効化されること、キャッシュヒットは履歴に記録されないことが不変条件。
+
+namespace {
+
+class MockDatabaseDriver : public IDatabaseDriver {
+public:
+    MOCK_METHOD(bool, connect, (std::string_view), (override));
+    MOCK_METHOD(void, disconnect, (), (override));
+    MOCK_METHOD(bool, isConnected, (), (const, noexcept, override));
+    MOCK_METHOD(ResultSet, execute, (std::string_view), (override));
+    MOCK_METHOD(void, cancel, (), (override));
+    MOCK_METHOD(void, setQueryTimeout, (std::chrono::seconds), (override));
+    MOCK_METHOD(std::chrono::seconds, queryTimeout, (), (const, noexcept, override));
+    MOCK_METHOD(std::string, getLastError, (), (const, override));
+    MOCK_METHOD(DriverType, getType, (), (const, noexcept, override));
+};
+
+class MockConnectionProvider : public IConnectionProvider {
+public:
+    MOCK_METHOD(std::string, connectAsync, (std::string_view), (override));
+    MOCK_METHOD(std::string, getConnectResult, (std::string_view), (override));
+    MOCK_METHOD(std::string, cancelConnect, (std::string_view), (override));
+    MOCK_METHOD(std::string, disconnect, (std::string_view), (override));
+    MOCK_METHOD(std::string, testConnection, (std::string_view), (override));
+    MOCK_METHOD(std::shared_ptr<IDatabaseDriver>, getQueryDriver, (std::string_view), (override));
+    MOCK_METHOD(std::shared_ptr<IDatabaseDriver>, getMetadataDriver, (std::string_view), (override));
+    MOCK_METHOD(DriverType, getDriverType, (std::string_view), (const, override));
+    MOCK_METHOD(std::optional<DatabaseConnectionParams>, getConnectionParams, (std::string_view), (const, override));
+    MOCK_METHOD(void, setDefaultQueryTimeoutSeconds, (int), (override));
+};
+
+ResultSet makeSelectResult() {
+    auto arena = std::make_shared<std::deque<std::string>>();
+    arena->emplace_back("42");
+    ResultSet rs;
+    rs.columns.push_back({.name = "value", .type = "INT"});
+    ResultRow row;
+    row.values.emplace_back(arena->back());
+    row.nullFlags.push_back(false);
+    rs.rows.push_back(std::move(row));
+    rs.storage = std::move(arena);
+    return rs;
+}
+
+std::string extractQueryId(const std::string& response) {
+    auto pos = response.find(R"("queryId":")");
+    if (pos == std::string::npos)
+        return {};
+    pos += std::string_view(R"("queryId":")").size();
+    auto end = response.find('"', pos);
+    return response.substr(pos, end - pos);
+}
+
+}  // namespace
+
+class AsyncQueryProviderCacheTest : public ::testing::Test {
+protected:
+    ::testing::NiceMock<MockConnectionProvider> connections;
+    std::shared_ptr<::testing::NiceMock<MockDatabaseDriver>> driver = std::make_shared<::testing::NiceMock<MockDatabaseDriver>>();
+    QueryHistory history{100};
+    std::shared_ptr<ResultCache> cache = std::make_shared<ResultCache>();
+
+    void SetUp() override {
+        ON_CALL(connections, getQueryDriver(::testing::_)).WillByDefault(::testing::Return(driver));
+        ON_CALL(connections, getDriverType(::testing::_)).WillByDefault(::testing::Return(DriverType::SQLServer));
+        ON_CALL(*driver, getType()).WillByDefault(::testing::Return(DriverType::SQLServer));
+    }
+
+    // 提出 → 完了までポーリングして最終レスポンス JSON を返す
+    std::string submitAndAwait(AsyncQueryProvider& provider, std::string_view sql) {
+        auto submitRes = provider.executeAsyncQuery(std::format(R"({{"connectionId":"c1","sql":"{}"}})", sql));
+        auto queryId = extractQueryId(submitRes);
+        EXPECT_FALSE(queryId.empty()) << submitRes;
+        for (int i = 0; i < 1000; ++i) {
+            auto res = provider.getAsyncQueryResult(std::format(R"({{"queryId":"{}"}})", queryId));
+            if (res.find(R"("status":"completed")") != std::string::npos || res.find(R"("status":"failed")") != std::string::npos || res.find(R"("status":"cancelled")") != std::string::npos) {
+                return res;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        }
+        ADD_FAILURE() << "query did not reach terminal status";
+        return {};
+    }
+};
+
+// 同一 SELECT の 2 回目はキャッシュから返り、driver->execute は 1 回しか呼ばれない
+TEST_F(AsyncQueryProviderCacheTest, SecondSelectServedFromSharedCache) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(makeSelectResult()));
+    AsyncQueryProvider provider(connections, history, cache);
+
+    auto first = submitAndAwait(provider, "SELECT 1");
+    auto second = submitAndAwait(provider, "SELECT 1");
+
+    EXPECT_NE(first.find(R"("status":"completed")"), std::string::npos);
+    EXPECT_NE(second.find(R"("status":"completed")"), std::string::npos);
+    EXPECT_NE(second.find("42"), std::string::npos);
+    auto stats = cache->getStats();
+    EXPECT_EQ(stats.putCount, 1u);
+    EXPECT_GE(stats.hitCount, 1u);
+}
+
+// 末尾セミコロン・空白違いの同一クエリもキー正規化で同一エントリを共有する
+TEST_F(AsyncQueryProviderCacheTest, NormalizedVariantsShareCacheEntry) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(makeSelectResult()));
+    AsyncQueryProvider provider(connections, history, cache);
+
+    (void)submitAndAwait(provider, "SELECT 1");
+    auto second = submitAndAwait(provider, "SELECT 1;");
+    auto third = submitAndAwait(provider, "  SELECT 1  ");
+
+    EXPECT_NE(second.find("42"), std::string::npos);
+    EXPECT_NE(third.find("42"), std::string::npos);
+    EXPECT_EQ(cache->getStats().putCount, 1u);
+}
+
+// DML の提出で同一接続のキャッシュが無効化され、次の SELECT は再実行される
+TEST_F(AsyncQueryProviderCacheTest, DmlSubmissionInvalidatesConnectionCache) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(3).WillRepeatedly(::testing::Invoke([](std::string_view) { return makeSelectResult(); }));
+    AsyncQueryProvider provider(connections, history, cache);
+
+    (void)submitAndAwait(provider, "SELECT 1");                      // miss → put
+    (void)submitAndAwait(provider, "DELETE FROM t WHERE id = 1");    // 無効化 + 実行
+    auto third = submitAndAwait(provider, "SELECT 1");               // 再実行 (キャッシュ消滅済)
+
+    EXPECT_NE(third.find(R"("status":"completed")"), std::string::npos);
+    // 無効化後の再実行分で put が 2 回になっている
+    EXPECT_EQ(cache->getStats().putCount, 2u);
+}
+
+// キャッシュヒットは履歴に記録されない (同期経路 executeQuery と同じ振る舞い)
+TEST_F(AsyncQueryProviderCacheTest, CacheHitDoesNotRecordHistory) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(makeSelectResult()));
+    AsyncQueryProvider provider(connections, history, cache);
+
+    (void)submitAndAwait(provider, "SELECT 1");
+    (void)submitAndAwait(provider, "SELECT 1");
+
+    EXPECT_EQ(history.getAll().size(), 1u);
+}
+
+// 複文はキャッシュ対象外 (put されない)
+TEST_F(AsyncQueryProviderCacheTest, MultiStatementIsNotCached) {
+    EXPECT_CALL(*driver, execute(::testing::_)).WillRepeatedly(::testing::Invoke([](std::string_view) { return makeSelectResult(); }));
+    AsyncQueryProvider provider(connections, history, cache);
+
+    (void)submitAndAwait(provider, "SELECT 1; SELECT 2");
+
+    EXPECT_EQ(cache->getStats().putCount, 0u);
+}
+
+// キャッシュ未注入 (nullptr) でも従来どおり動作する
+TEST_F(AsyncQueryProviderCacheTest, WorksWithoutCache) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(2).WillRepeatedly(::testing::Invoke([](std::string_view) { return makeSelectResult(); }));
+    AsyncQueryProvider provider(connections, history, nullptr);
+
+    auto first = submitAndAwait(provider, "SELECT 1");
+    auto second = submitAndAwait(provider, "SELECT 1");
+
+    EXPECT_NE(first.find(R"("status":"completed")"), std::string::npos);
+    EXPECT_NE(second.find(R"("status":"completed")"), std::string::npos);
+}

--- a/tests/providers/test_query_provider_cache.cpp
+++ b/tests/providers/test_query_provider_cache.cpp
@@ -1,0 +1,155 @@
+#include "providers/query_provider.h"
+
+#include "database/connection_types.h"
+#include "database/driver_interface.h"
+#include "database/query_history.h"
+#include "database/result_cache.h"
+#include "interfaces/providers/connection_provider.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+using velocitydb::DatabaseConnectionParams;
+using velocitydb::DriverType;
+using velocitydb::IConnectionProvider;
+using velocitydb::IDatabaseDriver;
+using velocitydb::QueryHistory;
+using velocitydb::QueryProvider;
+using velocitydb::ResultCache;
+using velocitydb::ResultRow;
+using velocitydb::ResultSet;
+
+// #511: executeQueryPaginated / getRowCount のキャッシュと、DML/USE による接続単位
+// 無効化を driver->execute の呼び出し回数で検証する (実 DB 不要)。
+
+namespace {
+
+class MockDatabaseDriver : public IDatabaseDriver {
+public:
+    MOCK_METHOD(bool, connect, (std::string_view), (override));
+    MOCK_METHOD(void, disconnect, (), (override));
+    MOCK_METHOD(bool, isConnected, (), (const, noexcept, override));
+    MOCK_METHOD(ResultSet, execute, (std::string_view), (override));
+    MOCK_METHOD(void, cancel, (), (override));
+    MOCK_METHOD(void, setQueryTimeout, (std::chrono::seconds), (override));
+    MOCK_METHOD(std::chrono::seconds, queryTimeout, (), (const, noexcept, override));
+    MOCK_METHOD(std::string, getLastError, (), (const, override));
+    MOCK_METHOD(DriverType, getType, (), (const, noexcept, override));
+};
+
+class MockConnectionProvider : public IConnectionProvider {
+public:
+    MOCK_METHOD(std::string, connectAsync, (std::string_view), (override));
+    MOCK_METHOD(std::string, getConnectResult, (std::string_view), (override));
+    MOCK_METHOD(std::string, cancelConnect, (std::string_view), (override));
+    MOCK_METHOD(std::string, disconnect, (std::string_view), (override));
+    MOCK_METHOD(std::string, testConnection, (std::string_view), (override));
+    MOCK_METHOD(std::shared_ptr<IDatabaseDriver>, getQueryDriver, (std::string_view), (override));
+    MOCK_METHOD(std::shared_ptr<IDatabaseDriver>, getMetadataDriver, (std::string_view), (override));
+    MOCK_METHOD(DriverType, getDriverType, (std::string_view), (const, override));
+    MOCK_METHOD(std::optional<DatabaseConnectionParams>, getConnectionParams, (std::string_view), (const, override));
+    MOCK_METHOD(void, setDefaultQueryTimeoutSeconds, (int), (override));
+};
+
+ResultSet makeSingleValueResult(std::string value) {
+    auto arena = std::make_shared<std::deque<std::string>>();
+    arena->emplace_back(std::move(value));
+    ResultSet rs;
+    rs.columns.push_back({.name = "value", .type = "INT"});
+    ResultRow row;
+    row.values.emplace_back(arena->back());
+    row.nullFlags.push_back(false);
+    rs.rows.push_back(std::move(row));
+    rs.storage = std::move(arena);
+    return rs;
+}
+
+}  // namespace
+
+class QueryProviderCacheTest : public ::testing::Test {
+protected:
+    ::testing::NiceMock<MockConnectionProvider> connections;
+    std::shared_ptr<::testing::NiceMock<MockDatabaseDriver>> driver = std::make_shared<::testing::NiceMock<MockDatabaseDriver>>();
+    QueryHistory history{100};
+    std::shared_ptr<ResultCache> cache = std::make_shared<ResultCache>();
+
+    void SetUp() override {
+        ON_CALL(connections, getQueryDriver(::testing::_)).WillByDefault(::testing::Return(driver));
+        ON_CALL(connections, getDriverType(::testing::_)).WillByDefault(::testing::Return(DriverType::SQLServer));
+        ON_CALL(*driver, getType()).WillByDefault(::testing::Return(DriverType::SQLServer));
+    }
+
+    static constexpr std::string_view kPaginatedParams = R"({"connectionId":"c1","sql":"SELECT * FROM t","startRow":0,"endRow":100})";
+    static constexpr std::string_view kRowCountParams = R"({"connectionId":"c1","sql":"SELECT * FROM t"})";
+};
+
+// 同一パラメータのページ取得 2 回目はキャッシュ命中し、driver->execute は 1 回
+TEST_F(QueryProviderCacheTest, PaginatedSecondCallHitsCache) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(makeSingleValueResult("v1")));
+    QueryProvider provider(connections, history, cache);
+
+    auto first = provider.executeQueryPaginated(kPaginatedParams);
+    auto second = provider.executeQueryPaginated(kPaginatedParams);
+
+    EXPECT_EQ(first, second);
+    EXPECT_NE(first.find("v1"), std::string::npos);
+}
+
+// ページ範囲が違えば別エントリとして実行される
+TEST_F(QueryProviderCacheTest, DifferentPageRangeMisses) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(2).WillRepeatedly(::testing::Invoke([](std::string_view) { return makeSingleValueResult("v1"); }));
+    QueryProvider provider(connections, history, cache);
+
+    (void)provider.executeQueryPaginated(kPaginatedParams);
+    (void)provider.executeQueryPaginated(R"({"connectionId":"c1","sql":"SELECT * FROM t","startRow":100,"endRow":200})");
+}
+
+// ソート条件が違えば別エントリとして実行される
+TEST_F(QueryProviderCacheTest, DifferentSortModelMisses) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(2).WillRepeatedly(::testing::Invoke([](std::string_view) { return makeSingleValueResult("v1"); }));
+    QueryProvider provider(connections, history, cache);
+
+    (void)provider.executeQueryPaginated(kPaginatedParams);
+    (void)provider.executeQueryPaginated(R"({"connectionId":"c1","sql":"SELECT * FROM t","startRow":0,"endRow":100,"sortModel":[{"colId":"id","sort":"asc"}]})");
+}
+
+// getRowCount の 2 回目はキャッシュ命中し、driver->execute は 1 回
+TEST_F(QueryProviderCacheTest, RowCountSecondCallHitsCache) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(makeSingleValueResult("42")));
+    QueryProvider provider(connections, history, cache);
+
+    auto first = provider.getRowCount(kRowCountParams);
+    auto second = provider.getRowCount(kRowCountParams);
+
+    EXPECT_NE(first.find(R"("rowCount":42)"), std::string::npos);
+    EXPECT_EQ(first, second);
+}
+
+// DML (executeQuery) 成功後は同一接続のページ/行数キャッシュが無効化され再実行される
+TEST_F(QueryProviderCacheTest, DmlInvalidatesPaginatedAndRowCountCache) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(5).WillRepeatedly(::testing::Invoke([](std::string_view) { return makeSingleValueResult("42"); }));
+    QueryProvider provider(connections, history, cache);
+
+    (void)provider.executeQueryPaginated(kPaginatedParams);                                       // 1: miss → put
+    (void)provider.getRowCount(kRowCountParams);                                                  // 2: miss → put
+    (void)provider.executeQuery(R"({"connectionId":"c1","sql":"DELETE FROM t WHERE id = 1"})");   // 3: DML → 無効化
+    (void)provider.executeQueryPaginated(kPaginatedParams);                                       // 4: 再実行
+    (void)provider.getRowCount(kRowCountParams);                                                  // 5: 再実行
+}
+
+// 別接続の DML は他接続のキャッシュに影響しない
+TEST_F(QueryProviderCacheTest, DmlOnOtherConnectionKeepsCache) {
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(2).WillRepeatedly(::testing::Invoke([](std::string_view) { return makeSingleValueResult("42"); }));
+    QueryProvider provider(connections, history, cache);
+
+    (void)provider.executeQueryPaginated(kPaginatedParams);                                       // 1: miss → put (c1)
+    (void)provider.executeQuery(R"({"connectionId":"c2","sql":"DELETE FROM t WHERE id = 1"})");   // 2: c2 の DML
+    (void)provider.executeQueryPaginated(kPaginatedParams);                                       // c1 はキャッシュ命中
+}


### PR DESCRIPTION
## Summary

#511 の残スコープと #510 (クエリ実行系最適化) の対応。

### 最大の問題: フロントエンド主経路がキャッシュ未接続だった

フロントエンドのクエリ実行は `executeAsyncQuery` (非同期 + ポーリング) が主経路だが、ResultCache は `QueryProvider` (同期経路) 専有で、**非同期経路のヒット率は構造的にゼロ**だった (docs/PERFORMANCE_VALIDATION.md の「キャッシュハンドラ未到達」とも整合)。

### 変更内容

- **キャッシュ共有**: `SystemContext` が `ResultCache` を生成し、`QueryProvider` / `AsyncQueryProvider` に注入 (コンストラクタ注入、省略時は従来挙動でテスト互換)
- **非同期経路のキャッシュ利用**: 単文 SELECT はヒット時 DB を叩かずキャッシュ済み ResultSet を返すタスクを積む (ポーリング契約・レスポンス形状は不変)。完了時に put。ヒットは履歴に記録しない (同期経路と整合)
- **ページネーション/行数キャッシュ**: `executeQueryPaginated` (sql + ソート + ページ範囲キー) と `getRowCount` をキャッシュ対応。グリッドのスクロール往復・再表示が対象
- **DML 無効化 (`invalidatePrefix`)**: キーが connectionId + '\0' 接頭辞であることを利用し、DML/DDL/USE/COPY 実行時に接続単位で一括無効化。**従来は `invalidate()` が本番未使用で、DML 後も stale な SELECT 結果が無期限に残り得た** (正確性修正でもある)。USE は DB コンテキスト変更で同一 SQL の意味が変わるため必須
- TTL は導入しない: LRU + 明示的無効化で stale 問題が解消されたため現時点で不要と判断

### #510 のレビュー結論

`AsyncQueryExecutor` / `ThreadPool` の待機ロジックを精査: ThreadPool は condition_variable ベースで busy-wait なし、UI スレッドのポーリングは `wait_for(0)` 非ブロッキング、stale クエリ eviction は interval スロットリング済み — 構造的な問題なし。レイテンシ改善は上記キャッシュ統合 (再実行クエリが DB 往復ゼロに) で達成。スレッドプールサイズの計測駆動チューニングは実測環境が整い次第の課題として残す。

## Test plan

- [x] Google Test 430/430 通過 (新規15件: invalidatePrefix 3、非同期キャッシュ 6 (ヒット時 execute 1回・正規化キー共有・DML無効化・履歴スキップ・複文非キャッシュ・キャッシュ無し互換)、ページ/行数キャッシュ 6 (命中・範囲/ソート別キー・DML無効化・他接続非影響))
- [x] `uv run scripts/pdg.py lint` 通過
- [x] IPC レスポンス形状は不変 (フロントエンド変更なし)

Fixes #510
Fixes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)