### PR TITLE
feat(compare): データ比較機能 (テーブル/クエリ結果の差分表示)

### DIFF
--- a/frontend/src/components/dialogs/DataCompareDialog.module.css
+++ b/frontend/src/components/dialogs/DataCompareDialog.module.css
@@ -1,0 +1,290 @@
+/* DataCompareDialog (#256): データ比較ダイアログ */
+
+.overlay {
+  composes: overlay from "./DialogBase.module.css";
+}
+
+.dialog {
+  composes: dialog from "./DialogBase.module.css";
+  width: 960px;
+  max-width: 95vw;
+  height: 85vh;
+}
+
+.header {
+  composes: header from "./DialogBase.module.css";
+}
+
+.closeButton {
+  composes: closeButton from "./DialogBase.module.css";
+}
+
+.content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.sources {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.sourcePanel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background-color: var(--bg-secondary);
+}
+
+.sourceTitle {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.label {
+  composes: label from "./DialogBase.module.css";
+}
+
+.select {
+  composes: select from "./DialogBase.module.css";
+}
+
+.input {
+  composes: input from "./DialogBase.module.css";
+}
+
+.textarea {
+  composes: textarea from "./DialogBase.module.css";
+  resize: vertical;
+  min-height: 60px;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+}
+
+.modeTabs {
+  display: flex;
+  gap: 4px;
+}
+
+.modeTab {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.modeTabActive {
+  background-color: var(--accent-color);
+  border-color: var(--accent-color);
+  color: #fff;
+}
+
+.actionsRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.button {
+  composes: button from "./DialogBase.module.css";
+}
+
+.buttonPrimary {
+  composes: buttonPrimary from "./DialogBase.module.css";
+}
+
+.error {
+  composes: error from "./DialogBase.module.css";
+}
+
+.keySection {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.keySectionLabel {
+  font-size: 13px;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.keyCheckbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-primary);
+  cursor: pointer;
+  padding: 2px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.summaryRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.summaryBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: 10px;
+  font-size: 12px;
+  color: var(--text-primary);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.badgeAdded {
+  border-color: var(--success-color, #4caf50);
+  color: var(--success-color, #4caf50);
+}
+
+.badgeRemoved {
+  border-color: var(--error-color, #f44336);
+  color: var(--error-color, #f44336);
+}
+
+.badgeModified {
+  border-color: var(--warning-color, #ff9800);
+  color: var(--warning-color, #ff9800);
+}
+
+.warnings {
+  margin: 0;
+  padding: 8px 12px 8px 28px;
+  border: 1px solid var(--warning-color, #ff9800);
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.filterToggle {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.gridWrapper {
+  flex: 1;
+  min-height: 120px;
+  overflow: auto;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+}
+
+.grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.grid th {
+  position: sticky;
+  top: 0;
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-color);
+  white-space: nowrap;
+}
+
+.grid td {
+  padding: 4px 10px;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-primary);
+  white-space: nowrap;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.rowAdded {
+  background-color: rgba(76, 175, 80, 0.12);
+}
+
+.rowRemoved {
+  background-color: rgba(244, 67, 54, 0.12);
+}
+
+.rowModified {
+  background-color: rgba(255, 152, 0, 0.08);
+}
+
+.statusCell {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.statusAdded {
+  color: var(--success-color, #4caf50);
+}
+
+.statusRemoved {
+  color: var(--error-color, #f44336);
+}
+
+.statusModified {
+  color: var(--warning-color, #ff9800);
+}
+
+.statusIdentical {
+  color: var(--text-secondary);
+}
+
+.changedCell {
+  background-color: rgba(255, 152, 0, 0.25);
+  border-radius: 2px;
+}
+
+.oldValue {
+  color: var(--error-color, #f44336);
+  text-decoration: line-through;
+}
+
+.arrow {
+  color: var(--text-secondary);
+  margin: 0 4px;
+}
+
+.newValue {
+  color: var(--success-color, #4caf50);
+}
+
+.nullValue {
+  font-style: italic;
+  color: var(--text-secondary);
+}
+
+.emptyState {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.noteText {
+  font-size: 12px;
+  color: var(--text-secondary);
+}

--- a/frontend/src/components/dialogs/DataCompareDialog.tsx
+++ b/frontend/src/components/dialogs/DataCompareDialog.tsx
@@ -1,0 +1,480 @@
+import { useCallback, useMemo, useState } from 'react';
+import { queryProvider } from '../../api/providers';
+import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
+import { useConnections } from '../../store/connectionStore';
+import type { Connection } from '../../types';
+import {
+  type DataDiffResult,
+  type DiffResultSet,
+  type DiffRow,
+  diffResultSetsAsync,
+  formatDiffSummary,
+} from '../../utils/dataDiff';
+import { buildSelectSql } from '../../utils/sqlIdentifier';
+import { DialogOverlay } from '../common/DialogOverlay';
+import styles from './DataCompareDialog.module.css';
+
+interface DataCompareDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+type SourceMode = 'table' | 'sql';
+
+interface SourceState {
+  connectionId: string;
+  mode: SourceMode;
+  table: string;
+  sql: string;
+}
+
+const EMPTY_SOURCE: SourceState = { connectionId: '', mode: 'table', table: '', sql: '' };
+
+/** 差分グリッドに表示する最大行数 (DOM 肥大化防止) */
+const DISPLAY_ROW_LIMIT = 500;
+
+function findConnection(connections: Connection[], id: string): Connection | undefined {
+  return connections.find((c) => c.id === id);
+}
+
+async function fetchSource(source: SourceState, connection: Connection): Promise<DiffResultSet> {
+  const sql =
+    source.mode === 'table'
+      ? buildSelectSql(source.table.trim(), connection.dbType)
+      : source.sql.trim();
+  const result = await queryProvider.executeQuery(source.connectionId, sql, false);
+  if ('multipleResults' in result) {
+    const first = result.results[0];
+    if (first === undefined) {
+      throw new Error('クエリが結果セットを返しませんでした');
+    }
+    return { columns: first.data.columns, rows: first.data.rows };
+  }
+  return { columns: result.columns, rows: result.rows };
+}
+
+function validateSource(source: SourceState, label: string): string | null {
+  if (!source.connectionId) return `${label}: 接続を選択してください`;
+  if (source.mode === 'table' && source.table.trim() === '') {
+    return `${label}: テーブル名を入力してください`;
+  }
+  if (source.mode === 'sql' && source.sql.trim() === '') {
+    return `${label}: SQLを入力してください`;
+  }
+  return null;
+}
+
+function sourceLabel(source: SourceState, connection: Connection | undefined): string {
+  const target = source.mode === 'table' ? source.table.trim() : 'カスタムSQL';
+  return `${connection?.name ?? '不明な接続'} / ${target}`;
+}
+
+function renderCellValue(value: string | null) {
+  if (value === null) return <span className={styles.nullValue}>NULL</span>;
+  return value;
+}
+
+const STATUS_LABELS: Record<DiffRow['status'], string> = {
+  added: '追加',
+  removed: '削除',
+  modified: '変更',
+  identical: '一致',
+};
+
+const STATUS_CLASSES: Record<DiffRow['status'], string> = {
+  added: styles.statusAdded,
+  removed: styles.statusRemoved,
+  modified: styles.statusModified,
+  identical: styles.statusIdentical,
+};
+
+const ROW_CLASSES: Partial<Record<DiffRow['status'], string>> = {
+  added: styles.rowAdded,
+  removed: styles.rowRemoved,
+  modified: styles.rowModified,
+};
+
+interface SourceEditorProps {
+  label: 'A' | 'B';
+  source: SourceState;
+  connections: Connection[];
+  disabled: boolean;
+  onChange: (patch: Partial<SourceState>) => void;
+}
+
+function SourceEditor({ label, source, connections, disabled, onChange }: SourceEditorProps) {
+  const connectionSelectId = `compare-conn-${label}`;
+  const tableInputId = `compare-table-${label}`;
+  const sqlInputId = `compare-sql-${label}`;
+  return (
+    <div className={styles.sourcePanel}>
+      <span className={styles.sourceTitle}>ソース {label}</span>
+      <label className={styles.label} htmlFor={connectionSelectId}>
+        接続 ({label})
+      </label>
+      <select
+        id={connectionSelectId}
+        className={styles.select}
+        value={source.connectionId}
+        disabled={disabled}
+        onChange={(e) => onChange({ connectionId: e.target.value })}
+      >
+        <option value="">接続を選択...</option>
+        {connections.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.name} ({c.server}/{c.database})
+          </option>
+        ))}
+      </select>
+      <div className={styles.modeTabs}>
+        <button
+          type="button"
+          className={`${styles.modeTab} ${source.mode === 'table' ? styles.modeTabActive : ''}`}
+          disabled={disabled}
+          onClick={() => onChange({ mode: 'table' })}
+        >
+          テーブル
+        </button>
+        <button
+          type="button"
+          className={`${styles.modeTab} ${source.mode === 'sql' ? styles.modeTabActive : ''}`}
+          disabled={disabled}
+          onClick={() => onChange({ mode: 'sql' })}
+        >
+          SQL
+        </button>
+      </div>
+      {source.mode === 'table' ? (
+        <>
+          <label className={styles.label} htmlFor={tableInputId}>
+            テーブル名 ({label})
+          </label>
+          <input
+            id={tableInputId}
+            className={styles.input}
+            type="text"
+            placeholder="schema.table (例: dbo.Users)"
+            value={source.table}
+            disabled={disabled}
+            onChange={(e) => onChange({ table: e.target.value })}
+          />
+        </>
+      ) : (
+        <>
+          <label className={styles.label} htmlFor={sqlInputId}>
+            SQL ({label})
+          </label>
+          <textarea
+            id={sqlInputId}
+            className={styles.textarea}
+            placeholder="SELECT ..."
+            value={source.sql}
+            disabled={disabled}
+            onChange={(e) => onChange({ sql: e.target.value })}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+export function DataCompareDialog({ isOpen, onClose }: DataCompareDialogProps) {
+  useDialogKeyboard({ isOpen, onEscape: onClose });
+  const connections = useConnections();
+  const copyToClipboard = useCopyToClipboard();
+
+  const [sourceA, setSourceA] = useState<SourceState>(EMPTY_SOURCE);
+  const [sourceB, setSourceB] = useState<SourceState>(EMPTY_SOURCE);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState<{ a: DiffResultSet; b: DiffResultSet } | null>(null);
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [isComparing, setIsComparing] = useState(false);
+  const [diff, setDiff] = useState<DataDiffResult | null>(null);
+  const [filter, setFilter] = useState<'diff' | 'all'>('diff');
+
+  const commonColumns = useMemo(() => {
+    if (loaded === null) return [];
+    const bNames = new Set(loaded.b.columns.map((c) => c.name));
+    return loaded.a.columns.map((c) => c.name).filter((n) => bNames.has(n));
+  }, [loaded]);
+
+  const updateSourceA = useCallback(
+    (patch: Partial<SourceState>) => setSourceA((prev) => ({ ...prev, ...patch })),
+    []
+  );
+  const updateSourceB = useCallback(
+    (patch: Partial<SourceState>) => setSourceB((prev) => ({ ...prev, ...patch })),
+    []
+  );
+
+  const loadSources = useCallback(async () => {
+    const validationError = validateSource(sourceA, 'A') ?? validateSource(sourceB, 'B');
+    if (validationError !== null) {
+      setLoadError(validationError);
+      return;
+    }
+    const connA = findConnection(connections, sourceA.connectionId);
+    const connB = findConnection(connections, sourceB.connectionId);
+    if (connA === undefined || connB === undefined) {
+      setLoadError('接続が見つかりません');
+      return;
+    }
+    setIsLoading(true);
+    setLoadError(null);
+    setDiff(null);
+    setLoaded(null);
+    try {
+      const [a, b] = await Promise.all([fetchSource(sourceA, connA), fetchSource(sourceB, connB)]);
+      const bNames = new Set(b.columns.map((c) => c.name));
+      const common = a.columns.map((c) => c.name).filter((n) => bNames.has(n));
+      if (common.length === 0) {
+        setLoadError('共通カラムが存在しないため比較できません');
+        return;
+      }
+      setLoaded({ a, b });
+      setSelectedKeys([common[0]]);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : 'データの読み込みに失敗しました');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [connections, sourceA, sourceB]);
+
+  const toggleKey = useCallback((name: string) => {
+    setDiff(null);
+    setSelectedKeys((prev) =>
+      prev.includes(name) ? prev.filter((k) => k !== name) : [...prev, name]
+    );
+  }, []);
+
+  const runCompare = useCallback(async () => {
+    if (loaded === null || selectedKeys.length === 0) return;
+    setIsComparing(true);
+    setLoadError(null);
+    try {
+      const result = await diffResultSetsAsync(loaded.a, loaded.b, { keyColumns: selectedKeys });
+      setDiff(result);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : '比較に失敗しました');
+    } finally {
+      setIsComparing(false);
+    }
+  }, [loaded, selectedKeys]);
+
+  const copySummary = useCallback(() => {
+    if (diff === null) return;
+    const text = formatDiffSummary(diff, {
+      a: sourceLabel(sourceA, findConnection(connections, sourceA.connectionId)),
+      b: sourceLabel(sourceB, findConnection(connections, sourceB.connectionId)),
+    });
+    copyToClipboard(text, 'サマリをコピーしました');
+  }, [diff, sourceA, sourceB, connections, copyToClipboard]);
+
+  const visibleRows = useMemo(() => {
+    if (diff === null) return [];
+    const rows = filter === 'diff' ? diff.rows.filter((r) => r.status !== 'identical') : diff.rows;
+    return rows.slice(0, DISPLAY_ROW_LIMIT);
+  }, [diff, filter]);
+
+  const totalVisibleCount = useMemo(() => {
+    if (diff === null) return 0;
+    if (filter === 'all') return diff.rows.length;
+    const { added, removed, modified } = diff.summary;
+    return added + removed + modified;
+  }, [diff, filter]);
+
+  if (!isOpen) return null;
+
+  return (
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+      ariaLabelledBy="data-compare-title"
+    >
+      <div className={styles.header}>
+        <h2 id="data-compare-title">データ比較</h2>
+        <button type="button" className={styles.closeButton} onClick={onClose} title="閉じる">
+          {'✕'}
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        {connections.length === 0 ? (
+          <div className={styles.emptyState}>比較するにはデータベースに接続してください</div>
+        ) : (
+          <>
+            <div className={styles.sources}>
+              <SourceEditor
+                label="A"
+                source={sourceA}
+                connections={connections}
+                disabled={isLoading}
+                onChange={updateSourceA}
+              />
+              <SourceEditor
+                label="B"
+                source={sourceB}
+                connections={connections}
+                disabled={isLoading}
+                onChange={updateSourceB}
+              />
+            </div>
+
+            <div className={styles.actionsRow}>
+              <button
+                type="button"
+                className={`${styles.button} ${styles.buttonPrimary}`}
+                onClick={loadSources}
+                disabled={isLoading}
+              >
+                {isLoading ? '読み込み中...' : 'データ読み込み'}
+              </button>
+              {loaded !== null && (
+                <span className={styles.noteText}>
+                  A: {loaded.a.rows.length}行 × {loaded.a.columns.length}列 / B:{' '}
+                  {loaded.b.rows.length}行 × {loaded.b.columns.length}列
+                </span>
+              )}
+            </div>
+
+            {loadError !== null && <div className={styles.error}>{loadError}</div>}
+
+            {loaded !== null && (
+              <div className={styles.keySection}>
+                <span className={styles.keySectionLabel}>キーカラム:</span>
+                {commonColumns.map((name) => (
+                  <label key={name} className={styles.keyCheckbox}>
+                    <input
+                      type="checkbox"
+                      checked={selectedKeys.includes(name)}
+                      onChange={() => toggleKey(name)}
+                    />
+                    {name}
+                  </label>
+                ))}
+                <button
+                  type="button"
+                  className={`${styles.button} ${styles.buttonPrimary}`}
+                  onClick={runCompare}
+                  disabled={isComparing || selectedKeys.length === 0}
+                >
+                  {isComparing ? '比較中...' : '比較実行'}
+                </button>
+              </div>
+            )}
+
+            {diff !== null && (
+              <>
+                <div className={styles.summaryRow}>
+                  <span className={`${styles.summaryBadge} ${styles.badgeAdded}`}>
+                    追加 {diff.summary.added}
+                  </span>
+                  <span className={`${styles.summaryBadge} ${styles.badgeRemoved}`}>
+                    削除 {diff.summary.removed}
+                  </span>
+                  <span className={`${styles.summaryBadge} ${styles.badgeModified}`}>
+                    変更 {diff.summary.modified}
+                  </span>
+                  <span className={styles.summaryBadge}>一致 {diff.summary.identical}</span>
+                  <button type="button" className={styles.button} onClick={copySummary}>
+                    サマリをコピー
+                  </button>
+                  <div className={styles.filterToggle}>
+                    <button
+                      type="button"
+                      className={`${styles.modeTab} ${filter === 'diff' ? styles.modeTabActive : ''}`}
+                      onClick={() => setFilter('diff')}
+                    >
+                      差分のみ
+                    </button>
+                    <button
+                      type="button"
+                      className={`${styles.modeTab} ${filter === 'all' ? styles.modeTabActive : ''}`}
+                      onClick={() => setFilter('all')}
+                    >
+                      すべて
+                    </button>
+                  </div>
+                </div>
+
+                {diff.warnings.length > 0 && (
+                  <ul className={styles.warnings}>
+                    {diff.warnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                )}
+
+                {visibleRows.length === 0 ? (
+                  <div className={styles.emptyState}>
+                    {filter === 'diff' ? '差分はありません' : '表示する行がありません'}
+                  </div>
+                ) : (
+                  <div className={styles.gridWrapper}>
+                    <table className={styles.grid}>
+                      <thead>
+                        <tr>
+                          <th>状態</th>
+                          <th>キー</th>
+                          {diff.columns.map((name) => (
+                            <th key={name}>{name}</th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {visibleRows.map((row, rowIndex) => (
+                          <tr
+                            // biome-ignore lint/suspicious/noArrayIndexKey: 重複キー行があり得るため index で一意化
+                            key={`${row.status}-${row.keyDisplay}-${rowIndex}`}
+                            className={ROW_CLASSES[row.status] ?? ''}
+                          >
+                            <td className={`${styles.statusCell} ${STATUS_CLASSES[row.status]}`}>
+                              {STATUS_LABELS[row.status]}
+                            </td>
+                            <td>{row.keyDisplay}</td>
+                            {diff.columns.map((name, colIndex) => {
+                              const changed = row.changedCells?.[colIndex] === true;
+                              const aValue = row.a?.[colIndex] ?? null;
+                              const bValue = row.b?.[colIndex] ?? null;
+                              return (
+                                <td key={name} className={changed ? styles.changedCell : ''}>
+                                  {changed ? (
+                                    <>
+                                      <span className={styles.oldValue}>
+                                        {renderCellValue(aValue)}
+                                      </span>
+                                      <span className={styles.arrow}>{'→'}</span>
+                                      <span className={styles.newValue}>
+                                        {renderCellValue(bValue)}
+                                      </span>
+                                    </>
+                                  ) : (
+                                    renderCellValue(row.status === 'removed' ? aValue : bValue)
+                                  )}
+                                </td>
+                              );
+                            })}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+
+                {totalVisibleCount > DISPLAY_ROW_LIMIT && (
+                  <span className={styles.noteText}>
+                    {totalVisibleCount}行中、先頭{DISPLAY_ROW_LIMIT}
+                    行のみ表示しています
+                  </span>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/frontend/src/components/dialogs/index.ts
+++ b/frontend/src/components/dialogs/index.ts
@@ -1,6 +1,7 @@
 // Barrel exports for dialog components
 
 export { ConnectionDialog } from './ConnectionDialog';
+export { DataCompareDialog } from './DataCompareDialog';
 export { DmlPreviewDialog } from './DmlPreviewDialog';
 export { ERImportDialog } from './ERImportDialog';
 export { ExecutionPlanDialog } from './ExecutionPlanDialog';

--- a/frontend/src/components/icons/SvgIcons.tsx
+++ b/frontend/src/components/icons/SvgIcons.tsx
@@ -94,6 +94,20 @@ export const ToolbarIcons = {
       <path d="M8 1v2M8 13v2M1 8h2M13 8h2M2.93 2.93l1.41 1.41M11.66 11.66l1.41 1.41M2.93 13.07l1.41-1.41M11.66 4.34l1.41-1.41" />
     </svg>
   ),
+  Compare: (props: IconProps) => (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      aria-hidden="true"
+      {...props}
+    >
+      <rect x="1.5" y="2.5" width="5" height="11" rx="1" />
+      <rect x="9.5" y="2.5" width="5" height="11" rx="1" />
+      <path d="M6.5 6h3M9.5 10h-3" />
+    </svg>
+  ),
 };
 
 // ====================================================================

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -36,6 +36,9 @@ const SearchDialog = lazyWithRetry(() =>
 const SettingsDialog = lazyWithRetry(() =>
   import('../dialogs/SettingsDialog').then((module) => ({ default: module.SettingsDialog }))
 );
+const DataCompareDialog = lazyWithRetry(() =>
+  import('../dialogs/DataCompareDialog').then((module) => ({ default: module.DataCompareDialog }))
+);
 // Simple loading fallback
 function LoadingFallback() {
   return <div style={{ display: 'none' }} />;
@@ -52,6 +55,9 @@ export function MainLayout() {
     isSettingsDialogOpen,
     openSettingsDialog,
     closeSettingsDialog,
+    isDataCompareDialogOpen,
+    openDataCompareDialog,
+    closeDataCompareDialog,
     queryConfirm,
     openQueryConfirm,
     closeQueryConfirm,
@@ -380,6 +386,14 @@ export function MainLayout() {
           <button
             type="button"
             className={styles.iconButton}
+            onClick={openDataCompareDialog}
+            title="データ比較"
+          >
+            <ToolbarIcons.Compare />
+          </button>
+          <button
+            type="button"
+            className={styles.iconButton}
             onClick={openSettingsDialog}
             title="設定 (Ctrl+,)"
           >
@@ -530,6 +544,12 @@ export function MainLayout() {
       {isSettingsDialogOpen && (
         <Suspense fallback={<LoadingFallback />}>
           <SettingsDialog isOpen={isSettingsDialogOpen} onClose={closeSettingsDialog} />
+        </Suspense>
+      )}
+
+      {isDataCompareDialogOpen && (
+        <Suspense fallback={<LoadingFallback />}>
+          <DataCompareDialog isOpen={isDataCompareDialogOpen} onClose={closeDataCompareDialog} />
         </Suspense>
       )}
 

--- a/frontend/src/hooks/useDialogState.ts
+++ b/frontend/src/hooks/useDialogState.ts
@@ -21,6 +21,10 @@ export interface UseDialogStateResult {
   openSettingsDialog: () => void;
   closeSettingsDialog: () => void;
 
+  isDataCompareDialogOpen: boolean;
+  openDataCompareDialog: () => void;
+  closeDataCompareDialog: () => void;
+
   queryConfirm: QueryConfirmState;
   openQueryConfirm: (params: Omit<QueryConfirmState, 'isOpen'>) => void;
   closeQueryConfirm: () => void;
@@ -36,8 +40,8 @@ const QUERY_CONFIRM_INITIAL: QueryConfirmState = {
 
 /**
  * MainLayout の dialog open/close state を集約する管理層 hook。
- * Connection / Search / Settings / QueryConfirm の 4 系統を保持し、open/close API と
- * keyboard shortcut 抑止用の hasOpenDialog (queryConfirm を除く 3 dialog の OR) を返す。
+ * Connection / Search / Settings / DataCompare / QueryConfirm の 5 系統を保持し、open/close API と
+ * keyboard shortcut 抑止用の hasOpenDialog (queryConfirm を除く 4 dialog の OR) を返す。
  *
  * 運用ルール: callback (e.g. handleConfirmExecute) はビジネスロジックとの結合点のため
  * 本 hook には含めず、呼び出し側 (MainLayout) で組み立てる。
@@ -46,6 +50,7 @@ export function useDialogState(): UseDialogStateResult {
   const [isConnectionDialogOpen, setIsConnectionDialogOpen] = useState(false);
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
   const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
+  const [isDataCompareDialogOpen, setIsDataCompareDialogOpen] = useState(false);
   const [queryConfirm, setQueryConfirm] = useState<QueryConfirmState>(QUERY_CONFIRM_INITIAL);
 
   const openConnectionDialog = useCallback(() => setIsConnectionDialogOpen(true), []);
@@ -57,6 +62,9 @@ export function useDialogState(): UseDialogStateResult {
   const openSettingsDialog = useCallback(() => setIsSettingsDialogOpen(true), []);
   const closeSettingsDialog = useCallback(() => setIsSettingsDialogOpen(false), []);
 
+  const openDataCompareDialog = useCallback(() => setIsDataCompareDialogOpen(true), []);
+  const closeDataCompareDialog = useCallback(() => setIsDataCompareDialogOpen(false), []);
+
   const openQueryConfirm = useCallback((params: Omit<QueryConfirmState, 'isOpen'>) => {
     setQueryConfirm({ isOpen: true, ...params });
   }, []);
@@ -64,7 +72,8 @@ export function useDialogState(): UseDialogStateResult {
 
   // queryConfirm は意図的に除外: production/read-only 警告ダイアログ open 中も
   // Escape (cancelQuery) を効かせるため、キーボードショートカット抑止対象外とする
-  const hasOpenDialog = isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen;
+  const hasOpenDialog =
+    isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen || isDataCompareDialogOpen;
 
   return {
     isConnectionDialogOpen,
@@ -76,6 +85,9 @@ export function useDialogState(): UseDialogStateResult {
     isSettingsDialogOpen,
     openSettingsDialog,
     closeSettingsDialog,
+    isDataCompareDialogOpen,
+    openDataCompareDialog,
+    closeDataCompareDialog,
     queryConfirm,
     openQueryConfirm,
     closeQueryConfirm,

--- a/frontend/src/tests/dialogs/DataCompareDialog.test.tsx
+++ b/frontend/src/tests/dialogs/DataCompareDialog.test.tsx
@@ -1,0 +1,218 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { queryProvider } from '../../api/providers';
+import type { ExecuteQueryResult } from '../../api/providers/query';
+import { DataCompareDialog } from '../../components/dialogs/DataCompareDialog';
+import { useConnectionStore } from '../../store/connectionStore';
+import type { Connection } from '../../types';
+
+vi.mock('../../api/providers', () => ({
+  queryProvider: {
+    executeQuery: vi.fn(),
+  },
+  connectionProvider: {},
+  schemaProvider: {},
+}));
+
+function makeConnection(id: string, name: string): Connection {
+  return {
+    id,
+    name,
+    server: 'localhost',
+    port: 1433,
+    database: 'testdb',
+    username: 'sa',
+    password: 'pass',
+    useWindowsAuth: false,
+    isActive: true,
+    isProduction: false,
+    isReadOnly: false,
+    dbType: 'sqlserver',
+  };
+}
+
+function queryResult(rows: (string | null)[][]): ExecuteQueryResult {
+  return {
+    columns: [
+      { name: 'id', type: 'int' },
+      { name: 'name', type: 'varchar' },
+    ],
+    rows,
+    affectedRows: 0,
+    executionTimeMs: 1,
+    cached: false,
+  };
+}
+
+// A: id=1 Alice (一致), id=2 Bob (変更元)
+// B: id=1 Alice, id=2 Bobby (変更), id=3 Carol (追加)
+const RESULT_A = queryResult([
+  ['1', 'Alice'],
+  ['2', 'Bob'],
+]);
+const RESULT_B = queryResult([
+  ['1', 'Alice'],
+  ['2', 'Bobby'],
+  ['3', 'Carol'],
+]);
+
+async function loadAndCompare() {
+  fireEvent.change(screen.getByLabelText('接続 (A)'), { target: { value: 'conn-1' } });
+  fireEvent.change(screen.getByLabelText('接続 (B)'), { target: { value: 'conn-2' } });
+  fireEvent.change(screen.getByLabelText('テーブル名 (A)'), { target: { value: 'dbo.TableA' } });
+  fireEvent.change(screen.getByLabelText('テーブル名 (B)'), { target: { value: 'dbo.TableB' } });
+  fireEvent.click(screen.getByText('データ読み込み'));
+
+  await waitFor(() => expect(screen.getByText('比較実行')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('比較実行'));
+  await waitFor(() => expect(screen.getByText('追加 1')).toBeInTheDocument());
+}
+
+describe('DataCompareDialog', () => {
+  const defaultProps = {
+    isOpen: true as boolean,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    useConnectionStore.setState({
+      connections: [makeConnection('conn-1', '接続1'), makeConnection('conn-2', '接続2')],
+      activeConnectionId: 'conn-1',
+    });
+    vi.mocked(queryProvider.executeQuery)
+      .mockReset()
+      .mockImplementation(async (_connectionId: string, sql: string) =>
+        sql.includes('TableA') ? RESULT_A : RESULT_B
+      );
+  });
+
+  afterEach(() => {
+    useConnectionStore.setState({ connections: [], activeConnectionId: null });
+    vi.clearAllMocks();
+  });
+
+  it('isOpen=false時に非表示', () => {
+    const { container } = render(<DataCompareDialog {...defaultProps} isOpen={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('isOpen=true時にタイトルとソース入力を表示', () => {
+    render(<DataCompareDialog {...defaultProps} />);
+    expect(screen.getByText('データ比較')).toBeInTheDocument();
+    expect(screen.getByText('ソース A')).toBeInTheDocument();
+    expect(screen.getByText('ソース B')).toBeInTheDocument();
+    expect(screen.getByLabelText('接続 (A)')).toBeInTheDocument();
+    expect(screen.getByLabelText('接続 (B)')).toBeInTheDocument();
+  });
+
+  it('接続がない場合は案内メッセージを表示', () => {
+    useConnectionStore.setState({ connections: [], activeConnectionId: null });
+    render(<DataCompareDialog {...defaultProps} />);
+    expect(screen.getByText('比較するにはデータベースに接続してください')).toBeInTheDocument();
+  });
+
+  it('Escapeキーで閉じる', () => {
+    const onClose = vi.fn();
+    render(<DataCompareDialog {...defaultProps} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('接続未選択で読み込むとバリデーションエラーを表示', () => {
+    render(<DataCompareDialog {...defaultProps} />);
+    fireEvent.click(screen.getByText('データ読み込み'));
+    expect(screen.getByText('A: 接続を選択してください')).toBeInTheDocument();
+    expect(queryProvider.executeQuery).not.toHaveBeenCalled();
+  });
+
+  it('2ソースを読み込み、行数とキーカラム選択を表示する', async () => {
+    render(<DataCompareDialog {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('接続 (A)'), { target: { value: 'conn-1' } });
+    fireEvent.change(screen.getByLabelText('接続 (B)'), { target: { value: 'conn-2' } });
+    fireEvent.change(screen.getByLabelText('テーブル名 (A)'), { target: { value: 'dbo.TableA' } });
+    fireEvent.change(screen.getByLabelText('テーブル名 (B)'), { target: { value: 'dbo.TableB' } });
+    fireEvent.click(screen.getByText('データ読み込み'));
+
+    await waitFor(() => expect(screen.getByText('キーカラム:')).toBeInTheDocument());
+    expect(screen.getByText('A: 2行 × 2列 / B: 3行 × 2列')).toBeInTheDocument();
+    expect(queryProvider.executeQuery).toHaveBeenCalledTimes(2);
+    expect(queryProvider.executeQuery).toHaveBeenCalledWith(
+      'conn-1',
+      'SELECT * FROM [dbo].[TableA]',
+      false
+    );
+    expect(queryProvider.executeQuery).toHaveBeenCalledWith(
+      'conn-2',
+      'SELECT * FROM [dbo].[TableB]',
+      false
+    );
+  });
+
+  it('比較実行でサマリカウントを表示する', async () => {
+    render(<DataCompareDialog {...defaultProps} />);
+    await loadAndCompare();
+
+    expect(screen.getByText('追加 1')).toBeInTheDocument();
+    expect(screen.getByText('削除 0')).toBeInTheDocument();
+    expect(screen.getByText('変更 1')).toBeInTheDocument();
+    expect(screen.getByText('一致 1')).toBeInTheDocument();
+  });
+
+  it('デフォルトの差分のみフィルタでは identical 行を表示しない', async () => {
+    render(<DataCompareDialog {...defaultProps} />);
+    await loadAndCompare();
+
+    // 変更行 (Bob → Bobby) と追加行 (Carol) は表示される
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Bobby')).toBeInTheDocument();
+    expect(screen.getByText('Carol')).toBeInTheDocument();
+    // identical 行 (Alice) は非表示
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  it('「すべて」フィルタに切り替えると identical 行も表示する', async () => {
+    render(<DataCompareDialog {...defaultProps} />);
+    await loadAndCompare();
+
+    fireEvent.click(screen.getByText('すべて'));
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('SQLモードでカスタムクエリを実行できる', async () => {
+    render(<DataCompareDialog {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('接続 (A)'), { target: { value: 'conn-1' } });
+    fireEvent.change(screen.getByLabelText('接続 (B)'), { target: { value: 'conn-2' } });
+
+    // 両ソースを SQL モードに切り替え
+    const sqlTabs = screen.getAllByText('SQL');
+    for (const tab of sqlTabs) {
+      fireEvent.click(tab);
+    }
+    fireEvent.change(screen.getByLabelText('SQL (A)'), {
+      target: { value: 'SELECT * FROM TableA WHERE x = 1' },
+    });
+    fireEvent.change(screen.getByLabelText('SQL (B)'), {
+      target: { value: 'SELECT * FROM TableB WHERE x = 1' },
+    });
+    fireEvent.click(screen.getByText('データ読み込み'));
+
+    await waitFor(() => expect(screen.getByText('キーカラム:')).toBeInTheDocument());
+    expect(queryProvider.executeQuery).toHaveBeenCalledWith(
+      'conn-1',
+      'SELECT * FROM TableA WHERE x = 1',
+      false
+    );
+  });
+
+  it('読み込みエラー時にエラーメッセージを表示', async () => {
+    vi.mocked(queryProvider.executeQuery).mockRejectedValue(new Error('接続が失われました'));
+    render(<DataCompareDialog {...defaultProps} />);
+    fireEvent.change(screen.getByLabelText('接続 (A)'), { target: { value: 'conn-1' } });
+    fireEvent.change(screen.getByLabelText('接続 (B)'), { target: { value: 'conn-2' } });
+    fireEvent.change(screen.getByLabelText('テーブル名 (A)'), { target: { value: 'dbo.TableA' } });
+    fireEvent.change(screen.getByLabelText('テーブル名 (B)'), { target: { value: 'dbo.TableB' } });
+    fireEvent.click(screen.getByText('データ読み込み'));
+
+    await waitFor(() => expect(screen.getByText('接続が失われました')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/tests/hooks/useDialogState.test.ts
+++ b/frontend/src/tests/hooks/useDialogState.test.ts
@@ -76,6 +76,23 @@ describe('useDialogState', () => {
     expect(result.current.hasOpenDialog).toBe(false);
   });
 
+  it('openDataCompareDialog / closeDataCompareDialog → isDataCompareDialogOpen が独立に切り替わる', () => {
+    const { result } = renderHook(() => useDialogState());
+
+    act(() => {
+      result.current.openDataCompareDialog();
+    });
+    expect(result.current.isDataCompareDialogOpen).toBe(true);
+    expect(result.current.isSettingsDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(true);
+
+    act(() => {
+      result.current.closeDataCompareDialog();
+    });
+    expect(result.current.isDataCompareDialogOpen).toBe(false);
+    expect(result.current.hasOpenDialog).toBe(false);
+  });
+
   it('openQueryConfirm → 渡した値が反映され isOpen が true', () => {
     const { result } = renderHook(() => useDialogState());
 

--- a/frontend/src/tests/utils/dataDiff.test.ts
+++ b/frontend/src/tests/utils/dataDiff.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type DiffResultSet,
+  diffResultSets,
+  diffResultSetsAsync,
+  formatDiffSummary,
+} from '../../utils/dataDiff';
+
+function resultSet(columnNames: string[], rows: (string | null)[][]): DiffResultSet {
+  return {
+    columns: columnNames.map((name) => ({ name, type: 'varchar' })),
+    rows,
+  };
+}
+
+describe('dataDiff', () => {
+  describe('基本分類', () => {
+    it('identical: 完全一致の行を identical として分類する', () => {
+      const a = resultSet(['id', 'name'], [['1', 'Alice']]);
+      const b = resultSet(['id', 'name'], [['1', 'Alice']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 0, removed: 0, modified: 0, identical: 1 });
+      expect(result.rows[0].status).toBe('identical');
+      expect(result.rows[0].changedCells).toBeNull();
+    });
+
+    it('added: B にのみ存在する行を added として分類する', () => {
+      const a = resultSet(['id', 'name'], [['1', 'Alice']]);
+      const b = resultSet(
+        ['id', 'name'],
+        [
+          ['1', 'Alice'],
+          ['2', 'Bob'],
+        ]
+      );
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 1, removed: 0, modified: 0, identical: 1 });
+      const added = result.rows.find((r) => r.status === 'added');
+      expect(added?.keyDisplay).toBe('2');
+      expect(added?.a).toBeNull();
+      expect(added?.b).toEqual(['2', 'Bob']);
+    });
+
+    it('removed: A にのみ存在する行を removed として分類する', () => {
+      const a = resultSet(
+        ['id', 'name'],
+        [
+          ['1', 'Alice'],
+          ['2', 'Bob'],
+        ]
+      );
+      const b = resultSet(['id', 'name'], [['1', 'Alice']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 0, removed: 1, modified: 0, identical: 1 });
+      const removed = result.rows.find((r) => r.status === 'removed');
+      expect(removed?.keyDisplay).toBe('2');
+      expect(removed?.a).toEqual(['2', 'Bob']);
+      expect(removed?.b).toBeNull();
+    });
+
+    it('modified: キー一致でセルが異なる行を modified とし changedCells を立てる', () => {
+      const a = resultSet(['id', 'name', 'age'], [['1', 'Alice', '20']]);
+      const b = resultSet(['id', 'name', 'age'], [['1', 'Alicia', '20']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 0, removed: 0, modified: 1, identical: 0 });
+      const modified = result.rows[0];
+      expect(modified.status).toBe('modified');
+      expect(modified.changedCells).toEqual([false, true, false]);
+      expect(modified.a).toEqual(['1', 'Alice', '20']);
+      expect(modified.b).toEqual(['1', 'Alicia', '20']);
+    });
+
+    it('混在: added/removed/modified/identical を同時に正しく数える', () => {
+      const a = resultSet(
+        ['id', 'v'],
+        [
+          ['1', 'same'],
+          ['2', 'old'],
+          ['3', 'gone'],
+        ]
+      );
+      const b = resultSet(
+        ['id', 'v'],
+        [
+          ['1', 'same'],
+          ['2', 'new'],
+          ['4', 'fresh'],
+        ]
+      );
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 1, removed: 1, modified: 1, identical: 1 });
+    });
+  });
+
+  describe('キーカラム', () => {
+    it('keyColumns 省略時は共通カラムの先頭をキーに使う', () => {
+      const a = resultSet(['id', 'name'], [['1', 'Alice']]);
+      const b = resultSet(['id', 'name'], [['1', 'Bob']]);
+
+      const result = diffResultSets(a, b);
+
+      expect(result.keyColumns).toEqual(['id']);
+      expect(result.summary.modified).toBe(1);
+    });
+
+    it('複合キー: 全キーカラムが一致した行のみ突き合わせる', () => {
+      const a = resultSet(
+        ['tenant', 'id', 'v'],
+        [
+          ['t1', '1', 'x'],
+          ['t2', '1', 'y'],
+        ]
+      );
+      const b = resultSet(
+        ['tenant', 'id', 'v'],
+        [
+          ['t1', '1', 'x'],
+          ['t3', '1', 'y'],
+        ]
+      );
+
+      const result = diffResultSets(a, b, { keyColumns: ['tenant', 'id'] });
+
+      expect(result.summary).toEqual({ added: 1, removed: 1, modified: 0, identical: 1 });
+      expect(result.rows.find((r) => r.status === 'removed')?.keyDisplay).toBe('t2 | 1');
+      expect(result.rows.find((r) => r.status === 'added')?.keyDisplay).toBe('t3 | 1');
+    });
+
+    it('存在しないキーカラム指定でエラーを投げる', () => {
+      const a = resultSet(['id'], [['1']]);
+      const b = resultSet(['id'], [['1']]);
+
+      expect(() => diffResultSets(a, b, { keyColumns: ['nope'] })).toThrow(
+        /キーカラム "nope" は両方の結果セットに存在する必要があります/
+      );
+    });
+
+    it('キー値の区切り文字衝突: JSON エンコードによりキーが混同されない', () => {
+      // ["a|b", "c"] と ["a", "b|c"] が同一キーにならないこと
+      const a = resultSet(['k1', 'k2'], [['a|b', 'c']]);
+      const b = resultSet(['k1', 'k2'], [['a', 'b|c']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['k1', 'k2'] });
+
+      expect(result.summary).toEqual({ added: 1, removed: 1, modified: 0, identical: 0 });
+    });
+  });
+
+  describe('重複キー', () => {
+    it('重複キーは警告を出し、出現順に位置対応で比較する', () => {
+      const a = resultSet(
+        ['id', 'v'],
+        [
+          ['1', 'a1'],
+          ['1', 'a2'],
+          ['1', 'a3'],
+        ]
+      );
+      const b = resultSet(
+        ['id', 'v'],
+        [
+          ['1', 'a1'],
+          ['1', 'b2'],
+        ]
+      );
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      // a1 vs a1 = identical, a2 vs b2 = modified, a3 = removed
+      expect(result.summary).toEqual({ added: 0, removed: 1, modified: 1, identical: 1 });
+      expect(result.warnings.some((w) => w.includes('A 側でキーが重複'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('B 側でキーが重複'))).toBe(true);
+    });
+
+    it('B 側の重複キーが余った場合は added になる', () => {
+      const a = resultSet(['id'], [['1']]);
+      const b = resultSet(['id'], [['1'], ['1']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 1, removed: 0, modified: 0, identical: 1 });
+    });
+  });
+
+  describe('NULL の扱い', () => {
+    it('NULL と空文字列を区別する', () => {
+      const a = resultSet(['id', 'v'], [['1', null]]);
+      const b = resultSet(['id', 'v'], [['1', '']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary.modified).toBe(1);
+      expect(result.rows[0].changedCells).toEqual([false, true]);
+    });
+
+    it('両側 NULL のセルは一致扱いになる', () => {
+      const a = resultSet(['id', 'v'], [['1', null]]);
+      const b = resultSet(['id', 'v'], [['1', null]]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary.identical).toBe(1);
+    });
+
+    it('キーカラムの NULL と空文字列も別キーとして扱う', () => {
+      const a = resultSet(['id', 'v'], [[null, 'x']]);
+      const b = resultSet(['id', 'v'], [['', 'x']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 1, removed: 1, modified: 0, identical: 0 });
+      expect(result.rows.find((r) => r.status === 'removed')?.keyDisplay).toBe('NULL');
+    });
+  });
+
+  describe('カラム集合の差異', () => {
+    it('共通カラムのみ比較し、片側のみのカラムを報告する', () => {
+      const a = resultSet(['id', 'name', 'aOnly'], [['1', 'Alice', 'x']]);
+      const b = resultSet(['id', 'name', 'bOnly'], [['1', 'Alice', 'y']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.columns).toEqual(['id', 'name']);
+      expect(result.aOnlyColumns).toEqual(['aOnly']);
+      expect(result.bOnlyColumns).toEqual(['bOnly']);
+      expect(result.summary.identical).toBe(1);
+      expect(result.warnings.some((w) => w.includes('A 側のみに存在するカラム'))).toBe(true);
+      expect(result.warnings.some((w) => w.includes('B 側のみに存在するカラム'))).toBe(true);
+    });
+
+    it('カラム順が違っても名前で対応付けて比較する', () => {
+      const a = resultSet(['id', 'name'], [['1', 'Alice']]);
+      const b = resultSet(['name', 'id'], [['Alice', '1']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary.identical).toBe(1);
+    });
+
+    it('共通カラムがない場合はエラーを投げる', () => {
+      const a = resultSet(['x'], [['1']]);
+      const b = resultSet(['y'], [['1']]);
+
+      expect(() => diffResultSets(a, b)).toThrow(/共通カラムが存在しない/);
+    });
+  });
+
+  describe('空入力', () => {
+    it('両方空なら全カウント 0', () => {
+      const a = resultSet(['id'], []);
+      const b = resultSet(['id'], []);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 0, removed: 0, modified: 0, identical: 0 });
+      expect(result.rows).toEqual([]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('A が空なら B の全行が added', () => {
+      const a = resultSet(['id'], []);
+      const b = resultSet(['id'], [['1'], ['2']]);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 2, removed: 0, modified: 0, identical: 0 });
+    });
+
+    it('B が空なら A の全行が removed', () => {
+      const a = resultSet(['id'], [['1'], ['2']]);
+      const b = resultSet(['id'], []);
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      expect(result.summary).toEqual({ added: 0, removed: 2, modified: 0, identical: 0 });
+    });
+  });
+
+  describe('順序非依存', () => {
+    it('入力行の順序を入れ替えても分類結果は同じ', () => {
+      const rowsA: (string | null)[][] = [
+        ['1', 'same'],
+        ['2', 'old'],
+        ['3', 'gone'],
+      ];
+      const rowsB: (string | null)[][] = [
+        ['4', 'fresh'],
+        ['1', 'same'],
+        ['2', 'new'],
+      ];
+
+      const forward = diffResultSets(resultSet(['id', 'v'], rowsA), resultSet(['id', 'v'], rowsB), {
+        keyColumns: ['id'],
+      });
+      const shuffled = diffResultSets(
+        resultSet(['id', 'v'], [...rowsA].reverse()),
+        resultSet(['id', 'v'], [...rowsB].reverse()),
+        { keyColumns: ['id'] }
+      );
+
+      expect(shuffled.summary).toEqual(forward.summary);
+      const statusByKey = (rows: { keyDisplay: string; status: string }[]) =>
+        new Map(rows.map((r) => [r.keyDisplay, r.status]));
+      expect(statusByKey(shuffled.rows)).toEqual(statusByKey(forward.rows));
+    });
+  });
+
+  describe('行数上限', () => {
+    it('maxRows 超過分は打ち切り、truncated と警告を返す', () => {
+      const manyRows = Array.from({ length: 10 }, (_, i): (string | null)[] => [String(i)]);
+      const a = resultSet(['id'], manyRows);
+      const b = resultSet(['id'], manyRows.slice(0, 3));
+
+      const result = diffResultSets(a, b, { keyColumns: ['id'], maxRows: 5 });
+
+      expect(result.truncated).toBe(true);
+      // A は先頭 5 行のみ比較: 0-2 identical, 3-4 removed
+      expect(result.summary).toEqual({ added: 0, removed: 2, modified: 0, identical: 3 });
+      expect(result.warnings.some((w) => w.includes('先頭 5 行のみ比較'))).toBe(true);
+    });
+  });
+
+  describe('diffResultSetsAsync', () => {
+    it('チャンク処理でも同期版と同じ結果を返す', async () => {
+      const size = 12_345;
+      const rowsA = Array.from({ length: size }, (_, i): (string | null)[] => [String(i), `v${i}`]);
+      const rowsB = rowsA.map((row): (string | null)[] => {
+        const id = Number(row[0]);
+        if (id % 100 === 0) return [row[0], 'changed'];
+        return [...row];
+      });
+      // 末尾 10 行を削除し、新規 10 行を追加
+      const b = resultSet(
+        ['id', 'v'],
+        [
+          ...rowsB.slice(0, size - 10),
+          ...Array.from({ length: 10 }, (_, i): (string | null)[] => [String(size + i), 'new']),
+        ]
+      );
+      const a = resultSet(['id', 'v'], rowsA);
+
+      const [syncResult, asyncResult] = [
+        diffResultSets(a, b, { keyColumns: ['id'] }),
+        await diffResultSetsAsync(a, b, { keyColumns: ['id'] }),
+      ];
+
+      expect(asyncResult.summary).toEqual(syncResult.summary);
+      expect(asyncResult.summary.added).toBe(10);
+      expect(asyncResult.summary.removed).toBe(10);
+      expect(asyncResult.rows.length).toBe(syncResult.rows.length);
+    });
+  });
+
+  describe('formatDiffSummary', () => {
+    it('サマリと警告をテキスト整形する', () => {
+      const a = resultSet(['id', 'x'], [['1', 'v']]);
+      const b = resultSet(['id'], [['2']]);
+      const result = diffResultSets(a, b, { keyColumns: ['id'] });
+
+      const text = formatDiffSummary(result, { a: 'conn1 / dbo.T1', b: 'conn2 / dbo.T2' });
+
+      expect(text).toContain('A: conn1 / dbo.T1');
+      expect(text).toContain('B: conn2 / dbo.T2');
+      expect(text).toContain('キーカラム: id');
+      expect(text).toContain('追加: 1 行 / 削除: 1 行 / 変更: 0 行 / 一致: 0 行');
+      expect(text).toContain('警告:');
+    });
+  });
+});

--- a/frontend/src/utils/dataDiff.ts
+++ b/frontend/src/utils/dataDiff.ts
@@ -1,0 +1,370 @@
+// データ比較 (#256): 2つの結果セット (テーブル / クエリ結果) をキーカラムで突き合わせ、
+// added / removed / modified / identical に分類する UI 非依存の純粋 diff エンジン。
+//
+// 仕様:
+// - キーカラム: ユーザー選択 (未指定時は共通カラムの先頭 1 つ)。複合キー対応。
+// - カラム集合が異なる場合は共通カラム (A のカラム順) のみ比較し、片側のみのカラムは報告する。
+// - NULL と空文字列は区別する (SQL の NULL semantics に合わせ null !== '')。
+// - キー重複時は警告を出し、同一キー内では出現順 (位置) で対応付けて比較する。
+// - 計算量はキーの Map 構築により O(n)。MAX_COMPARE_ROWS (100,000 行/片側) を超えた分は
+//   打ち切って警告する。diffResultSetsAsync はチャンク処理で UI スレッドを塞がない。
+
+export interface DiffColumn {
+  name: string;
+  type: string;
+}
+
+export interface DiffResultSet {
+  columns: DiffColumn[];
+  rows: (string | null)[][];
+}
+
+export type DiffRowStatus = 'added' | 'removed' | 'modified' | 'identical';
+
+export interface DiffRow {
+  status: DiffRowStatus;
+  /** キー値の表示用文字列 (NULL は "NULL"、複合キーは " | " 区切り) */
+  keyDisplay: string;
+  /** 共通カラム順に射影した A 側の値。added 行は null */
+  a: (string | null)[] | null;
+  /** 共通カラム順に射影した B 側の値。removed 行は null */
+  b: (string | null)[] | null;
+  /** modified 行のみ: 共通カラムごとの変更フラグ。それ以外の status では null */
+  changedCells: boolean[] | null;
+}
+
+export interface DiffSummary {
+  added: number;
+  removed: number;
+  modified: number;
+  identical: number;
+}
+
+export interface DataDiffResult {
+  /** 比較対象となった共通カラム名 (A のカラム順) */
+  columns: string[];
+  /** 実際に使用したキーカラム */
+  keyColumns: string[];
+  /** removed/modified/identical は A の行順、added は末尾に B の行順で並ぶ */
+  rows: DiffRow[];
+  summary: DiffSummary;
+  warnings: string[];
+  aOnlyColumns: string[];
+  bOnlyColumns: string[];
+  /** 行数上限 (maxRows) により一部のみ比較した場合 true */
+  truncated: boolean;
+}
+
+export interface DiffOptions {
+  /** キーカラム名。省略時は共通カラムの先頭 1 つ */
+  keyColumns?: string[];
+  /** 片側あたりの比較上限行数 (デフォルト MAX_COMPARE_ROWS) */
+  maxRows?: number;
+}
+
+/** 片側あたりの比較上限行数。超過分は打ち切って warning を出す */
+export const MAX_COMPARE_ROWS = 100_000;
+
+/** diffResultSetsAsync の 1 チャンクで処理する行数 */
+export const DIFF_CHUNK_SIZE = 5_000;
+
+/** 警告メッセージに列挙する重複キーの最大数 */
+const MAX_LISTED_DUPLICATE_KEYS = 5;
+
+interface KeyBucket {
+  /** B 側の行 index (昇順) */
+  indices: number[];
+  /** 位置対応付けで消費済みの数 */
+  used: number;
+}
+
+interface DiffSession {
+  readonly done: boolean;
+  /** 最大 budget 行分の処理を進める */
+  step(budget: number): void;
+  /** done 後に呼び出して結果を得る */
+  result(): DataDiffResult;
+}
+
+function makeKey(row: (string | null)[], keyIndices: number[]): string {
+  // JSON 化により null と '' 、区切り文字を含む値を衝突なく区別する
+  return JSON.stringify(keyIndices.map((i) => row[i]));
+}
+
+function makeKeyDisplay(row: (string | null)[], keyIndices: number[]): string {
+  return keyIndices.map((i) => row[i] ?? 'NULL').join(' | ');
+}
+
+function project(row: (string | null)[], indices: number[]): (string | null)[] {
+  return indices.map((i) => row[i]);
+}
+
+function listKeys(keys: string[]): string {
+  const listed = keys.slice(0, MAX_LISTED_DUPLICATE_KEYS).join(', ');
+  return keys.length > MAX_LISTED_DUPLICATE_KEYS ? `${listed}, ...` : listed;
+}
+
+function createDiffSession(a: DiffResultSet, b: DiffResultSet, options?: DiffOptions): DiffSession {
+  const maxRows = options?.maxRows ?? MAX_COMPARE_ROWS;
+
+  const aNames = a.columns.map((c) => c.name);
+  const bNames = b.columns.map((c) => c.name);
+  const aNameSet = new Set(aNames);
+  const bNameSet = new Set(bNames);
+
+  const columns = aNames.filter((n) => bNameSet.has(n));
+  if (columns.length === 0) {
+    throw new Error('共通カラムが存在しないため比較できません');
+  }
+  const aOnlyColumns = aNames.filter((n) => !bNameSet.has(n));
+  const bOnlyColumns = bNames.filter((n) => !aNameSet.has(n));
+
+  const requestedKeys = options?.keyColumns ?? [];
+  const keyColumns = requestedKeys.length > 0 ? [...requestedKeys] : [columns[0]];
+  for (const key of keyColumns) {
+    if (!columns.includes(key)) {
+      throw new Error(`キーカラム "${key}" は両方の結果セットに存在する必要があります`);
+    }
+  }
+
+  const aIndexByName = new Map(aNames.map((n, i) => [n, i]));
+  const bIndexByName = new Map(bNames.map((n, i) => [n, i]));
+  const lookup = (map: Map<string, number>, name: string): number => map.get(name) ?? -1;
+  const aCommonIdx = columns.map((n) => lookup(aIndexByName, n));
+  const bCommonIdx = columns.map((n) => lookup(bIndexByName, n));
+  const aKeyIdx = keyColumns.map((n) => lookup(aIndexByName, n));
+  const bKeyIdx = keyColumns.map((n) => lookup(bIndexByName, n));
+
+  const aTruncated = a.rows.length > maxRows;
+  const bTruncated = b.rows.length > maxRows;
+  const aRows = aTruncated ? a.rows.slice(0, maxRows) : a.rows;
+  const bRows = bTruncated ? b.rows.slice(0, maxRows) : b.rows;
+
+  const buckets = new Map<string, KeyBucket>();
+  const bConsumed = new Uint8Array(bRows.length);
+  const aKeyCounts = new Map<string, number>();
+  const duplicateKeysA: string[] = [];
+  const duplicateKeysB: string[] = [];
+
+  const rows: DiffRow[] = [];
+  const summary: DiffSummary = { added: 0, removed: 0, modified: 0, identical: 0 };
+
+  // phase 0: B をキーで index / 1: A を走査 / 2: B の未消費行を added として収集 / 3: 完了
+  let phase = 0;
+  let cursor = 0;
+  let finalResult: DataDiffResult | null = null;
+
+  const indexBRows = (budget: number): number => {
+    const end = Math.min(cursor + budget, bRows.length);
+    let used = 0;
+    for (; cursor < end; cursor++, used++) {
+      const key = makeKey(bRows[cursor], bKeyIdx);
+      const bucket = buckets.get(key);
+      if (bucket === undefined) {
+        buckets.set(key, { indices: [cursor], used: 0 });
+      } else {
+        if (bucket.indices.length === 1) {
+          duplicateKeysB.push(makeKeyDisplay(bRows[cursor], bKeyIdx));
+        }
+        bucket.indices.push(cursor);
+      }
+    }
+    return used;
+  };
+
+  const walkARows = (budget: number): number => {
+    const end = Math.min(cursor + budget, aRows.length);
+    let used = 0;
+    for (; cursor < end; cursor++, used++) {
+      const row = aRows[cursor];
+      const key = makeKey(row, aKeyIdx);
+      const seen = aKeyCounts.get(key) ?? 0;
+      if (seen === 1) {
+        duplicateKeysA.push(makeKeyDisplay(row, aKeyIdx));
+      }
+      aKeyCounts.set(key, seen + 1);
+
+      const keyDisplay = makeKeyDisplay(row, aKeyIdx);
+      const aValues = project(row, aCommonIdx);
+      const bucket = buckets.get(key);
+      if (bucket !== undefined && bucket.used < bucket.indices.length) {
+        const bRowIndex = bucket.indices[bucket.used];
+        bucket.used += 1;
+        bConsumed[bRowIndex] = 1;
+        const bValues = project(bRows[bRowIndex], bCommonIdx);
+        let anyChanged = false;
+        const changedCells = aValues.map((v, i) => {
+          const changed = v !== bValues[i];
+          if (changed) anyChanged = true;
+          return changed;
+        });
+        if (anyChanged) {
+          summary.modified += 1;
+          rows.push({ status: 'modified', keyDisplay, a: aValues, b: bValues, changedCells });
+        } else {
+          summary.identical += 1;
+          rows.push({
+            status: 'identical',
+            keyDisplay,
+            a: aValues,
+            b: bValues,
+            changedCells: null,
+          });
+        }
+      } else {
+        summary.removed += 1;
+        rows.push({ status: 'removed', keyDisplay, a: aValues, b: null, changedCells: null });
+      }
+    }
+    return used;
+  };
+
+  const collectAdded = (budget: number): number => {
+    const end = Math.min(cursor + budget, bRows.length);
+    let used = 0;
+    for (; cursor < end; cursor++, used++) {
+      if (bConsumed[cursor] === 1) continue;
+      const row = bRows[cursor];
+      summary.added += 1;
+      rows.push({
+        status: 'added',
+        keyDisplay: makeKeyDisplay(row, bKeyIdx),
+        a: null,
+        b: project(row, bCommonIdx),
+        changedCells: null,
+      });
+    }
+    return used;
+  };
+
+  const buildResult = (): DataDiffResult => {
+    const warnings: string[] = [];
+    if (aTruncated || bTruncated) {
+      const sides = [aTruncated ? 'A' : null, bTruncated ? 'B' : null].filter(
+        (s): s is string => s !== null
+      );
+      warnings.push(
+        `${sides.join(' / ')} 側が ${maxRows.toLocaleString()} 行を超えたため、先頭 ${maxRows.toLocaleString()} 行のみ比較しました`
+      );
+    }
+    if (duplicateKeysA.length > 0) {
+      warnings.push(
+        `A 側でキーが重複しています (${duplicateKeysA.length} キー: ${listKeys(duplicateKeysA)})。重複キーは出現順に対応付けて比較しました`
+      );
+    }
+    if (duplicateKeysB.length > 0) {
+      warnings.push(
+        `B 側でキーが重複しています (${duplicateKeysB.length} キー: ${listKeys(duplicateKeysB)})。重複キーは出現順に対応付けて比較しました`
+      );
+    }
+    if (aOnlyColumns.length > 0) {
+      warnings.push(`A 側のみに存在するカラムは比較対象外です: ${aOnlyColumns.join(', ')}`);
+    }
+    if (bOnlyColumns.length > 0) {
+      warnings.push(`B 側のみに存在するカラムは比較対象外です: ${bOnlyColumns.join(', ')}`);
+    }
+    return {
+      columns,
+      keyColumns,
+      rows,
+      summary,
+      warnings,
+      aOnlyColumns,
+      bOnlyColumns,
+      truncated: aTruncated || bTruncated,
+    };
+  };
+
+  return {
+    get done() {
+      return phase === 3;
+    },
+    step(budget: number): void {
+      let remaining = budget;
+      while (remaining > 0 && phase < 3) {
+        if (phase === 0) {
+          remaining -= indexBRows(remaining);
+          if (cursor >= bRows.length) {
+            phase = 1;
+            cursor = 0;
+          }
+        } else if (phase === 1) {
+          remaining -= walkARows(remaining);
+          if (cursor >= aRows.length) {
+            phase = 2;
+            cursor = 0;
+          }
+        } else {
+          remaining -= collectAdded(remaining);
+          if (cursor >= bRows.length) {
+            phase = 3;
+          }
+        }
+      }
+    },
+    result(): DataDiffResult {
+      if (phase !== 3) {
+        throw new Error('diff が完了していません');
+      }
+      if (finalResult === null) {
+        finalResult = buildResult();
+      }
+      return finalResult;
+    },
+  };
+}
+
+/** 同期版: 全行を一括処理する。テスト・小規模データ向け */
+export function diffResultSets(
+  a: DiffResultSet,
+  b: DiffResultSet,
+  options?: DiffOptions
+): DataDiffResult {
+  const session = createDiffSession(a, b, options);
+  while (!session.done) {
+    session.step(Number.MAX_SAFE_INTEGER);
+  }
+  return session.result();
+}
+
+/**
+ * 非同期版: DIFF_CHUNK_SIZE 行ごとに setTimeout でイベントループへ制御を返し、
+ * 大規模データ (〜100k 行) でも UI をフリーズさせない。
+ */
+export async function diffResultSetsAsync(
+  a: DiffResultSet,
+  b: DiffResultSet,
+  options?: DiffOptions
+): Promise<DataDiffResult> {
+  const session = createDiffSession(a, b, options);
+  while (!session.done) {
+    session.step(DIFF_CHUNK_SIZE);
+    if (!session.done) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    }
+  }
+  return session.result();
+}
+
+/** 比較結果のサマリをクリップボード用テキストに整形する */
+export function formatDiffSummary(
+  result: DataDiffResult,
+  labels: { a: string; b: string }
+): string {
+  const lines = [
+    '[データ比較結果]',
+    `A: ${labels.a}`,
+    `B: ${labels.b}`,
+    `キーカラム: ${result.keyColumns.join(', ')}`,
+    `追加: ${result.summary.added} 行 / 削除: ${result.summary.removed} 行 / 変更: ${result.summary.modified} 行 / 一致: ${result.summary.identical} 行`,
+  ];
+  if (result.warnings.length > 0) {
+    lines.push('警告:');
+    for (const warning of result.warnings) {
+      lines.push(`- ${warning}`);
+    }
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION
2つのテーブルまたはクエリ結果をキーカラムで突き合わせ、
added/removed/modified/identical に分類して表示するデータ比較機能を追加 (#256)。

- utils/dataDiff.ts: UI非依存の純粋diffエンジン (O(n)、NULL/空文字列区別、 複合キー、キー重複警告+位置対応付け、共通カラム比較、100k行上限、 チャンク処理のasync版)
- dialogs/DataCompareDialog: ソースA/B指定 (接続 + テーブル名 or SQL)、 キーカラム複数選択、サマリカウント + 差分グリッド、差分のみ/すべてフィルタ、 サマリのクリップボードコピー
- MainLayout: ツールバーに比較ボタン追加 (SettingsDialogと同一パターン)
- ToolbarIcons.Compare 追加、useDialogState に open/close state 追加

Fixes #256