### PR TITLE
feat(compare): スキーマ比較と移行DDL生成

### DIFF
--- a/frontend/src/components/dialogs/SchemaCompareDialog.module.css
+++ b/frontend/src/components/dialogs/SchemaCompareDialog.module.css
@@ -1,0 +1,353 @@
+.overlay {
+  composes: overlay from "./DialogBase.module.css";
+}
+
+.dialog {
+  composes: dialog from "./DialogBase.module.css";
+  background-color: var(--bg-secondary);
+  width: 720px;
+  max-height: 85vh;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.closeButton {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+}
+
+.closeButton:hover {
+  color: var(--text-primary);
+  background-color: var(--bg-hover);
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+/* Source pickers */
+.sourceRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.sourcePicker {
+  flex: 1;
+  min-width: 0;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.sourcePicker h3 {
+  margin: 0 0 10px 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.sourceArrow {
+  align-self: center;
+  color: var(--text-secondary);
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.formGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.formGroup:last-child {
+  margin-bottom: 0;
+}
+
+.label {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.select {
+  padding: 6px 10px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+  width: 100%;
+}
+
+.select:focus {
+  outline: none;
+  border-color: var(--accent-color);
+}
+
+.hint {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin-bottom: 12px;
+}
+
+/* Compare row */
+.compareRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.compareButton {
+  padding: 8px 24px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  background-color: var(--button-primary-bg);
+  border: none;
+  color: white;
+  transition: background-color 0.15s;
+}
+
+.compareButton:hover:not(:disabled) {
+  background-color: var(--button-primary-hover);
+}
+
+.compareButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.progress {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.error {
+  padding: 10px 12px;
+  background-color: rgba(247, 84, 100, 0.1);
+  border: 1px solid rgba(247, 84, 100, 0.3);
+  border-radius: 8px;
+  color: var(--error-color);
+  font-size: 13px;
+  margin-bottom: 16px;
+}
+
+/* Diff result */
+.resultSection {
+  border-top: 1px solid var(--border-color);
+  padding-top: 12px;
+}
+
+.resultSection h3 {
+  margin: 0 0 8px 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.noDiff {
+  color: var(--text-secondary);
+  font-size: 13px;
+  margin: 0 0 12px 0;
+}
+
+.diffList {
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 8px 12px;
+  max-height: 220px;
+  overflow-y: auto;
+  margin-bottom: 16px;
+}
+
+.diffTable {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 13px;
+}
+
+.marker {
+  width: 16px;
+  text-align: center;
+  font-weight: bold;
+  font-family: "Consolas", "Monaco", monospace;
+  flex-shrink: 0;
+}
+
+.markerAdded {
+  color: var(--success-color, #4caf50);
+}
+
+.markerRemoved {
+  color: var(--error-color, #f75464);
+}
+
+.markerChanged {
+  color: var(--warning-color, #e0a030);
+}
+
+.diffTableName {
+  color: var(--text-primary);
+  font-family: "Consolas", "Monaco", monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.diffMeta {
+  color: var(--text-secondary);
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.columnDiffList {
+  list-style: none;
+  margin: 0 0 4px 0;
+  padding: 0 0 0 32px;
+  font-size: 12px;
+  font-family: "Consolas", "Monaco", monospace;
+}
+
+.columnDiffList li {
+  padding: 2px 0;
+}
+
+.colAdded {
+  color: var(--success-color, #4caf50);
+}
+
+.colRemoved {
+  color: var(--error-color, #f75464);
+}
+
+.colChanged {
+  color: var(--warning-color, #e0a030);
+}
+
+/* DDL section */
+.ddlSection {
+  margin-top: 4px;
+}
+
+.ddlHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.ddlHeader h3 {
+  margin: 0;
+  flex: 1;
+}
+
+.dialectLabel {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.dialectSelect {
+  padding: 4px 8px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.ddlHeader button {
+  padding: 6px 14px;
+  background-color: var(--bg-tertiary);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+
+.ddlHeader button:hover {
+  border-color: var(--border-color);
+  background-color: var(--bg-hover);
+}
+
+.ddlContent {
+  width: 100%;
+  box-sizing: border-box;
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 12px;
+  color: var(--text-primary);
+  min-height: 180px;
+  max-height: 260px;
+  resize: vertical;
+  font-family: "Consolas", "Monaco", monospace;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+.saveMessage {
+  margin-top: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+/* Footer */
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.closeFooterButton {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  transition: background-color 0.15s;
+}
+
+.closeFooterButton:hover {
+  background-color: var(--bg-hover);
+}

--- a/frontend/src/components/dialogs/SchemaCompareDialog.tsx
+++ b/frontend/src/components/dialogs/SchemaCompareDialog.tsx
@@ -1,0 +1,436 @@
+import { useCallback, useMemo, useState } from 'react';
+import { ioProvider, schemaProvider } from '../../api/providers';
+import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
+import { useConnections } from '../../store/connectionStore';
+import type { Connection } from '../../types';
+import {
+  generateMigrationDdl,
+  type MigrationDialect,
+  renderColumnType,
+} from '../../utils/migrationDdl';
+import {
+  type ColumnChange,
+  diffSchemas,
+  isEmptyDiff,
+  type SchemaDiff,
+  type SchemaTable,
+  tableKey,
+} from '../../utils/schemaDiff';
+import { DialogOverlay } from '../common/DialogOverlay';
+import styles from './SchemaCompareDialog.module.css';
+
+interface SchemaCompareDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface CompareResult {
+  diff: SchemaDiff;
+  sourceLabel: string;
+  targetLabel: string;
+  generatedAt: string;
+}
+
+/** getColumns 同時実行数の上限 (バックエンド ODBC 接続への負荷を抑制) */
+const COLUMN_FETCH_CONCURRENCY = 4;
+
+/** ツリー表示と同じ規約でカラム取得用テーブル識別子を組み立てる (dbo / 空スキーマは修飾なし) */
+function toColumnFetchId(table: { schema: string; name: string }): string {
+  return table.schema !== '' && table.schema !== 'dbo'
+    ? `${table.schema}.${table.name}`
+    : table.name;
+}
+
+/** 指定接続の全テーブル + カラム定義を取得する (同時実行数を制限した並列取得) */
+async function fetchSchemaTables(
+  connectionId: string,
+  database: string,
+  onProgress: (done: number, total: number) => void
+): Promise<SchemaTable[]> {
+  const { tables } = await schemaProvider.getTables(connectionId, database);
+  const targets = tables.filter((t) => t.type !== 'VIEW');
+  const results: SchemaTable[] = new Array(targets.length);
+  let done = 0;
+  let nextIndex = 0;
+
+  const workers = Array.from(
+    { length: Math.min(COLUMN_FETCH_CONCURRENCY, targets.length) },
+    async () => {
+      while (nextIndex < targets.length) {
+        const i = nextIndex;
+        nextIndex += 1;
+        const table = targets[i];
+        const columns = await schemaProvider.getColumns(connectionId, toColumnFetchId(table));
+        results[i] = { schema: table.schema, name: table.name, columns };
+        done += 1;
+        onProgress(done, targets.length);
+      }
+    }
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+function describeColumnChange(change: ColumnChange): string {
+  const parts: string[] = [];
+  if (change.changes.includes('type') || change.changes.includes('size')) {
+    parts.push(`${renderColumnType(change.from)} -> ${renderColumnType(change.to)}`);
+  }
+  if (change.changes.includes('nullable')) {
+    parts.push(change.to.nullable ? 'NOT NULL -> NULL' : 'NULL -> NOT NULL');
+  }
+  if (change.changes.includes('isPrimaryKey')) {
+    parts.push(change.to.isPrimaryKey ? 'PK追加' : 'PK解除');
+  }
+  return parts.join(', ');
+}
+
+interface SourcePickerProps {
+  title: string;
+  idPrefix: string;
+  connections: Connection[];
+  connectionId: string;
+  database: string;
+  databases: string[];
+  onConnectionChange: (connectionId: string) => void;
+  onDatabaseChange: (database: string) => void;
+  disabled: boolean;
+}
+
+function SourcePicker({
+  title,
+  idPrefix,
+  connections,
+  connectionId,
+  database,
+  databases,
+  onConnectionChange,
+  onDatabaseChange,
+  disabled,
+}: SourcePickerProps) {
+  return (
+    <div className={styles.sourcePicker}>
+      <h3>{title}</h3>
+      <div className={styles.formGroup}>
+        <label className={styles.label} htmlFor={`${idPrefix}-connection`}>
+          接続
+        </label>
+        <select
+          id={`${idPrefix}-connection`}
+          className={styles.select}
+          value={connectionId}
+          onChange={(e) => onConnectionChange(e.target.value)}
+          disabled={disabled}
+        >
+          <option value="">選択してください</option>
+          {connections.map((conn) => (
+            <option key={conn.id} value={conn.id}>
+              {conn.name} ({conn.server})
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className={styles.formGroup}>
+        <label className={styles.label} htmlFor={`${idPrefix}-database`}>
+          データベース
+        </label>
+        <select
+          id={`${idPrefix}-database`}
+          className={styles.select}
+          value={database}
+          onChange={(e) => onDatabaseChange(e.target.value)}
+          disabled={disabled || connectionId === ''}
+        >
+          {databases.map((db) => (
+            <option key={db} value={db}>
+              {db}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+export function SchemaCompareDialog({ isOpen, onClose }: SchemaCompareDialogProps) {
+  useDialogKeyboard({ isOpen, onEscape: onClose });
+  const connections = useConnections();
+
+  const [connectionIdA, setConnectionIdA] = useState('');
+  const [databaseA, setDatabaseA] = useState('');
+  const [databasesA, setDatabasesA] = useState<string[]>([]);
+  const [connectionIdB, setConnectionIdB] = useState('');
+  const [databaseB, setDatabaseB] = useState('');
+  const [databasesB, setDatabasesB] = useState<string[]>([]);
+
+  const [dialect, setDialect] = useState<MigrationDialect>('sqlserver');
+  const [isComparing, setIsComparing] = useState(false);
+  const [progressText, setProgressText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<CompareResult | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  const ddl = useMemo(() => {
+    if (!result) return '';
+    return generateMigrationDdl(result.diff, {
+      dialect,
+      sourceLabel: result.sourceLabel,
+      targetLabel: result.targetLabel,
+      generatedAt: result.generatedAt,
+    });
+  }, [result, dialect]);
+
+  const selectConnection = useCallback(
+    async (
+      connectionId: string,
+      setConnectionId: (v: string) => void,
+      setDatabase: (v: string) => void,
+      setDatabases: (v: string[]) => void
+    ) => {
+      setConnectionId(connectionId);
+      const conn = connections.find((c) => c.id === connectionId);
+      const fallback = conn ? [conn.database] : [];
+      setDatabase(conn?.database ?? '');
+      setDatabases(fallback);
+      if (!conn) return;
+      try {
+        const databases = await schemaProvider.getDatabases(connectionId);
+        if (databases.length > 0) {
+          setDatabases(
+            databases.includes(conn.database) ? databases : [conn.database, ...databases]
+          );
+        }
+      } catch {
+        // getDatabases 未対応/失敗時は接続時の database のみ選択可能とする
+      }
+    },
+    [connections]
+  );
+
+  const selectConnectionA = useCallback(
+    (id: string) => selectConnection(id, setConnectionIdA, setDatabaseA, setDatabasesA),
+    [selectConnection]
+  );
+
+  const selectConnectionB = useCallback(
+    (id: string) => {
+      void selectConnection(id, setConnectionIdB, setDatabaseB, setDatabasesB);
+      const conn = connections.find((c) => c.id === id);
+      if (conn?.dbType) setDialect(conn.dbType);
+    },
+    [selectConnection, connections]
+  );
+
+  const compare = useCallback(async () => {
+    const connA = connections.find((c) => c.id === connectionIdA);
+    const connB = connections.find((c) => c.id === connectionIdB);
+    if (!connA || !connB) return;
+
+    setIsComparing(true);
+    setError(null);
+    setResult(null);
+    setSaveMessage(null);
+    try {
+      const fromTables = await fetchSchemaTables(connA.id, databaseA, (done, total) => {
+        setProgressText(`移行元スキーマ取得中... (${done}/${total})`);
+      });
+      const toTables = await fetchSchemaTables(connB.id, databaseB, (done, total) => {
+        setProgressText(`移行先スキーマ取得中... (${done}/${total})`);
+      });
+      setResult({
+        diff: diffSchemas(fromTables, toTables),
+        sourceLabel: `${connA.name}/${databaseA}`,
+        targetLabel: `${connB.name}/${databaseB}`,
+        generatedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'スキーマ比較に失敗しました');
+    } finally {
+      setIsComparing(false);
+      setProgressText('');
+    }
+  }, [connections, connectionIdA, connectionIdB, databaseA, databaseB]);
+
+  const copyDdl = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(ddl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API 非対応環境では無視
+    }
+  }, [ddl]);
+
+  const downloadDdl = useCallback(async () => {
+    try {
+      const { filePath } = await ioProvider.saveQueryToFile(ddl, 'schema_migration.sql');
+      setSaveMessage(`保存しました: ${filePath}`);
+    } catch (err) {
+      setSaveMessage(
+        err instanceof Error ? `保存に失敗しました: ${err.message}` : '保存に失敗しました'
+      );
+    }
+  }, [ddl]);
+
+  if (!isOpen) return null;
+
+  const canCompare =
+    !isComparing &&
+    connectionIdA !== '' &&
+    connectionIdB !== '' &&
+    databaseA !== '' &&
+    databaseB !== '';
+
+  return (
+    <DialogOverlay
+      onClose={onClose}
+      overlayClassName={styles.overlay}
+      dialogClassName={styles.dialog}
+      ariaLabelledBy="schema-compare-dialog-title"
+    >
+      <div className={styles.header}>
+        <h2 id="schema-compare-dialog-title">スキーマ比較</h2>
+        <button type="button" className={styles.closeButton} onClick={onClose}>
+          {'✕'}
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.sourceRow}>
+          <SourcePicker
+            title="移行元 (A)"
+            idPrefix="schema-compare-a"
+            connections={connections}
+            connectionId={connectionIdA}
+            database={databaseA}
+            databases={databasesA}
+            onConnectionChange={(id) => void selectConnectionA(id)}
+            onDatabaseChange={setDatabaseA}
+            disabled={isComparing}
+          />
+          <div className={styles.sourceArrow}>{'→'}</div>
+          <SourcePicker
+            title="移行先 (B)"
+            idPrefix="schema-compare-b"
+            connections={connections}
+            connectionId={connectionIdB}
+            database={databaseB}
+            databases={databasesB}
+            onConnectionChange={selectConnectionB}
+            onDatabaseChange={setDatabaseB}
+            disabled={isComparing}
+          />
+        </div>
+
+        {connections.length === 0 && (
+          <div className={styles.hint}>比較するには先にデータベースへ接続してください。</div>
+        )}
+
+        <div className={styles.compareRow}>
+          <button
+            type="button"
+            className={styles.compareButton}
+            onClick={() => void compare()}
+            disabled={!canCompare}
+          >
+            {isComparing ? '比較中...' : '比較'}
+          </button>
+          {isComparing && progressText && <span className={styles.progress}>{progressText}</span>}
+        </div>
+
+        {error && <div className={styles.error}>{error}</div>}
+
+        {result && (
+          <div className={styles.resultSection}>
+            <h3>比較結果</h3>
+            {isEmptyDiff(result.diff) ? (
+              <p className={styles.noDiff}>差分はありません (移行 DDL は不要です)。</p>
+            ) : (
+              <div className={styles.diffList}>
+                {result.diff.addedTables.map((table) => (
+                  <div key={`added-${tableKey(table)}`} className={styles.diffTable}>
+                    <span className={`${styles.marker} ${styles.markerAdded}`}>+</span>
+                    <span className={styles.diffTableName}>{tableKey(table)}</span>
+                    <span className={styles.diffMeta}>追加 ({table.columns.length} カラム)</span>
+                  </div>
+                ))}
+                {result.diff.changedTables.map((table) => (
+                  <div key={`changed-${tableKey(table)}`}>
+                    <div className={styles.diffTable}>
+                      <span className={`${styles.marker} ${styles.markerChanged}`}>~</span>
+                      <span className={styles.diffTableName}>{tableKey(table)}</span>
+                      <span className={styles.diffMeta}>変更</span>
+                    </div>
+                    <ul className={styles.columnDiffList}>
+                      {table.addedColumns.map((col) => (
+                        <li key={`add-${col.name}`} className={styles.colAdded}>
+                          + {col.name} : {renderColumnType(col)}
+                        </li>
+                      ))}
+                      {table.changedColumns.map((change) => (
+                        <li key={`chg-${change.name}`} className={styles.colChanged}>
+                          ~ {change.name} : {describeColumnChange(change)}
+                        </li>
+                      ))}
+                      {table.removedColumns.map((col) => (
+                        <li key={`rem-${col.name}`} className={styles.colRemoved}>
+                          - {col.name}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+                {result.diff.removedTables.map((table) => (
+                  <div key={`removed-${tableKey(table)}`} className={styles.diffTable}>
+                    <span className={`${styles.marker} ${styles.markerRemoved}`}>-</span>
+                    <span className={styles.diffTableName}>{tableKey(table)}</span>
+                    <span className={styles.diffMeta}>削除</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            <div className={styles.ddlSection}>
+              <div className={styles.ddlHeader}>
+                <h3>移行DDL</h3>
+                <label className={styles.dialectLabel} htmlFor="schema-compare-dialect">
+                  DDL方言
+                </label>
+                <select
+                  id="schema-compare-dialect"
+                  className={styles.dialectSelect}
+                  value={dialect}
+                  onChange={(e) => setDialect(e.target.value as MigrationDialect)}
+                >
+                  <option value="sqlserver">SQL Server</option>
+                  <option value="postgresql">PostgreSQL</option>
+                  <option value="mysql">MySQL</option>
+                </select>
+                <button type="button" onClick={() => void copyDdl()}>
+                  {copied ? 'コピーしました' : 'コピー'}
+                </button>
+                <button type="button" onClick={() => void downloadDdl()}>
+                  ダウンロード (.sql)
+                </button>
+              </div>
+              <textarea
+                className={styles.ddlContent}
+                aria-label="生成された移行DDL"
+                readOnly
+                value={ddl}
+              />
+              {saveMessage && <div className={styles.saveMessage}>{saveMessage}</div>}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        <button type="button" className={styles.closeFooterButton} onClick={onClose}>
+          閉じる
+        </button>
+      </div>
+    </DialogOverlay>
+  );
+}

--- a/frontend/src/components/dialogs/index.ts
+++ b/frontend/src/components/dialogs/index.ts
@@ -4,6 +4,7 @@ export { ConnectionDialog } from './ConnectionDialog';
 export { DmlPreviewDialog } from './DmlPreviewDialog';
 export { ERImportDialog } from './ERImportDialog';
 export { ExecutionPlanDialog } from './ExecutionPlanDialog';
+export { SchemaCompareDialog } from './SchemaCompareDialog';
 export { SearchDialog } from './SearchDialog';
 export { SettingsDialog } from './SettingsDialog';
 export { type AppSettings, getSettings } from './settingsUtils';

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -36,6 +36,11 @@ const SearchDialog = lazyWithRetry(() =>
 const SettingsDialog = lazyWithRetry(() =>
   import('../dialogs/SettingsDialog').then((module) => ({ default: module.SettingsDialog }))
 );
+const SchemaCompareDialog = lazyWithRetry(() =>
+  import('../dialogs/SchemaCompareDialog').then((module) => ({
+    default: module.SchemaCompareDialog,
+  }))
+);
 // Simple loading fallback
 function LoadingFallback() {
   return <div style={{ display: 'none' }} />;
@@ -52,6 +57,9 @@ export function MainLayout() {
     isSettingsDialogOpen,
     openSettingsDialog,
     closeSettingsDialog,
+    isSchemaCompareDialogOpen,
+    openSchemaCompareDialog,
+    closeSchemaCompareDialog,
     queryConfirm,
     openQueryConfirm,
     closeQueryConfirm,
@@ -367,6 +375,13 @@ export function MainLayout() {
 
         <div className={styles.toolbarDivider} />
 
+        {/* Schema Compare */}
+        <div className={styles.toolbarGroup}>
+          <button type="button" onClick={openSchemaCompareDialog} title="スキーマ比較・移行DDL生成">
+            <span>スキーマ比較</span>
+          </button>
+        </div>
+
         {/* Search and Settings */}
         <div className={styles.toolbarGroup}>
           <button
@@ -530,6 +545,15 @@ export function MainLayout() {
       {isSettingsDialogOpen && (
         <Suspense fallback={<LoadingFallback />}>
           <SettingsDialog isOpen={isSettingsDialogOpen} onClose={closeSettingsDialog} />
+        </Suspense>
+      )}
+
+      {isSchemaCompareDialogOpen && (
+        <Suspense fallback={<LoadingFallback />}>
+          <SchemaCompareDialog
+            isOpen={isSchemaCompareDialogOpen}
+            onClose={closeSchemaCompareDialog}
+          />
         </Suspense>
       )}
 

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -39,6 +39,11 @@ const SettingsDialog = lazyWithRetry(() =>
 const DataCompareDialog = lazyWithRetry(() =>
   import('../dialogs/DataCompareDialog').then((module) => ({ default: module.DataCompareDialog }))
 );
+const SchemaCompareDialog = lazyWithRetry(() =>
+  import('../dialogs/SchemaCompareDialog').then((module) => ({
+    default: module.SchemaCompareDialog,
+  }))
+);
 // Simple loading fallback
 function LoadingFallback() {
   return <div style={{ display: 'none' }} />;
@@ -58,6 +63,9 @@ export function MainLayout() {
     isDataCompareDialogOpen,
     openDataCompareDialog,
     closeDataCompareDialog,
+    isSchemaCompareDialogOpen,
+    openSchemaCompareDialog,
+    closeSchemaCompareDialog,
     queryConfirm,
     openQueryConfirm,
     closeQueryConfirm,
@@ -557,6 +565,15 @@ export function MainLayout() {
       {isDataCompareDialogOpen && (
         <Suspense fallback={<LoadingFallback />}>
           <DataCompareDialog isOpen={isDataCompareDialogOpen} onClose={closeDataCompareDialog} />
+        </Suspense>
+      )}
+
+      {isSchemaCompareDialogOpen && (
+        <Suspense fallback={<LoadingFallback />}>
+          <SchemaCompareDialog
+            isOpen={isSchemaCompareDialogOpen}
+            onClose={closeSchemaCompareDialog}
+          />
         </Suspense>
       )}
 

--- a/frontend/src/hooks/useDialogState.ts
+++ b/frontend/src/hooks/useDialogState.ts
@@ -21,6 +21,10 @@ export interface UseDialogStateResult {
   openSettingsDialog: () => void;
   closeSettingsDialog: () => void;
 
+  isSchemaCompareDialogOpen: boolean;
+  openSchemaCompareDialog: () => void;
+  closeSchemaCompareDialog: () => void;
+
   queryConfirm: QueryConfirmState;
   openQueryConfirm: (params: Omit<QueryConfirmState, 'isOpen'>) => void;
   closeQueryConfirm: () => void;
@@ -46,6 +50,7 @@ export function useDialogState(): UseDialogStateResult {
   const [isConnectionDialogOpen, setIsConnectionDialogOpen] = useState(false);
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
   const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
+  const [isSchemaCompareDialogOpen, setIsSchemaCompareDialogOpen] = useState(false);
   const [queryConfirm, setQueryConfirm] = useState<QueryConfirmState>(QUERY_CONFIRM_INITIAL);
 
   const openConnectionDialog = useCallback(() => setIsConnectionDialogOpen(true), []);
@@ -57,6 +62,9 @@ export function useDialogState(): UseDialogStateResult {
   const openSettingsDialog = useCallback(() => setIsSettingsDialogOpen(true), []);
   const closeSettingsDialog = useCallback(() => setIsSettingsDialogOpen(false), []);
 
+  const openSchemaCompareDialog = useCallback(() => setIsSchemaCompareDialogOpen(true), []);
+  const closeSchemaCompareDialog = useCallback(() => setIsSchemaCompareDialogOpen(false), []);
+
   const openQueryConfirm = useCallback((params: Omit<QueryConfirmState, 'isOpen'>) => {
     setQueryConfirm({ isOpen: true, ...params });
   }, []);
@@ -64,7 +72,11 @@ export function useDialogState(): UseDialogStateResult {
 
   // queryConfirm は意図的に除外: production/read-only 警告ダイアログ open 中も
   // Escape (cancelQuery) を効かせるため、キーボードショートカット抑止対象外とする
-  const hasOpenDialog = isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen;
+  const hasOpenDialog =
+    isConnectionDialogOpen ||
+    isSearchDialogOpen ||
+    isSettingsDialogOpen ||
+    isSchemaCompareDialogOpen;
 
   return {
     isConnectionDialogOpen,
@@ -76,6 +88,9 @@ export function useDialogState(): UseDialogStateResult {
     isSettingsDialogOpen,
     openSettingsDialog,
     closeSettingsDialog,
+    isSchemaCompareDialogOpen,
+    openSchemaCompareDialog,
+    closeSchemaCompareDialog,
     queryConfirm,
     openQueryConfirm,
     closeQueryConfirm,

--- a/frontend/src/hooks/useDialogState.ts
+++ b/frontend/src/hooks/useDialogState.ts
@@ -25,6 +25,10 @@ export interface UseDialogStateResult {
   openDataCompareDialog: () => void;
   closeDataCompareDialog: () => void;
 
+  isSchemaCompareDialogOpen: boolean;
+  openSchemaCompareDialog: () => void;
+  closeSchemaCompareDialog: () => void;
+
   queryConfirm: QueryConfirmState;
   openQueryConfirm: (params: Omit<QueryConfirmState, 'isOpen'>) => void;
   closeQueryConfirm: () => void;
@@ -40,8 +44,8 @@ const QUERY_CONFIRM_INITIAL: QueryConfirmState = {
 
 /**
  * MainLayout の dialog open/close state を集約する管理層 hook。
- * Connection / Search / Settings / DataCompare / QueryConfirm の 5 系統を保持し、open/close API と
- * keyboard shortcut 抑止用の hasOpenDialog (queryConfirm を除く 4 dialog の OR) を返す。
+ * Connection / Search / Settings / DataCompare / SchemaCompare / QueryConfirm の 6 系統を保持し、
+ * open/close API と keyboard shortcut 抑止用の hasOpenDialog (queryConfirm を除く 5 dialog の OR) を返す。
  *
  * 運用ルール: callback (e.g. handleConfirmExecute) はビジネスロジックとの結合点のため
  * 本 hook には含めず、呼び出し側 (MainLayout) で組み立てる。
@@ -51,6 +55,7 @@ export function useDialogState(): UseDialogStateResult {
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
   const [isSettingsDialogOpen, setIsSettingsDialogOpen] = useState(false);
   const [isDataCompareDialogOpen, setIsDataCompareDialogOpen] = useState(false);
+  const [isSchemaCompareDialogOpen, setIsSchemaCompareDialogOpen] = useState(false);
   const [queryConfirm, setQueryConfirm] = useState<QueryConfirmState>(QUERY_CONFIRM_INITIAL);
 
   const openConnectionDialog = useCallback(() => setIsConnectionDialogOpen(true), []);
@@ -65,6 +70,9 @@ export function useDialogState(): UseDialogStateResult {
   const openDataCompareDialog = useCallback(() => setIsDataCompareDialogOpen(true), []);
   const closeDataCompareDialog = useCallback(() => setIsDataCompareDialogOpen(false), []);
 
+  const openSchemaCompareDialog = useCallback(() => setIsSchemaCompareDialogOpen(true), []);
+  const closeSchemaCompareDialog = useCallback(() => setIsSchemaCompareDialogOpen(false), []);
+
   const openQueryConfirm = useCallback((params: Omit<QueryConfirmState, 'isOpen'>) => {
     setQueryConfirm({ isOpen: true, ...params });
   }, []);
@@ -73,7 +81,11 @@ export function useDialogState(): UseDialogStateResult {
   // queryConfirm は意図的に除外: production/read-only 警告ダイアログ open 中も
   // Escape (cancelQuery) を効かせるため、キーボードショートカット抑止対象外とする
   const hasOpenDialog =
-    isConnectionDialogOpen || isSearchDialogOpen || isSettingsDialogOpen || isDataCompareDialogOpen;
+    isConnectionDialogOpen ||
+    isSearchDialogOpen ||
+    isSettingsDialogOpen ||
+    isDataCompareDialogOpen ||
+    isSchemaCompareDialogOpen;
 
   return {
     isConnectionDialogOpen,
@@ -88,6 +100,9 @@ export function useDialogState(): UseDialogStateResult {
     isDataCompareDialogOpen,
     openDataCompareDialog,
     closeDataCompareDialog,
+    isSchemaCompareDialogOpen,
+    openSchemaCompareDialog,
+    closeSchemaCompareDialog,
     queryConfirm,
     openQueryConfirm,
     closeQueryConfirm,

--- a/frontend/src/tests/dialogs/SchemaCompareDialog.test.tsx
+++ b/frontend/src/tests/dialogs/SchemaCompareDialog.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ioProvider, schemaProvider } from '../../api/providers';
+import type { ColumnInfo, TableInfo } from '../../api/providers/schema';
+import { SchemaCompareDialog } from '../../components/dialogs/SchemaCompareDialog';
+import { useConnectionStore } from '../../store/connectionStore';
+import type { Connection } from '../../types';
+
+vi.mock('../../api/providers', () => ({
+  schemaProvider: {
+    getDatabases: vi.fn(),
+    getTables: vi.fn(),
+    getColumns: vi.fn(),
+  },
+  ioProvider: {
+    saveQueryToFile: vi.fn(),
+  },
+  connectionProvider: {},
+}));
+
+function makeConnection(id: string, name: string, database: string): Connection {
+  return {
+    id,
+    name,
+    server: 'localhost',
+    port: 1433,
+    database,
+    username: 'sa',
+    password: '',
+    useWindowsAuth: false,
+    isActive: true,
+    isProduction: false,
+    isReadOnly: false,
+    dbType: 'sqlserver',
+  };
+}
+
+const CONN_A = makeConnection('conn-a', 'DevServer', 'AppDb');
+const CONN_B = makeConnection('conn-b', 'ProdServer', 'AppDb');
+
+// 移行元 (A): users (name varchar(50)), legacy
+const TABLES_A: TableInfo[] = [
+  { schema: 'dbo', name: 'users', type: 'TABLE' },
+  { schema: 'dbo', name: 'legacy', type: 'TABLE' },
+  { schema: 'dbo', name: 'v_users', type: 'VIEW' },
+];
+
+// 移行先 (B): users (name varchar(100) + email 追加), orders
+const TABLES_B: TableInfo[] = [
+  { schema: 'dbo', name: 'users', type: 'TABLE' },
+  { schema: 'dbo', name: 'orders', type: 'TABLE' },
+];
+
+const COLUMNS: Record<string, Record<string, ColumnInfo[]>> = {
+  'conn-a': {
+    users: [
+      { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+      { name: 'name', type: 'varchar', size: 50, nullable: false, isPrimaryKey: false },
+    ],
+    legacy: [{ name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true }],
+  },
+  'conn-b': {
+    users: [
+      { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+      { name: 'name', type: 'varchar', size: 100, nullable: false, isPrimaryKey: false },
+      { name: 'email', type: 'varchar', size: 255, nullable: true, isPrimaryKey: false },
+    ],
+    orders: [{ name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true }],
+  },
+};
+
+function selectSources() {
+  const connectionSelects = screen.getAllByLabelText('接続');
+  fireEvent.change(connectionSelects[0], { target: { value: 'conn-a' } });
+  fireEvent.change(connectionSelects[1], { target: { value: 'conn-b' } });
+}
+
+async function compareAndWait() {
+  selectSources();
+  await waitFor(() => {
+    expect(screen.getByText('比較')).not.toBeDisabled();
+  });
+  fireEvent.click(screen.getByText('比較'));
+  await waitFor(() => {
+    expect(screen.getByText('比較結果')).toBeInTheDocument();
+  });
+}
+
+describe('SchemaCompareDialog', () => {
+  const defaultProps = {
+    isOpen: true as boolean,
+    onClose: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useConnectionStore.setState({ connections: [CONN_A, CONN_B], activeConnectionId: null });
+
+    vi.mocked(schemaProvider.getDatabases).mockResolvedValue(['AppDb', 'OtherDb']);
+    vi.mocked(schemaProvider.getTables).mockImplementation(async (connectionId) => ({
+      tables: connectionId === 'conn-a' ? TABLES_A : TABLES_B,
+      loadTimeMs: 1,
+    }));
+    vi.mocked(schemaProvider.getColumns).mockImplementation(async (connectionId, table) => {
+      const columns = COLUMNS[connectionId]?.[table];
+      if (!columns) throw new Error(`unexpected getColumns(${connectionId}, ${table})`);
+      return columns;
+    });
+    vi.mocked(ioProvider.saveQueryToFile).mockResolvedValue({ filePath: 'C:\\out\\mig.sql' });
+  });
+
+  it('isOpen=false時は非表示', () => {
+    const { container } = render(<SchemaCompareDialog {...defaultProps} isOpen={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('isOpen=true時にタイトルと接続セレクタを表示する', () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    expect(screen.getByText('スキーマ比較')).toBeInTheDocument();
+    expect(screen.getByText('移行元 (A)')).toBeInTheDocument();
+    expect(screen.getByText('移行先 (B)')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('接続')).toHaveLength(2);
+  });
+
+  it('Escapeキーでダイアログが閉じる', () => {
+    const onClose = vi.fn();
+    render(<SchemaCompareDialog {...defaultProps} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('接続未選択時は比較ボタンが無効', () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    expect(screen.getByText('比較')).toBeDisabled();
+  });
+
+  it('接続選択でデータベース一覧を取得する', async () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    selectSources();
+    await waitFor(() => {
+      expect(schemaProvider.getDatabases).toHaveBeenCalledWith('conn-a');
+      expect(schemaProvider.getDatabases).toHaveBeenCalledWith('conn-b');
+    });
+  });
+
+  it('比較実行でテーブル別にグループ化された差分を表示する', async () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    await compareAndWait();
+
+    // 追加 (B のみ) / 削除 (A のみ) / 変更 (共通で差分あり)
+    expect(screen.getByText('dbo.orders')).toBeInTheDocument();
+    expect(screen.getByText('dbo.legacy')).toBeInTheDocument();
+    expect(screen.getByText('dbo.users')).toBeInTheDocument();
+    expect(screen.getByText(/\+ email : varchar\(255\)/)).toBeInTheDocument();
+    expect(screen.getByText(/~ name : varchar\(50\) -> varchar\(100\)/)).toBeInTheDocument();
+  });
+
+  it('VIEW は比較対象から除外される (getColumns が呼ばれない)', async () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    await compareAndWait();
+    expect(schemaProvider.getColumns).not.toHaveBeenCalledWith('conn-a', 'v_users');
+  });
+
+  it('比較実行で移行DDLが生成される (既定方言 sqlserver)', async () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    await compareAndWait();
+
+    const ddl = (screen.getByLabelText('生成された移行DDL') as HTMLTextAreaElement).value;
+    expect(ddl).toContain('CREATE TABLE [dbo].[orders] (');
+    expect(ddl).toContain('ALTER TABLE [dbo].[users] ADD [email] varchar(255);');
+    expect(ddl).toContain('ALTER TABLE [dbo].[users] ALTER COLUMN [name] varchar(100) NOT NULL;');
+    expect(ddl).toContain('-- DROP TABLE [dbo].[legacy];');
+    expect(ddl).toContain('-- 移行元 (from): DevServer/AppDb');
+    expect(ddl).toContain('-- 移行先 (to):   ProdServer/AppDb');
+  });
+
+  it('方言切替でDDLが再生成される', async () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    await compareAndWait();
+
+    fireEvent.change(screen.getByLabelText('DDL方言'), { target: { value: 'postgresql' } });
+    const ddl = (screen.getByLabelText('生成された移行DDL') as HTMLTextAreaElement).value;
+    expect(ddl).toContain('CREATE TABLE "dbo"."orders" (');
+    expect(ddl).toContain('ALTER TABLE "dbo"."users" ADD COLUMN "email" varchar(255);');
+    expect(ddl).toContain('-- 方言: postgresql');
+  });
+
+  it('ダウンロードボタンで saveQueryToFile を呼び出す', async () => {
+    render(<SchemaCompareDialog {...defaultProps} />);
+    await compareAndWait();
+
+    fireEvent.click(screen.getByText('ダウンロード (.sql)'));
+    await waitFor(() => {
+      expect(ioProvider.saveQueryToFile).toHaveBeenCalledWith(
+        expect.stringContaining('CREATE TABLE [dbo].[orders]'),
+        'schema_migration.sql'
+      );
+    });
+    expect(await screen.findByText(/保存しました: C:\\out\\mig\.sql/)).toBeInTheDocument();
+  });
+
+  it('スキーマ取得失敗時はエラーを表示する', async () => {
+    vi.mocked(schemaProvider.getTables).mockRejectedValue(new Error('connection lost'));
+    render(<SchemaCompareDialog {...defaultProps} />);
+    selectSources();
+    await waitFor(() => {
+      expect(screen.getByText('比較')).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByText('比較'));
+
+    expect(await screen.findByText('connection lost')).toBeInTheDocument();
+    expect(screen.queryByText('比較結果')).not.toBeInTheDocument();
+  });
+
+  it('接続が存在しない場合はヒントを表示する', () => {
+    useConnectionStore.setState({ connections: [], activeConnectionId: null });
+    render(<SchemaCompareDialog {...defaultProps} />);
+    expect(
+      screen.getByText('比較するには先にデータベースへ接続してください。')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/utils/migrationDdl.test.ts
+++ b/frontend/src/tests/utils/migrationDdl.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+import type { Column } from '../../types';
+import {
+  generateMigrationDdl,
+  type MigrationDialect,
+  renderColumnType,
+} from '../../utils/migrationDdl';
+import { diffSchemas, type SchemaTable } from '../../utils/schemaDiff';
+
+function col(name: string, overrides: Partial<Column> = {}): Column {
+  return {
+    name,
+    type: 'int',
+    size: 4,
+    nullable: true,
+    isPrimaryKey: false,
+    ...overrides,
+  };
+}
+
+function table(schema: string, name: string, columns: Column[]): SchemaTable {
+  return { schema, name, columns };
+}
+
+function generate(
+  from: SchemaTable[],
+  to: SchemaTable[],
+  dialect: MigrationDialect = 'sqlserver'
+): string {
+  return generateMigrationDdl(diffSchemas(from, to), {
+    dialect,
+    sourceLabel: 'src-conn/SrcDb',
+    targetLabel: 'dst-conn/DstDb',
+  });
+}
+
+describe('renderColumnType', () => {
+  it('文字列系は size を括弧付与する', () => {
+    expect(renderColumnType({ type: 'varchar', size: 50 })).toBe('varchar(50)');
+    expect(renderColumnType({ type: 'nvarchar', size: 100 })).toBe('nvarchar(100)');
+    expect(renderColumnType({ type: 'char', size: 8 })).toBe('char(8)');
+  });
+
+  it('数値系などは size を付与せず型名をそのまま返す', () => {
+    expect(renderColumnType({ type: 'int', size: 4 })).toBe('int');
+    expect(renderColumnType({ type: 'datetime2', size: 8 })).toBe('datetime2');
+  });
+
+  it('既に括弧付きの型はそのまま返す', () => {
+    expect(renderColumnType({ type: 'numeric(10,2)', size: 9 })).toBe('numeric(10,2)');
+  });
+
+  it('size が 0 以下の場合は付与しない', () => {
+    expect(renderColumnType({ type: 'varchar', size: 0 })).toBe('varchar');
+    expect(renderColumnType({ type: 'nvarchar', size: -1 })).toBe('nvarchar');
+  });
+});
+
+describe('generateMigrationDdl: ヘッダー', () => {
+  it('移行元/移行先/方言と生成日時プレースホルダを含む', () => {
+    const ddl = generate([], []);
+    expect(ddl).toContain('-- 移行元 (from): src-conn/SrcDb');
+    expect(ddl).toContain('-- 移行先 (to):   dst-conn/DstDb');
+    expect(ddl).toContain('-- 方言: sqlserver');
+    expect(ddl).toContain('{{GENERATED_AT}}');
+  });
+
+  it('generatedAt 指定時はその値を出力する', () => {
+    const ddl = generateMigrationDdl(diffSchemas([], []), {
+      dialect: 'postgresql',
+      sourceLabel: 'a',
+      targetLabel: 'b',
+      generatedAt: '2026-07-23T00:00:00Z',
+    });
+    expect(ddl).toContain('-- 生成日時: 2026-07-23T00:00:00Z');
+    expect(ddl).not.toContain('{{GENERATED_AT}}');
+  });
+
+  it('差分なしの場合はその旨を出力する', () => {
+    expect(generate([], [])).toContain('-- 差分はありません。');
+  });
+});
+
+describe('generateMigrationDdl: CREATE TABLE', () => {
+  const users = table('dbo', 'users', [
+    col('id', { type: 'int', nullable: false, isPrimaryKey: true }),
+    col('name', { type: 'varchar', size: 50, nullable: false }),
+    col('bio', { type: 'varchar', size: 200 }),
+  ]);
+
+  it('SQL Server: [schema].[table] + NOT NULL + PRIMARY KEY を生成する', () => {
+    const ddl = generate([], [users], 'sqlserver');
+    expect(ddl).toContain('CREATE TABLE [dbo].[users] (');
+    expect(ddl).toContain('  [id] int NOT NULL,');
+    expect(ddl).toContain('  [name] varchar(50) NOT NULL,');
+    expect(ddl).toContain('  [bio] varchar(200),');
+    expect(ddl).toContain('  PRIMARY KEY ([id])');
+    expect(ddl).toContain(');');
+  });
+
+  it('PostgreSQL: "schema"."table" 引用符で生成する', () => {
+    const ddl = generate([], [users], 'postgresql');
+    expect(ddl).toContain('CREATE TABLE "dbo"."users" (');
+    expect(ddl).toContain('  "name" varchar(50) NOT NULL,');
+    expect(ddl).toContain('  PRIMARY KEY ("id")');
+  });
+
+  it('MySQL: バッククォート引用でスキーマ修飾なし', () => {
+    const ddl = generate([], [users], 'mysql');
+    expect(ddl).toContain('CREATE TABLE `users` (');
+    expect(ddl).not.toContain('`dbo`.');
+    expect(ddl).toContain('  PRIMARY KEY (`id`)');
+  });
+
+  it('複合主キーは全 PK カラムを列挙する', () => {
+    const t = table('dbo', 'm', [
+      col('a', { isPrimaryKey: true, nullable: false }),
+      col('b', { isPrimaryKey: true, nullable: false }),
+    ]);
+    expect(generate([], [t], 'sqlserver')).toContain('PRIMARY KEY ([a], [b])');
+  });
+
+  it('PK なしテーブルには PRIMARY KEY 行を出力しない', () => {
+    const t = table('dbo', 'log', [col('message', { type: 'varchar', size: 100 })]);
+    expect(generate([], [t], 'sqlserver')).not.toContain('PRIMARY KEY');
+  });
+});
+
+describe('generateMigrationDdl: ALTER TABLE', () => {
+  const base = table('dbo', 't', [col('id', { nullable: false, isPrimaryKey: true })]);
+
+  it('カラム追加: SQL Server は ADD、PostgreSQL/MySQL は ADD COLUMN', () => {
+    const to = table('dbo', 't', [...base.columns, col('email', { type: 'varchar', size: 255 })]);
+    expect(generate([base], [to], 'sqlserver')).toContain(
+      'ALTER TABLE [dbo].[t] ADD [email] varchar(255);'
+    );
+    expect(generate([base], [to], 'postgresql')).toContain(
+      'ALTER TABLE "dbo"."t" ADD COLUMN "email" varchar(255);'
+    );
+    expect(generate([base], [to], 'mysql')).toContain(
+      'ALTER TABLE `t` ADD COLUMN `email` varchar(255);'
+    );
+  });
+
+  it('NOT NULL カラム追加には警告コメントを付与する', () => {
+    const to = table('dbo', 't', [
+      ...base.columns,
+      col('code', { type: 'varchar', size: 10, nullable: false }),
+    ]);
+    const ddl = generate([base], [to], 'sqlserver');
+    expect(ddl).toContain('-- 注意: NOT NULL カラム追加は既存行がある場合に失敗します');
+    expect(ddl).toContain('ALTER TABLE [dbo].[t] ADD [code] varchar(10) NOT NULL;');
+  });
+
+  it('型変更: SQL Server は ALTER COLUMN + NULL 指定', () => {
+    const from = table('dbo', 't', [col('id', { nullable: false }), col('v', { type: 'int' })]);
+    const to = table('dbo', 't', [
+      col('id', { nullable: false }),
+      col('v', { type: 'bigint', size: 8 }),
+    ]);
+    const ddl = generate([from], [to], 'sqlserver');
+    expect(ddl).toContain('ALTER TABLE [dbo].[t] ALTER COLUMN [v] bigint NULL;');
+    expect(ddl).toContain('-- 注意: 型変更 (int -> bigint) はデータ変換に失敗する可能性があります');
+  });
+
+  it('型変更: PostgreSQL は ALTER COLUMN ... TYPE', () => {
+    const from = table('public', 't', [col('v', { type: 'integer' })]);
+    const to = table('public', 't', [col('v', { type: 'bigint', size: 8 })]);
+    expect(generate([from], [to], 'postgresql')).toContain(
+      'ALTER TABLE "public"."t" ALTER COLUMN "v" TYPE bigint;'
+    );
+  });
+
+  it('型変更: MySQL は MODIFY COLUMN', () => {
+    const from = table('', 't', [col('v', { type: 'int' })]);
+    const to = table('', 't', [col('v', { type: 'bigint', size: 8, nullable: false })]);
+    expect(generate([from], [to], 'mysql')).toContain(
+      'ALTER TABLE `t` MODIFY COLUMN `v` bigint NOT NULL;'
+    );
+  });
+
+  it('NULL 制約変更: PostgreSQL は SET / DROP NOT NULL を使い分ける', () => {
+    const from = table('public', 't', [
+      col('a', { nullable: true }),
+      col('b', { nullable: false }),
+    ]);
+    const to = table('public', 't', [col('a', { nullable: false }), col('b', { nullable: true })]);
+    const ddl = generate([from], [to], 'postgresql');
+    expect(ddl).toContain('ALTER TABLE "public"."t" ALTER COLUMN "a" SET NOT NULL;');
+    expect(ddl).toContain('ALTER TABLE "public"."t" ALTER COLUMN "b" DROP NOT NULL;');
+    expect(ddl).toContain('-- 注意: NOT NULL 化は NULL 値が存在する場合に失敗します');
+  });
+
+  it('サイズ縮小には切り捨て警告コメントを付与する', () => {
+    const from = table('dbo', 't', [col('v', { type: 'varchar', size: 100 })]);
+    const to = table('dbo', 't', [col('v', { type: 'varchar', size: 50 })]);
+    const ddl = generate([from], [to], 'sqlserver');
+    expect(ddl).toContain(
+      '-- 注意: サイズ縮小 (varchar(100) -> varchar(50)) はデータ切り捨ての可能性があります'
+    );
+    expect(ddl).toContain('ALTER TABLE [dbo].[t] ALTER COLUMN [v] varchar(50) NULL;');
+  });
+
+  it('主キー変更は自動生成対象外の注意コメントのみ出力する', () => {
+    const from = table('dbo', 't', [col('id', { isPrimaryKey: false, nullable: false })]);
+    const to = table('dbo', 't', [col('id', { isPrimaryKey: true, nullable: false })]);
+    const ddl = generate([from], [to], 'sqlserver');
+    expect(ddl).toContain('-- 注意: 主キー変更 (id) は自動生成の対象外です');
+    expect(ddl).not.toContain('ALTER TABLE [dbo].[t] ALTER COLUMN [id]');
+  });
+});
+
+describe('generateMigrationDdl: 破壊的操作', () => {
+  it('DROP TABLE はコメントアウト + 警告付きで出力する', () => {
+    const ddl = generate([table('dbo', 'legacy', [col('id')])], [], 'sqlserver');
+    expect(ddl).toContain('-- DROP TABLE [dbo].[legacy];');
+    expect(ddl).not.toContain('\nDROP TABLE');
+    expect(ddl).toContain('【破壊的操作】DROP TABLE は既定でコメントアウトされています');
+  });
+
+  it('DROP COLUMN はコメントアウト + 警告付きで出力する', () => {
+    const from = table('dbo', 't', [col('id'), col('legacy')]);
+    const to = table('dbo', 't', [col('id')]);
+    const ddl = generate([from], [to], 'sqlserver');
+    expect(ddl).toContain('-- ALTER TABLE [dbo].[t] DROP COLUMN [legacy];');
+    expect(ddl).not.toContain('\nALTER TABLE [dbo].[t] DROP COLUMN');
+    expect(ddl).toContain('【破壊的操作】DROP COLUMN は既定でコメントアウトされています');
+  });
+});
+
+describe('generateMigrationDdl: 決定的な出力順', () => {
+  it('CREATE → ALTER → DROP のセクション順で、テーブルはキー昇順に出力する', () => {
+    const from = [
+      table('dbo', 'removed_z', [col('id')]),
+      table('dbo', 'removed_a', [col('id')]),
+      table('dbo', 'changed', [col('id')]),
+    ];
+    const to = [
+      table('dbo', 'added_z', [col('id')]),
+      table('dbo', 'added_a', [col('id')]),
+      table('dbo', 'changed', [col('id'), col('extra')]),
+    ];
+    const ddl = generate(from, to, 'sqlserver');
+
+    const positions = [
+      ddl.indexOf('CREATE TABLE [dbo].[added_a]'),
+      ddl.indexOf('CREATE TABLE [dbo].[added_z]'),
+      ddl.indexOf('ALTER TABLE [dbo].[changed] ADD [extra]'),
+      ddl.indexOf('-- DROP TABLE [dbo].[removed_a];'),
+      ddl.indexOf('-- DROP TABLE [dbo].[removed_z];'),
+    ];
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+  });
+
+  it('同一入力からは常に同一の出力を生成する', () => {
+    const from = [table('dbo', 'a', [col('id')])];
+    const to = [table('dbo', 'b', [col('id')])];
+    expect(generate(from, to)).toBe(generate(from, to));
+  });
+});
+
+describe('generateMigrationDdl: 識別子エスケープ', () => {
+  it('特殊文字を含む識別子を方言ごとにエスケープする', () => {
+    const t = table('dbo', 'we]ird', [col('col"1'), col('col`2')]);
+    expect(generate([], [t], 'sqlserver')).toContain('CREATE TABLE [dbo].[we]]ird] (');
+    expect(generate([], [t], 'postgresql')).toContain('"col""1"');
+    expect(generate([], [t], 'mysql')).toContain('`col``2`');
+  });
+});

--- a/frontend/src/tests/utils/schemaDiff.test.ts
+++ b/frontend/src/tests/utils/schemaDiff.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import type { Column } from '../../types';
+import { diffSchemas, isEmptyDiff, type SchemaTable, tableKey } from '../../utils/schemaDiff';
+
+function col(name: string, overrides: Partial<Column> = {}): Column {
+  return {
+    name,
+    type: 'int',
+    size: 4,
+    nullable: true,
+    isPrimaryKey: false,
+    ...overrides,
+  };
+}
+
+function table(schema: string, name: string, columns: Column[]): SchemaTable {
+  return { schema, name, columns };
+}
+
+describe('tableKey', () => {
+  it('schema ありは "schema.name" を返す', () => {
+    expect(tableKey({ schema: 'dbo', name: 'users' })).toBe('dbo.users');
+  });
+
+  it('schema 空は name のみ返す', () => {
+    expect(tableKey({ schema: '', name: 'users' })).toBe('users');
+  });
+});
+
+describe('diffSchemas: テーブル集合', () => {
+  it('追加・削除・共通テーブルを分類する', () => {
+    const from = [table('dbo', 't1', [col('id')]), table('dbo', 't2', [col('id')])];
+    const to = [table('dbo', 't2', [col('id')]), table('dbo', 't3', [col('id')])];
+
+    const diff = diffSchemas(from, to);
+
+    expect(diff.addedTables.map(tableKey)).toEqual(['dbo.t3']);
+    expect(diff.removedTables.map(tableKey)).toEqual(['dbo.t1']);
+    expect(diff.changedTables).toEqual([]);
+    expect(diff.unchangedTableCount).toBe(1);
+    expect(isEmptyDiff(diff)).toBe(false);
+  });
+
+  it('両方空なら差分なし', () => {
+    const diff = diffSchemas([], []);
+    expect(diff.addedTables).toEqual([]);
+    expect(diff.removedTables).toEqual([]);
+    expect(diff.changedTables).toEqual([]);
+    expect(diff.unchangedTableCount).toBe(0);
+    expect(isEmptyDiff(diff)).toBe(true);
+  });
+
+  it('移行元が空なら全テーブルが追加になる', () => {
+    const to = [table('dbo', 'a', [col('id')]), table('dbo', 'b', [col('id')])];
+    const diff = diffSchemas([], to);
+    expect(diff.addedTables.map(tableKey)).toEqual(['dbo.a', 'dbo.b']);
+    expect(diff.removedTables).toEqual([]);
+  });
+
+  it('移行先が空なら全テーブルが削除になる', () => {
+    const from = [table('dbo', 'a', [col('id')])];
+    const diff = diffSchemas(from, []);
+    expect(diff.addedTables).toEqual([]);
+    expect(diff.removedTables.map(tableKey)).toEqual(['dbo.a']);
+  });
+
+  it('テーブル名の大文字小文字は区別する (Users と users は別テーブル)', () => {
+    const from = [table('dbo', 'Users', [col('id')])];
+    const to = [table('dbo', 'users', [col('id')])];
+    const diff = diffSchemas(from, to);
+    expect(diff.addedTables.map(tableKey)).toEqual(['dbo.users']);
+    expect(diff.removedTables.map(tableKey)).toEqual(['dbo.Users']);
+  });
+
+  it('同名テーブルでもスキーマが異なれば別テーブル扱い', () => {
+    const from = [table('sales', 'orders', [col('id')])];
+    const to = [table('archive', 'orders', [col('id')])];
+    const diff = diffSchemas(from, to);
+    expect(diff.addedTables.map(tableKey)).toEqual(['archive.orders']);
+    expect(diff.removedTables.map(tableKey)).toEqual(['sales.orders']);
+  });
+
+  it('出力はテーブルキー昇順で決定的に整列される', () => {
+    const from = [
+      table('dbo', 'zebra', [col('id')]),
+      table('dbo', 'alpha', [col('id')]),
+      table('abc', 'middle', [col('id')]),
+    ];
+    const diff = diffSchemas(from, []);
+    expect(diff.removedTables.map(tableKey)).toEqual(['abc.middle', 'dbo.alpha', 'dbo.zebra']);
+  });
+});
+
+describe('diffSchemas: カラム差分', () => {
+  it('カラム追加を検出する (移行先の定義順)', () => {
+    const from = [table('dbo', 't', [col('id')])];
+    const to = [table('dbo', 't', [col('id'), col('email'), col('age')])];
+
+    const diff = diffSchemas(from, to);
+
+    expect(diff.changedTables).toHaveLength(1);
+    expect(diff.changedTables[0].addedColumns.map((c) => c.name)).toEqual(['email', 'age']);
+    expect(diff.changedTables[0].removedColumns).toEqual([]);
+    expect(diff.changedTables[0].changedColumns).toEqual([]);
+  });
+
+  it('カラム削除を検出する', () => {
+    const from = [table('dbo', 't', [col('id'), col('legacy')])];
+    const to = [table('dbo', 't', [col('id')])];
+
+    const diff = diffSchemas(from, to);
+
+    expect(diff.changedTables[0].removedColumns.map((c) => c.name)).toEqual(['legacy']);
+  });
+
+  it('type / size / nullable / isPrimaryKey の変更を属性別に検出する', () => {
+    const from = [
+      table('dbo', 't', [
+        col('a', { type: 'int' }),
+        col('b', { type: 'varchar', size: 50 }),
+        col('c', { nullable: true }),
+        col('d', { isPrimaryKey: false }),
+      ]),
+    ];
+    const to = [
+      table('dbo', 't', [
+        col('a', { type: 'bigint', size: 8 }),
+        col('b', { type: 'varchar', size: 100 }),
+        col('c', { nullable: false }),
+        col('d', { isPrimaryKey: true }),
+      ]),
+    ];
+
+    const diff = diffSchemas(from, to);
+    const changed = diff.changedTables[0].changedColumns;
+
+    expect(changed.map((c) => c.name)).toEqual(['a', 'b', 'c', 'd']);
+    expect(changed[0].changes).toEqual(['type', 'size']);
+    expect(changed[1].changes).toEqual(['size']);
+    expect(changed[2].changes).toEqual(['nullable']);
+    expect(changed[3].changes).toEqual(['isPrimaryKey']);
+  });
+
+  it('変更前後の定義を from / to として保持する', () => {
+    const from = [table('dbo', 't', [col('a', { type: 'int' })])];
+    const to = [table('dbo', 't', [col('a', { type: 'bigint' })])];
+
+    const change = diffSchemas(from, to).changedTables[0].changedColumns[0];
+    expect(change.from.type).toBe('int');
+    expect(change.to.type).toBe('bigint');
+  });
+
+  it('カラム名の大文字小文字は区別する', () => {
+    const from = [table('dbo', 't', [col('Id')])];
+    const to = [table('dbo', 't', [col('id')])];
+
+    const diff = diffSchemas(from, to);
+    expect(diff.changedTables[0].addedColumns.map((c) => c.name)).toEqual(['id']);
+    expect(diff.changedTables[0].removedColumns.map((c) => c.name)).toEqual(['Id']);
+  });
+
+  it('差分のない共通テーブルは changedTables に含まれない', () => {
+    const shared = [col('id', { isPrimaryKey: true, nullable: false }), col('name')];
+    const diff = diffSchemas([table('dbo', 't', shared)], [table('dbo', 't', [...shared])]);
+    expect(diff.changedTables).toEqual([]);
+    expect(diff.unchangedTableCount).toBe(1);
+    expect(isEmptyDiff(diff)).toBe(true);
+  });
+
+  it('comment の変更は差分として扱わない (比較対象外)', () => {
+    const from = [table('dbo', 't', [col('id', { comment: 'old' })])];
+    const to = [table('dbo', 't', [col('id', { comment: 'new' })])];
+    expect(isEmptyDiff(diffSchemas(from, to))).toBe(true);
+  });
+});

--- a/frontend/src/utils/migrationDdl.ts
+++ b/frontend/src/utils/migrationDdl.ts
@@ -1,0 +1,220 @@
+// 移行 DDL 生成 (純関数層)。
+// utils/schemaDiff.ts が生成した SchemaDiff から、方言別の移行スクリプト (DDL) を生成する。
+// 破壊的操作 (DROP TABLE / DROP COLUMN) は既定でコメントアウトして出力する。
+// 識別子クォートは utils/sql/quoting.ts に依存。
+
+import type { Column, DatabaseType } from '../types';
+import type { ColumnChange, SchemaDiff, SchemaTable, TableDiff } from './schemaDiff';
+import { isEmptyDiff, tableKey } from './schemaDiff';
+import { quoteIdentifier } from './sql/quoting';
+
+export type MigrationDialect = DatabaseType;
+
+export interface MigrationDdlOptions {
+  dialect: MigrationDialect;
+  /** ヘッダーに記載する移行元の説明 (例: "dev-server/AppDb") */
+  sourceLabel: string;
+  /** ヘッダーに記載する移行先の説明 */
+  targetLabel: string;
+  /** 生成日時。省略時はプレースホルダ {{GENERATED_AT}} を出力する (純関数性維持) */
+  generatedAt?: string;
+}
+
+/** サイズ表記 type(size) を付与する型ファミリー (文字列 / バイナリ系のみ)。それ以外は取得値をそのまま出力 */
+const SIZED_TYPE_RE = /^(n?char|n?varchar|character(?: varying)?|varbinary|binary|varchar2)$/i;
+
+/** カラム型の描画。型名は取得値をそのまま使い、文字列/バイナリ系のみ size を括弧付与する */
+export function renderColumnType(column: Pick<Column, 'type' | 'size'>): string {
+  const type = column.type.trim();
+  if (type.includes('(')) return type;
+  if (column.size > 0 && SIZED_TYPE_RE.test(type)) {
+    return `${type}(${column.size})`;
+  }
+  return type;
+}
+
+function qualifyTable(schema: string, name: string, dialect: MigrationDialect): string {
+  // MySQL はスキーマ = データベースのため名前のみ修飾 (utils/sql/ddl/table-ddl.ts と同方針)
+  if (dialect === 'mysql' || schema === '') {
+    return quoteIdentifier(name, dialect);
+  }
+  return `${quoteIdentifier(schema, dialect)}.${quoteIdentifier(name, dialect)}`;
+}
+
+function renderColumnDef(column: Column, dialect: MigrationDialect): string {
+  const notNull = column.nullable ? '' : ' NOT NULL';
+  return `${quoteIdentifier(column.name, dialect)} ${renderColumnType(column)}${notNull}`;
+}
+
+function buildCreateTable(table: SchemaTable, dialect: MigrationDialect): string[] {
+  const lines: string[] = [];
+  lines.push(`CREATE TABLE ${qualifyTable(table.schema, table.name, dialect)} (`);
+
+  const defs = table.columns.map((c) => `  ${renderColumnDef(c, dialect)}`);
+  const pkColumns = table.columns.filter((c) => c.isPrimaryKey);
+  if (pkColumns.length > 0) {
+    const pkList = pkColumns.map((c) => quoteIdentifier(c.name, dialect)).join(', ');
+    defs.push(`  PRIMARY KEY (${pkList})`);
+  }
+  lines.push(defs.join(',\n'));
+  lines.push(');');
+  return lines;
+}
+
+function buildAddColumn(table: TableDiff, column: Column, dialect: MigrationDialect): string {
+  const target = qualifyTable(table.schema, table.name, dialect);
+  const def = renderColumnDef(column, dialect);
+  const keyword = dialect === 'sqlserver' ? 'ADD' : 'ADD COLUMN';
+  const statement = `ALTER TABLE ${target} ${keyword} ${def};`;
+  if (!column.nullable) {
+    return `-- 注意: NOT NULL カラム追加は既存行がある場合に失敗します (DEFAULT 指定を検討)\n${statement}`;
+  }
+  return statement;
+}
+
+function riskComments(change: ColumnChange): string[] {
+  const comments: string[] = [];
+  const fromType = renderColumnType(change.from);
+  const toType = renderColumnType(change.to);
+  if (change.changes.includes('type')) {
+    comments.push(
+      `-- 注意: 型変更 (${fromType} -> ${toType}) はデータ変換に失敗する可能性があります`
+    );
+  } else if (change.changes.includes('size') && change.to.size < change.from.size) {
+    comments.push(
+      `-- 注意: サイズ縮小 (${fromType} -> ${toType}) はデータ切り捨ての可能性があります`
+    );
+  }
+  if (change.changes.includes('nullable') && !change.to.nullable) {
+    comments.push('-- 注意: NOT NULL 化は NULL 値が存在する場合に失敗します');
+  }
+  return comments;
+}
+
+function buildAlterColumn(
+  table: TableDiff,
+  change: ColumnChange,
+  dialect: MigrationDialect
+): string[] {
+  const target = qualifyTable(table.schema, table.name, dialect);
+  const col = quoteIdentifier(change.name, dialect);
+  const lines: string[] = [...riskComments(change)];
+
+  const needsDefChange =
+    change.changes.includes('type') ||
+    change.changes.includes('size') ||
+    change.changes.includes('nullable');
+
+  if (needsDefChange) {
+    switch (dialect) {
+      case 'postgresql': {
+        if (change.changes.includes('type') || change.changes.includes('size')) {
+          lines.push(
+            `ALTER TABLE ${target} ALTER COLUMN ${col} TYPE ${renderColumnType(change.to)};`
+          );
+        }
+        if (change.changes.includes('nullable')) {
+          lines.push(
+            change.to.nullable
+              ? `ALTER TABLE ${target} ALTER COLUMN ${col} DROP NOT NULL;`
+              : `ALTER TABLE ${target} ALTER COLUMN ${col} SET NOT NULL;`
+          );
+        }
+        break;
+      }
+      case 'mysql': {
+        lines.push(`ALTER TABLE ${target} MODIFY COLUMN ${renderColumnDef(change.to, dialect)};`);
+        break;
+      }
+      default: {
+        const nullability = change.to.nullable ? 'NULL' : 'NOT NULL';
+        lines.push(
+          `ALTER TABLE ${target} ALTER COLUMN ${col} ${renderColumnType(change.to)} ${nullability};`
+        );
+        break;
+      }
+    }
+  }
+
+  if (change.changes.includes('isPrimaryKey')) {
+    lines.push(
+      `-- 注意: 主キー変更 (${change.name}) は自動生成の対象外です。制約の付け替えを手動で行ってください`
+    );
+  }
+  return lines;
+}
+
+function buildDropColumn(table: TableDiff, column: Column, dialect: MigrationDialect): string[] {
+  const target = qualifyTable(table.schema, table.name, dialect);
+  return [
+    '-- 【破壊的操作】DROP COLUMN は既定でコメントアウトされています。実行する場合は解除してください',
+    `-- ALTER TABLE ${target} DROP COLUMN ${quoteIdentifier(column.name, dialect)};`,
+  ];
+}
+
+function buildDropTable(table: SchemaTable, dialect: MigrationDialect): string[] {
+  return [
+    '-- 【破壊的操作】DROP TABLE は既定でコメントアウトされています。実行する場合は解除してください',
+    `-- DROP TABLE ${qualifyTable(table.schema, table.name, dialect)};`,
+  ];
+}
+
+function buildHeader(diff: SchemaDiff, options: MigrationDdlOptions): string[] {
+  return [
+    '-- ============================================================',
+    '-- スキーマ移行スクリプト (Velocity-DB schema compare)',
+    `-- 移行元 (from): ${options.sourceLabel}`,
+    `-- 移行先 (to):   ${options.targetLabel}`,
+    `-- 方言: ${options.dialect}`,
+    `-- 生成日時: ${options.generatedAt ?? '{{GENERATED_AT}}'}`,
+    `-- 差分: 追加テーブル ${diff.addedTables.length} / 削除テーブル ${diff.removedTables.length} / 変更テーブル ${diff.changedTables.length}`,
+    '-- 注意: 実行前に必ず内容を確認し、バックアップを取得してください。',
+    '--       破壊的操作 (DROP TABLE / DROP COLUMN) はコメントアウトされています。',
+    '-- ============================================================',
+  ];
+}
+
+/**
+ * SchemaDiff から移行 DDL スクリプトを生成する。
+ *
+ * - 「移行元スキーマを移行先スキーマの形へ変換する」DDL を出力する。
+ * - セクション順: CREATE TABLE → ALTER TABLE → DROP TABLE (各テーブルキー昇順、決定的)。
+ * - 破壊的操作はコメントアウト + 警告付き。
+ */
+export function generateMigrationDdl(diff: SchemaDiff, options: MigrationDdlOptions): string {
+  const { dialect } = options;
+  const sections: string[] = [buildHeader(diff, options).join('\n')];
+
+  if (isEmptyDiff(diff)) {
+    sections.push('-- 差分はありません。');
+    return `${sections.join('\n\n')}\n`;
+  }
+
+  for (const table of diff.addedTables) {
+    sections.push(
+      [`-- [追加テーブル] ${tableKey(table)}`, ...buildCreateTable(table, dialect)].join('\n')
+    );
+  }
+
+  for (const table of diff.changedTables) {
+    const lines: string[] = [`-- [変更テーブル] ${tableKey(table)}`];
+    for (const column of table.addedColumns) {
+      lines.push(buildAddColumn(table, column, dialect));
+    }
+    for (const change of table.changedColumns) {
+      lines.push(...buildAlterColumn(table, change, dialect));
+    }
+    for (const column of table.removedColumns) {
+      lines.push(...buildDropColumn(table, column, dialect));
+    }
+    sections.push(lines.join('\n'));
+  }
+
+  for (const table of diff.removedTables) {
+    sections.push(
+      [`-- [削除テーブル] ${tableKey(table)}`, ...buildDropTable(table, dialect)].join('\n')
+    );
+  }
+
+  return `${sections.join('\n\n')}\n`;
+}

--- a/frontend/src/utils/schemaDiff.ts
+++ b/frontend/src/utils/schemaDiff.ts
@@ -1,0 +1,136 @@
+// スキーマ比較エンジン (純関数層)。
+// 2 つのスキーマモデル (テーブル + カラム定義) を比較し、構造化された差分モデルを返す。
+// DDL 生成は utils/migrationDdl.ts が担当する (本モジュールは SQL を一切生成しない)。
+
+import type { Column } from '../types';
+
+/** 比較対象のテーブル定義 (schema 名は空文字許容: 既定スキーマ扱い) */
+export interface SchemaTable {
+  schema: string;
+  name: string;
+  columns: Column[];
+}
+
+/** カラム比較で差分検出の対象となる属性 */
+export type ColumnChangeKind = 'type' | 'size' | 'nullable' | 'isPrimaryKey';
+
+/** 共通テーブル内で定義が変化したカラム */
+export interface ColumnChange {
+  name: string;
+  /** 移行元 (from) 側の定義 */
+  from: Column;
+  /** 移行先 (to) 側の定義 */
+  to: Column;
+  /** 変化した属性の一覧 (定義順: type, size, nullable, isPrimaryKey) */
+  changes: ColumnChangeKind[];
+}
+
+/** 両スキーマに存在するテーブルのカラムレベル差分 */
+export interface TableDiff {
+  schema: string;
+  name: string;
+  /** 移行先にのみ存在するカラム (ADD COLUMN 対象)。移行先の定義順 */
+  addedColumns: Column[];
+  /** 移行元にのみ存在するカラム (DROP COLUMN 対象)。移行元の定義順 */
+  removedColumns: Column[];
+  /** 定義が変化したカラム。移行先の定義順 */
+  changedColumns: ColumnChange[];
+}
+
+/** スキーマ全体の差分モデル。「移行元 (from) → 移行先 (to)」方向で解釈する */
+export interface SchemaDiff {
+  /** 移行先にのみ存在するテーブル (CREATE TABLE 対象)。キー昇順 */
+  addedTables: SchemaTable[];
+  /** 移行元にのみ存在するテーブル (DROP TABLE 対象)。キー昇順 */
+  removedTables: SchemaTable[];
+  /** 両方に存在し差分があるテーブル。キー昇順 */
+  changedTables: TableDiff[];
+  /** 両方に存在し差分がないテーブル数 */
+  unchangedTableCount: number;
+}
+
+/** テーブル識別キー ("schema.name" / schema 空なら "name")。大文字小文字は区別する */
+export function tableKey(table: Pick<SchemaTable, 'schema' | 'name'>): string {
+  return table.schema !== '' ? `${table.schema}.${table.name}` : table.name;
+}
+
+function compareColumn(from: Column, to: Column): ColumnChangeKind[] {
+  const changes: ColumnChangeKind[] = [];
+  if (from.type !== to.type) changes.push('type');
+  if (from.size !== to.size) changes.push('size');
+  if (from.nullable !== to.nullable) changes.push('nullable');
+  if (from.isPrimaryKey !== to.isPrimaryKey) changes.push('isPrimaryKey');
+  return changes;
+}
+
+function diffTableColumns(from: SchemaTable, to: SchemaTable): TableDiff | null {
+  const fromByName = new Map(from.columns.map((c) => [c.name, c]));
+  const toByName = new Map(to.columns.map((c) => [c.name, c]));
+
+  const addedColumns = to.columns.filter((c) => !fromByName.has(c.name));
+  const removedColumns = from.columns.filter((c) => !toByName.has(c.name));
+
+  const changedColumns: ColumnChange[] = [];
+  for (const toCol of to.columns) {
+    const fromCol = fromByName.get(toCol.name);
+    if (!fromCol) continue;
+    const changes = compareColumn(fromCol, toCol);
+    if (changes.length > 0) {
+      changedColumns.push({ name: toCol.name, from: fromCol, to: toCol, changes });
+    }
+  }
+
+  if (addedColumns.length === 0 && removedColumns.length === 0 && changedColumns.length === 0) {
+    return null;
+  }
+  return { schema: to.schema, name: to.name, addedColumns, removedColumns, changedColumns };
+}
+
+function sortByKey<T extends Pick<SchemaTable, 'schema' | 'name'>>(tables: T[]): T[] {
+  return [...tables].sort((a, b) => {
+    const ka = tableKey(a);
+    const kb = tableKey(b);
+    if (ka < kb) return -1;
+    if (ka > kb) return 1;
+    return 0;
+  });
+}
+
+/**
+ * 2 つのスキーマモデルを比較し差分を返す。
+ *
+ * - 方向: `from` (移行元) を `to` (移行先) の形へ変換するための差分。
+ * - テーブル / カラム名は取得値のまま大文字小文字を区別して比較する。
+ * - 出力の各テーブル一覧はキー昇順で決定的に整列する。
+ */
+export function diffSchemas(from: SchemaTable[], to: SchemaTable[]): SchemaDiff {
+  const fromByKey = new Map(from.map((t) => [tableKey(t), t]));
+  const toByKey = new Map(to.map((t) => [tableKey(t), t]));
+
+  const addedTables = sortByKey(to.filter((t) => !fromByKey.has(tableKey(t))));
+  const removedTables = sortByKey(from.filter((t) => !toByKey.has(tableKey(t))));
+
+  const changedTables: TableDiff[] = [];
+  let unchangedTableCount = 0;
+  for (const toTable of sortByKey(to.filter((t) => fromByKey.has(tableKey(t))))) {
+    const fromTable = fromByKey.get(tableKey(toTable));
+    if (!fromTable) continue;
+    const diff = diffTableColumns(fromTable, toTable);
+    if (diff) {
+      changedTables.push(diff);
+    } else {
+      unchangedTableCount += 1;
+    }
+  }
+
+  return { addedTables, removedTables, changedTables, unchangedTableCount };
+}
+
+/** 差分が 1 件も存在しないかを判定する */
+export function isEmptyDiff(diff: SchemaDiff): boolean {
+  return (
+    diff.addedTables.length === 0 &&
+    diff.removedTables.length === 0 &&
+    diff.changedTables.length === 0
+  );
+}


### PR DESCRIPTION
2 つの接続/データベースのスキーマ (テーブル + カラム定義) を比較し、
方言別 (SQL Server / PostgreSQL / MySQL) の移行 DDL を自動生成する SchemaCompareDialog を追加 (#257)。

- utils/schemaDiff.ts: 純関数の差分エンジン (テーブル追加/削除、 カラム追加/削除/変更 type・size・nullable・isPrimaryKey)
- utils/migrationDdl.ts: CREATE TABLE / ALTER TABLE / DROP (コメント アウト + 警告) を方言別クォートで生成。危険な変換に注意コメント付与
- dialogs/SchemaCompareDialog: 接続/DB 選択、進捗表示、差分ツリー、 方言切替、DDL コピー / .sql 保存
- MainLayout / useDialogState に SettingsDialog と同型の最小配線

Fixes #257