### PR TITLE
feat(schema): 全テーブル列定義の一括取得 getAllColumns

### DIFF
--- a/backend/database/postgresql_dialect.cpp
+++ b/backend/database/postgresql_dialect.cpp
@@ -91,6 +91,34 @@ auto PostgreSqlDialect::getColumnsQuery(std::string_view schema, std::string_vie
                        s, t, s, t);
 }
 
+auto PostgreSqlDialect::getAllColumnsQuery() const -> std::string {
+    // getColumnsQuery の全テーブル版 (#512)。コメント取得は regclass の文字列パースでなく
+    // pg_class JOIN + col_description(oid, ...) を使う (mixed-case 名でも安全)
+    return "SELECT c.table_schema, "
+           "       c.table_name, "
+           "       c.column_name, "
+           "       c.data_type, "
+           "       COALESCE(c.character_maximum_length, c.numeric_precision, 0) AS col_size, "
+           "       CASE WHEN c.is_nullable = 'YES' THEN 1 ELSE 0 END AS is_nullable, "
+           "       CASE WHEN pk.column_name IS NOT NULL THEN 1 ELSE 0 END AS is_primary_key, "
+           "       COALESCE(col_description(pc.oid, c.ordinal_position), '') AS comment "
+           "FROM information_schema.columns c "
+           "LEFT JOIN pg_catalog.pg_namespace pn ON pn.nspname = c.table_schema "
+           "LEFT JOIN pg_catalog.pg_class pc ON pc.relnamespace = pn.oid AND pc.relname = c.table_name "
+           "LEFT JOIN ("
+           "    SELECT kcu.column_name, kcu.table_schema, kcu.table_name "
+           "    FROM information_schema.table_constraints tc "
+           "    JOIN information_schema.key_column_usage kcu "
+           "      ON tc.constraint_name = kcu.constraint_name "
+           "     AND tc.table_schema = kcu.table_schema "
+           "    WHERE tc.constraint_type = 'PRIMARY KEY'"
+           ") pk ON c.column_name = pk.column_name "
+           "    AND c.table_schema = pk.table_schema "
+           "    AND c.table_name = pk.table_name "
+           "WHERE c.table_schema NOT IN ('pg_catalog', 'information_schema') "
+           "ORDER BY c.table_schema, c.table_name, c.ordinal_position";
+}
+
 // Consumer expects: [0]=schema, [1]=name, [2]=type, [3]=rowCount, [4]=createdAt, [5]=modifiedAt, [6]=owner, [7]=comment
 auto PostgreSqlDialect::getTableMetadataQuery(std::string_view schema, std::string_view table) const -> std::string {
     auto s = escapeSql(schema);

--- a/backend/database/postgresql_dialect.h
+++ b/backend/database/postgresql_dialect.h
@@ -26,6 +26,7 @@ public:
     [[nodiscard]] std::string getDatabasesQuery() const override;
     [[nodiscard]] std::string getTablesQuery() const override;
     [[nodiscard]] std::string getColumnsQuery(std::string_view schema, std::string_view table) const override;
+    [[nodiscard]] std::string getAllColumnsQuery() const override;
     [[nodiscard]] std::string getTableMetadataQuery(std::string_view schema, std::string_view table) const override;
 
     // IRelationQueryable

--- a/backend/database/sqlserver_dialect.cpp
+++ b/backend/database/sqlserver_dialect.cpp
@@ -106,6 +106,39 @@ std::string SqlServerDialect::getColumnsQuery(std::string_view schema, std::stri
                        escapeSql(table), escapeSql(schema));
 }
 
