### PR TITLE
fix(scripts): vcpkg baseline 同期の HEAD 取得と clean のロック耐性を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,5 @@
 {
   "cmake.useCMakePresets": "always",
-  "cmake.defaultBuildPreset": "release",
-  "cmake.defaultConfigurePreset": "release",
-  "cmake.defaultTestPreset": "release",
   "cmake.generator": "Ninja",
   "cmake.configureSettings": {
     "CMAKE_BUILD_TYPE": "Release"
@@ -49,5 +46,14 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.markdownlint": "always"
     }
-  }
+  },
+  "python.analysis.exclude": [
+      "**/node_modules",
+      "**/__pycache__",
+      "**/.*",
+      ".venv",
+      ".git",
+      ".ruff_cache",
+      ".pytest_cache",
+  ],
 }

--- a/scripts/_lib/build.py
+++ b/scripts/_lib/build.py
@@ -3,6 +3,7 @@
 import io
 import json
 import shutil
+import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TextIO
@@ -152,16 +153,21 @@ def _sync_vcpkg_to_baseline(project_root: Path, vcpkg_dir: Path, out: TextIO | N
     if not baseline:
         return True
 
-    head_ok, head_sha = utils.run_command(
-        ["git", "-C", str(vcpkg_dir), "rev-parse", "HEAD"],
-        "git rev-parse",
-        capture_output=True,
-        out=None,
-    )
-    if not (head_ok and head_sha):
+    # NOTE: utils.run_command returns stderr as its second element, not stdout,
+    # so it cannot be used to read HEAD (git rev-parse prints the SHA to stdout).
+    # Capture stdout directly here instead.
+    try:
+        head_result = subprocess.run(
+            ["git", "-C", str(vcpkg_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            encoding="utf-8",
+        )
+    except OSError:
+        return True
+    if head_result.returncode != 0 or not head_result.stdout:
         return True
 
-    head = head_sha.strip()
+    head = head_result.stdout.strip()
     if baseline == head:
         return True
 

--- a/scripts/pdg.py
+++ b/scripts/pdg.py
@@ -342,11 +342,22 @@ def cmd_clean(args: argparse.Namespace) -> bool:
         # Clean log directory
         log_dir = project_root / "log"
         if log_dir.exists():
-            for log_file in log_dir.glob("*.log"):
-                log_file.unlink()
-                cleaned_items.append(f"  [OK] Deleted: {log_file.name}")
-            if not cleaned_items:
+            log_files = list(log_dir.glob("*.log"))
+            if not log_files:
                 cleaned_items.append("  [INFO] No log files found")
+            for log_file in log_files:
+                try:
+                    log_file.unlink()
+                    cleaned_items.append(f"  [OK] Deleted: {log_file.name}")
+                except PermissionError:
+                    # Windows: file is held open by a running VelocityDB / dev
+                    # process. Skip it instead of aborting the whole command.
+                    cleaned_items.append(
+                        f"  [SKIP] In use by another process: {log_file.name} "
+                        "(close the running app, then retry)"
+                    )
+                except OSError as e:
+                    cleaned_items.append(f"  [FAIL] Could not delete {log_file.name}: {e}")
         else:
             cleaned_items.append("  [INFO] Log directory does not exist")
 
@@ -354,16 +365,22 @@ def cmd_clean(args: argparse.Namespace) -> bool:
         # Clean WebView2 cache
         webview_cache = project_root / "build" / "Release" / "VelocityDB.exe.WebView2"
         if webview_cache.exists():
-            shutil.rmtree(webview_cache)
-            cleaned_items.append("  [OK] Deleted: WebView2 cache")
+            try:
+                shutil.rmtree(webview_cache)
+                cleaned_items.append("  [OK] Deleted: WebView2 cache")
+            except OSError as e:
+                cleaned_items.append(f"  [SKIP] WebView2 cache in use or locked: {e}")
         else:
             cleaned_items.append("  [INFO] WebView2 cache does not exist")
 
         # Clean frontend node_modules/.cache
         frontend_cache = project_root / "frontend" / "node_modules" / ".cache"
         if frontend_cache.exists():
-            shutil.rmtree(frontend_cache)
-            cleaned_items.append("  [OK] Deleted: Frontend cache")
+            try:
+                shutil.rmtree(frontend_cache)
+                cleaned_items.append("  [OK] Deleted: Frontend cache")
+            except OSError as e:
+                cleaned_items.append(f"  [SKIP] Frontend cache in use or locked: {e}")
 
     for item in cleaned_items:
         print(item)


### PR DESCRIPTION
## 概要

ビルドスクリプトの不具合修正と開発環境設定の改善。

## 変更内容

### `scripts/_lib/build.py` — vcpkg baseline 同期が機能していなかった問題の修正

`utils.run_command` は戻り値の2要素目に **stderr** を返す実装のため、`git rev-parse HEAD` の SHA (stdout) を取得できず、`_sync_vcpkg_to_baseline` が常に早期 return していた。`subprocess.run` で stdout を直接取得するよう修正し、`vcpkg.json` の builtin-baseline と project-local vcpkg の HEAD 不一致時に checkout が実行されるようにした。

### `scripts/pdg.py` — `clean` コマンドの Windows ファイルロック耐性

実行中の VelocityDB / dev プロセスがログファイルや WebView2 キャッシュ、frontend キャッシュを掴んでいると `PermissionError` / `OSError` でコマンド全体が中断していた。対象ファイルを `[SKIP]` 表示してスキップし、残りの削除を続行するよう変更。

### `.vscode/settings.json`

- Pylance の解析対象から `node_modules` / `__pycache__` / キャッシュディレクトリ等を除外
- CMake preset のデフォルト指定を削除し `CMakePresets.json` 側に一本化

## テスト

- `ruff check scripts/` / `ruff format --check scripts/` 通過
- `uv run scripts/pdg.py --help` で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)