+std::string SqlServerDialect::getAllColumnsQuery() const {
+    // getColumnsQuery の全テーブル版 (#512)。テーブル数 N に対する N 回の IPC/ODBC 往復を
+    // 1 クエリに畳む。PK 判定は per-table 版と同じ EXISTS 相関
+    return R"(
+            SELECT
+                s.name AS schema_name,
+                o.name AS table_name,
+                c.name AS column_name,
+                t.name AS data_type,
+                c.max_length,
+                c.is_nullable,
+                CASE WHEN EXISTS (
+                    SELECT 1
+                    FROM sys.index_columns ic
+                    INNER JOIN sys.indexes i ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+                    WHERE i.is_primary_key = 1
+                      AND ic.object_id = c.object_id
+                      AND ic.column_id = c.column_id
+                ) THEN 1 ELSE 0 END AS is_primary_key,
+                CAST(ep.value AS NVARCHAR(MAX)) AS comment
+            FROM sys.columns c
+            INNER JOIN sys.types t ON c.user_type_id = t.user_type_id
+            INNER JOIN sys.objects o ON c.object_id = o.object_id
+            INNER JOIN sys.schemas s ON o.schema_id = s.schema_id
+            LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id
+                AND ep.minor_id = c.column_id
+                AND ep.class = 1
+                AND ep.name = 'MS_Description'
+            WHERE o.type IN ('U', 'V')
+            ORDER BY s.name, o.name, c.column_id
+        )";
+}
+
 std::string SqlServerDialect::getTableMetadataQuery(std::string_view schema, std::string_view table) const {
     return std::format(R"(
             SELECT

--- a/backend/database/sqlserver_dialect.h
+++ b/backend/database/sqlserver_dialect.h
@@ -26,6 +26,7 @@ public:
     [[nodiscard]] std::string getDatabasesQuery() const override;
     [[nodiscard]] std::string getTablesQuery() const override;
     [[nodiscard]] std::string getColumnsQuery(std::string_view schema, std::string_view table) const override;
+    [[nodiscard]] std::string getAllColumnsQuery() const override;
     [[nodiscard]] std::string getTableMetadataQuery(std::string_view schema, std::string_view table) const override;
 
     // IRelationQueryable

--- a/backend/interfaces/providers/schema_provider.h
+++ b/backend/interfaces/providers/schema_provider.h
@@ -13,6 +13,8 @@ public:
     [[nodiscard]] virtual std::string getDatabases(std::string_view params) = 0;
     [[nodiscard]] virtual std::string getTables(std::string_view params) = 0;
     [[nodiscard]] virtual std::string getColumns(std::string_view params) = 0;
+    /// 全テーブル/ビューの列定義を 1 回の IPC で返す (#512: ER 図読込等の N+1 解消)
+    [[nodiscard]] virtual std::string getAllColumns(std::string_view params) = 0;
     [[nodiscard]] virtual std::string getIndexes(std::string_view params) = 0;
     [[nodiscard]] virtual std::string getConstraints(std::string_view params) = 0;
     [[nodiscard]] virtual std::string getForeignKeys(std::string_view params) = 0;

--- a/backend/interfaces/schema_queryable.h
+++ b/backend/interfaces/schema_queryable.h
@@ -16,6 +16,10 @@ public:
     [[nodiscard]] virtual std::string getDatabasesQuery() const = 0;
     [[nodiscard]] virtual std::string getTablesQuery() const = 0;
     [[nodiscard]] virtual std::string getColumnsQuery(std::string_view schema, std::string_view table) const = 0;
+    /// 全ユーザテーブル/ビューの列定義を 1 クエリで返す (#512: テーブル毎の N+1 往復解消)。
+    /// 行レイアウト: [0]=schema, [1]=table, [2]=column_name, [3]=data_type, [4]=size,
+    /// [5]=is_nullable, [6]=is_primary_key, [7]=comment。schema, table, 列順でソート済みであること
+    [[nodiscard]] virtual std::string getAllColumnsQuery() const = 0;
     [[nodiscard]] virtual std::string getTableMetadataQuery(std::string_view schema, std::string_view table) const = 0;
 
 protected:

--- a/backend/ipc_handler.cpp
+++ b/backend/ipc_handler.cpp
@@ -62,6 +62,7 @@ void IPCHandler::registerRoutes() {
     m_routes["getDatabases"] = [this](auto p) { return m_ctx.schema().getDatabases(p); };
     m_routes["getTables"] = [this](auto p) { return m_ctx.schema().getTables(p); };
     m_routes["getColumns"] = [this](auto p) { return m_ctx.schema().getColumns(p); };
+    m_routes["getAllColumns"] = [this](auto p) { return m_ctx.schema().getAllColumns(p); };
     m_routes["getIndexes"] = [this](auto p) { return m_ctx.schema().getIndexes(p); };
     m_routes["getConstraints"] = [this](auto p) { return m_ctx.schema().getConstraints(p); };
     m_routes["getForeignKeys"] = [this](auto p) { return m_ctx.schema().getForeignKeys(p); };

--- a/backend/providers/schema_provider.cpp
+++ b/backend/providers/schema_provider.cpp
@@ -205,6 +205,62 @@ std::string SchemaProvider::getColumns(std::string_view params) {
     });
 }
 
+std::string SchemaProvider::getAllColumns(std::string_view params) {
+    return withCache("getAllColumns:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
+        auto connectionIdResult = extractConnectionId(params);
+        if (!connectionIdResult) {
+            return std::unexpected(connectionIdResult.error());
+        }
+        auto connectionId = *connectionIdResult;
+        auto driver = m_connections.getMetadataDriver(connectionId);
+        if (!driver) [[unlikely]] {
+            return std::unexpected(std::format("Connection not found: {}", connectionId));
+        }
+        auto driverType = m_connections.getDriverType(connectionId);
+        auto dialect = DriverFactory::createSchemaQueryable(driverType);
+        auto queryResult = driver->execute(dialect->getAllColumnsQuery());
+
+        // (schema, table) でソート済みの行を走査し、テーブル毎の配列にグルーピングする
+        std::string json = "[";
+        std::string_view currentSchema;
+        std::string_view currentTable;
+        bool firstTable = true;
+        bool firstColumn = true;
+        for (const auto& row : queryResult.rows) {
+            if (row.values.size() < 7)
+                continue;
+            auto schema = row.values[0];
+            auto table = row.values[1];
+            if (firstTable || schema != currentSchema || table != currentTable) {
+                if (!firstTable)
+                    json += "]}";
+                if (!firstTable)
+                    json += ",";
+                json += std::format(R"({{"schema":"{}","table":"{}","columns":[)", JsonUtils::escapeString(schema), JsonUtils::escapeString(table));
+                currentSchema = schema;
+                currentTable = table;
+                firstTable = false;
+                firstColumn = true;
+            }
+            if (!firstColumn)
+                json += ",";
+            firstColumn = false;
+            std::string_view sizeStr = row.values[4];
+            int colSize = 0;
+            std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), colSize);
+            auto comment = row.values.size() >= 8 ? row.values[7] : std::string_view{};
+            auto nullable = row.values[5] == "1" ? "true" : "false";
+            auto isPk = row.values[6] == "1" ? "true" : "false";
+            json += std::format(R"({{"name":"{}","type":"{}","size":{},"nullable":{},"isPrimaryKey":{},"comment":"{}"}})", JsonUtils::escapeString(row.values[2]),
+                                JsonUtils::escapeString(row.values[3]), colSize, nullable, isPk, JsonUtils::escapeString(comment));
+        }
+        if (!firstTable)
+            json += "]}";
+        json += "]";
+        return json;
+    });
+}
+
 std::string SchemaProvider::getIndexes(std::string_view params) {
     return withCache("getIndexes:" + std::string(params), [&]() -> std::expected<std::string, std::string> {
         thread_local static simdjson::dom::parser parser;

--- a/backend/providers/schema_provider.h
+++ b/backend/providers/schema_provider.h
@@ -28,6 +28,7 @@ public:
     [[nodiscard]] std::string getDatabases(std::string_view params) override;
     [[nodiscard]] std::string getTables(std::string_view params) override;
     [[nodiscard]] std::string getColumns(std::string_view params) override;
+    [[nodiscard]] std::string getAllColumns(std::string_view params) override;
     [[nodiscard]] std::string getIndexes(std::string_view params) override;
     [[nodiscard]] std::string getConstraints(std::string_view params) override;
     [[nodiscard]] std::string getForeignKeys(std::string_view params) override;

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -79,6 +79,21 @@ export const mockData: Record<string, unknown> = {
       isPrimaryKey: false,
     },
   ],
+  getAllColumns: [
+    {
+      schema: 'dbo',
+      table: 'Users',
+      columns: [
+        { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+        { name: 'name', type: 'nvarchar', size: 255, nullable: false, isPrimaryKey: false },
+      ],
+    },
+    {
+      schema: 'dbo',
+      table: 'Orders',
+      columns: [{ name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true }],
+    },
+  ],
   getQueryHistory: [],
   parseERDiagram: { name: '', databaseType: '', tables: [], relations: [], shapes: [], ddl: '' },
   getExecutionPlan: { plan: 'Mock execution plan text', actual: false },

--- a/frontend/src/api/providers/schema.ts
+++ b/frontend/src/api/providers/schema.ts
@@ -112,10 +112,17 @@ export interface GetTablesResult {
   loadTimeMs: number;
 }
 
+export interface TableColumns {
+  schema: string;
+  table: string;
+  columns: ColumnInfo[];
+}
+
 export interface SchemaProvider {
   getDatabases(connectionId: string): Promise<string[]>;
   getTables(connectionId: string, database: string): Promise<GetTablesResult>;
   getColumns(connectionId: string, table: string): Promise<ColumnInfo[]>;
+  getAllColumns(connectionId: string): Promise<TableColumns[]>;
   getIndexes(connectionId: string, table: string): Promise<IndexInfo[]>;
   getConstraints(connectionId: string, table: string): Promise<ConstraintInfo[]>;
   getForeignKeys(connectionId: string, table: string): Promise<ForeignKeyInfo[]>;
@@ -160,6 +167,10 @@ class SchemaProviderImpl extends BaseProvider implements SchemaProvider {
 
   async getColumns(connectionId: string, table: string): Promise<ColumnInfo[]> {
     return this.invokeAndParse('getColumns', { connectionId, table }, S.getColumns);
+  }
+
+  async getAllColumns(connectionId: string): Promise<TableColumns[]> {
+    return this.invokeAndParse('getAllColumns', { connectionId }, S.getAllColumns);
   }
 
   async getIndexes(connectionId: string, table: string): Promise<IndexInfo[]> {

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -74,6 +74,13 @@ export const getColumns = z.array(
     comment: z.string().optional(),
   })
 );
+export const getAllColumns = z.array(
+  z.object({
+    schema: z.string(),
+    table: z.string(),
+    columns: getColumns,
+  })
+);
 
 // --- Transaction ---
 export const beginTransaction = zVoidResponse;

--- a/frontend/src/store/erDiagramStore.ts
+++ b/frontend/src/store/erDiagramStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { schemaProvider } from '../api/providers';
+import type { ColumnInfo } from '../api/providers/schema';
 import type { ERRelationEdge, ERShapeNode, ERTableNode } from '../types';
 import { DEFAULT_PAGE, GRID_LAYOUT } from '../utils/erDiagramConstants';
 import { type ERDiagramModel, toERDiagramModel } from '../utils/erDiagramParser';
@@ -129,7 +130,18 @@ export const useERDiagramStore = create<ERDiagramState>((set, get) => ({
 
       const { columns: gridColumns, nodeWidth, nodeHeight, gap } = GRID_LAYOUT;
 
-      // Load columns for each table
+      // 全テーブルの列を 1 回の IPC で取得 (#512: テーブル毎の N+1 往復解消)。
+      // 失敗時は従来のテーブル毎取得にフォールバック
+      let bulkColumns: Map<string, ColumnInfo[]> | null = null;
+      try {
+        const allColumns = await schemaProvider.getAllColumns(connectionId);
+        bulkColumns = new Map(
+          allColumns.map((t) => [t.schema ? `${t.schema}.${t.table}` : t.table, t.columns])
+        );
+      } catch (err) {
+        console.warn('getAllColumns failed; falling back to per-table fetch:', err);
+      }
+
       for (let i = 0; i < tablesData.length; i++) {
         const tableInfo = tablesData[i];
         if (tableInfo.type !== 'TABLE' && tableInfo.type !== 'VIEW') continue;
@@ -139,7 +151,9 @@ export const useERDiagramStore = create<ERDiagramState>((set, get) => ({
           : tableInfo.name;
 
         try {
-          const columnsData = await schemaProvider.getColumns(connectionId, fullTableName);
+          const columnsData =
+            bulkColumns?.get(fullTableName) ??
+            (await schemaProvider.getColumns(connectionId, fullTableName));
 
           const col = i % gridColumns;
           const row = Math.floor(i / gridColumns);

--- a/frontend/src/tests/api/schemaProvider.test.ts
+++ b/frontend/src/tests/api/schemaProvider.test.ts
@@ -64,6 +64,23 @@ describe('schemaProvider', () => {
     expect(mock.calls[0]?.params).toEqual({ connectionId: 'conn-1', table: 'users' });
   });
 
+  it('getAllColumns は connectionId を渡しテーブル毎の列配列を返す (#512)', async () => {
+    mock.setResponse('getAllColumns', [
+      {
+        schema: 'dbo',
+        table: 'users',
+        columns: [{ name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true }],
+      },
+    ]);
+
+    const result = await schemaProvider.getAllColumns('conn-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ schema: 'dbo', table: 'users' });
+    expect(result[0].columns).toHaveLength(1);
+    expect(mock.calls[0]).toEqual({ method: 'getAllColumns', params: { connectionId: 'conn-1' } });
+  });
+
   it('getIndexes は index 配列を返す', async () => {
     mock.setResponse('getIndexes', [
       { name: 'pk_users', columns: ['id'], isUnique: true, isPrimaryKey: true, type: 'BTREE' },

--- a/frontend/src/tests/stores/erDiagramStore.test.ts
+++ b/frontend/src/tests/stores/erDiagramStore.test.ts
@@ -76,3 +76,53 @@ describe('erDiagramStore - viewport & focus', () => {
     });
   });
 });
+
+describe('erDiagramStore - loadFromDatabase (#512 一括列取得)', () => {
+  const pk = { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true };
+
+  beforeEach(() => {
+    useERDiagramStore.setState({ tables: [], relations: [], isLoading: false, error: null });
+  });
+
+  it('getAllColumns を 1 回だけ呼び、テーブル毎の getColumns を呼ばない', async () => {
+    const { schemaProvider } = await import('../../api/providers');
+    const getTables = vi.fn().mockResolvedValue({
+      tables: [
+        { schema: 'dbo', name: 'Users', type: 'TABLE' },
+        { schema: 'dbo', name: 'Orders', type: 'TABLE' },
+      ],
+      loadTimeMs: 1,
+    });
+    const getAllColumns = vi.fn().mockResolvedValue([
+      { schema: 'dbo', table: 'Users', columns: [pk] },
+      { schema: 'dbo', table: 'Orders', columns: [pk] },
+    ]);
+    const getColumns = vi.fn();
+    Object.assign(schemaProvider, { getTables, getAllColumns, getColumns });
+
+    await useERDiagramStore.getState().loadFromDatabase('conn-1', 'db1');
+
+    expect(getAllColumns).toHaveBeenCalledTimes(1);
+    expect(getColumns).not.toHaveBeenCalled();
+    expect(useERDiagramStore.getState().tables).toHaveLength(2);
+  });
+
+  it('getAllColumns 失敗時はテーブル毎の getColumns にフォールバックする', async () => {
+    const { schemaProvider } = await import('../../api/providers');
+    const getTables = vi.fn().mockResolvedValue({
+      tables: [
+        { schema: 'dbo', name: 'Users', type: 'TABLE' },
+        { schema: 'dbo', name: 'Orders', type: 'TABLE' },
+      ],
+      loadTimeMs: 1,
+    });
+    const getAllColumns = vi.fn().mockRejectedValue(new Error('not supported'));
+    const getColumns = vi.fn().mockResolvedValue([pk]);
+    Object.assign(schemaProvider, { getTables, getAllColumns, getColumns });
+
+    await useERDiagramStore.getState().loadFromDatabase('conn-1', 'db1');
+
+    expect(getColumns).toHaveBeenCalledTimes(2);
+    expect(useERDiagramStore.getState().tables).toHaveLength(2);
+  });
+});

--- a/tests/providers/test_schema_provider.cpp
+++ b/tests/providers/test_schema_provider.cpp
@@ -139,3 +139,50 @@ TEST_F(SchemaProviderCacheTest, ErrorResponseIsNotCached) {
     EXPECT_NE(firstError.find("Connection not found"), std::string::npos);
     EXPECT_NE(secondOk.find("PK_Users"), std::string::npos);
 }
+
+// --- getAllColumns (#512) ---
+
+// (schema, table) ソート済み行がテーブル毎にグルーピングされる
+TEST_F(SchemaProviderCacheTest, GetAllColumnsGroupsRowsByTable) {
+    resolveDriverByDefault();
+    // 行レイアウト: schema, table, column, type, size, nullable, isPk, comment
+    auto rows = makeResultSet({
+        {"dbo", "orders", "id", "int", "4", "0", "1", ""},
+        {"dbo", "orders", "user_id", "int", "4", "1", "0", "FK"},
+        {"dbo", "users", "id", "int", "4", "0", "1", ""},
+    });
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(rows));
+
+    SchemaProvider provider(connections);
+    const auto json = provider.getAllColumns(R"({"connectionId":"db_1"})");
+
+    EXPECT_NE(json.find(R"("schema":"dbo","table":"orders")"), std::string::npos);
+    EXPECT_NE(json.find(R"("schema":"dbo","table":"users")"), std::string::npos);
+    EXPECT_NE(json.find(R"("name":"user_id","type":"int","size":4,"nullable":true,"isPrimaryKey":false,"comment":"FK")"), std::string::npos);
+    // orders グループが users より先 (ソート順保持)
+    EXPECT_LT(json.find(R"("table":"orders")"), json.find(R"("table":"users")"));
+}
+
+// 2 回目はキャッシュ命中し driver->execute は 1 回
+TEST_F(SchemaProviderCacheTest, GetAllColumnsSecondCallHitsCache) {
+    resolveDriverByDefault();
+    auto rows = makeResultSet({{"dbo", "users", "id", "int", "4", "0", "1", ""}});
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(rows));
+
+    SchemaProvider provider(connections);
+    const auto first = provider.getAllColumns(R"({"connectionId":"db_1"})");
+    const auto second = provider.getAllColumns(R"({"connectionId":"db_1"})");
+
+    EXPECT_EQ(first, second);
+}
+
+// テーブルが 1 件もない場合は空配列
+TEST_F(SchemaProviderCacheTest, GetAllColumnsEmptySchemaYieldsEmptyArray) {
+    resolveDriverByDefault();
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(ResultSet{}));
+
+    SchemaProvider provider(connections);
+    const auto json = provider.getAllColumns(R"({"connectionId":"db_1"})");
+
+    EXPECT_NE(json.find(R"("data":[])"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

#512 (schema_inspector の並列化・キャッシュ) の対応。

### 現状分析

- メタデータキャッシュは導入済み (SchemaProvider の withCache: TTL + 上限 + clearSchemaCache)
- 最大のボトルネックはキャッシュではなく **ER 図の DB 読込の N+1**: テーブル毎に `getColumns` を直列 await しており、1000 テーブルなら 1000 回の IPC + ODBC 往復 (1回 ~90ms 実測 → 理論上 90 秒級)

### 変更内容

- **`getAllColumns` IPC を新設**: 全ユーザテーブル/ビューの列定義を **1 クエリ**で取得し、(schema, table) でグルーピングして返す
  - `ISchemaQueryable::getAllColumnsQuery` を SQL Server (sys.columns ベース、PK は EXISTS 相関) / PostgreSQL (information_schema.columns、コメントは pg_class JOIN + col_description で mixed-case 安全) 両方に実装
  - 既存の withCache に乗せる (2回目以降はキャッシュ命中)
- **ER 図読込を一括取得に変更**: `erDiagramStore.loadFromDatabase` が getAllColumns 1 回 + Map 参照になり、往復回数がテーブル数 N から **1** に。失敗時は従来のテーブル毎取得へフォールバック
- スレッド並列化は不採用: ODBC 接続はコネクション単位で直列であり、複数メタデータ接続を張るより 1 クエリに畳む方が単純で効果が大きい (往復 N→1 は並列化の上限を超える改善)

## Test plan

- [x] Google Test: 新規3件 (グルーピング・キャッシュ命中・空スキーマ) 含め通過 (QueryHistory の時間系テスト 1 件が高負荷時にフレークしたが単体再実行で通過、本変更と無関係)
- [x] Vitest: 対象テスト (schemaProvider 18件 / erDiagramStore 8件 — 一括取得で getColumns 不呼出・フォールバック動作) 通過
- [x] lint (clang-format / biome) 通過

Fixes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)