### PR TITLE
feat(tree): スキーマツリーの仮想化 (1万ノード展開 24.4s → 21.7ms)

### DIFF
--- a/docs/perf/e2e-benchmark.json
+++ b/docs/perf/e2e-benchmark.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "generatedAt": "2026-07-23T04:40:37.942Z",
-    "gitCommit": "d594ad7",
+    "generatedAt": "2026-07-24T02:48:26.848Z",
+    "gitCommit": "unknown",
     "playwrightVersion": "1.58.2",
     "environment": "docker",
     "note": "Vite dev server + mocked window.invoke (page.addInitScript) による frontend レンダリングのみのリグレッション基準値。production WebView2 / 実 DB の実測値ではない。"
@@ -33,6 +33,16 @@
       "scenario": "result-grid",
       "metric": "result-grid-1k",
       "durationMs": 201.1
+    },
+    {
+      "scenario": "tree-10k",
+      "metric": "tree-expand-columns-50",
+      "durationMs": 161.7
+    },
+    {
+      "scenario": "tree-10k",
+      "metric": "tree-expand-tables-5000",
+      "durationMs": 21.7
     }
   ]
 }

--- a/frontend/e2e/perf-tree-10k.spec.ts
+++ b/frontend/e2e/perf-tree-10k.spec.ts
@@ -1,0 +1,177 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { recordBenchResults } from './helpers/benchRecorder';
+
+/**
+ * #502 スキーマツリー 1万ノード規模の展開操作ベンチマーク
+ *
+ * mocked window.invoke (page.addInitScript) で 5,000 テーブル + 5,000 ビュー (計 10,000
+ * table/view ノード + カラム) のスキーマを返し、以下の 2 つの展開操作の応答時間を
+ * `tree-expand` measure (frontend/src/utils/perfMarks.ts) から取得する:
+ *
+ * 1. tree-expand-tables-5000: "Tables (5000)" フォルダ展開 (クリック → 5,000 行 commit 完了)。
+ *    展開後ツリーの初回レンダリングに相当する。
+ * 2. tree-expand-columns-50: 5,000 行表示中に先頭テーブルを展開 (カラム 50 件の遅延ロード込み)。
+ *
+ * 実行方法: CLAUDE.md「E2Eテスト (Playwright)」参照。
+ * 結果は docs/perf/e2e-benchmark.json (scenario: tree-10k) に記録する。
+ */
+
+const TABLE_COUNT = 5000;
+const VIEW_COUNT = 5000;
+const COLUMN_COUNT = 50;
+
+/**
+ * IPC mock: フィクスチャは JSON 埋め込みではなくページ内で生成する
+ * (10,000 件を addInitScript の文字列に埋め込むと ~700KB になるため)。
+ */
+const MOCK_INVOKE_SCRIPT = `
+  const TABLE_COUNT = ${TABLE_COUNT};
+  const VIEW_COUNT = ${VIEW_COUNT};
+  const COLUMN_COUNT = ${COLUMN_COUNT};
+  const pad4 = (n) => String(n).padStart(4, '0');
+  window.invoke = async (requestStr) => {
+    let method = '';
+    try { method = JSON.parse(requestStr).method; } catch (_e) {}
+    if (method === 'loadSession') {
+      return JSON.stringify({
+        success: true,
+        data: { queries: [], activeQueryId: null, connectionProfiles: [], window: {} },
+      });
+    }
+    if (method === 'getConnectionProfiles') {
+      return JSON.stringify({
+        success: true,
+        data: {
+          profiles: [
+            {
+              id: 'prof-tree-10k',
+              name: 'PerfTree',
+              server: 'localhost',
+              port: 1433,
+              database: 'bench',
+              username: 'sa',
+              useWindowsAuth: true,
+              savePassword: false,
+              isProduction: false,
+              isReadOnly: false,
+              environment: 'development',
+              dbType: 'sqlserver',
+              folderPath: '',
+            },
+          ],
+        },
+      });
+    }
+    if (method === 'connectAsync') {
+      return JSON.stringify({ success: true, data: { requestId: 'req-tree-10k' } });
+    }
+    if (method === 'getConnectResult') {
+      return JSON.stringify({
+        success: true,
+        data: { status: 'connected', connectionId: 'conn-tree-10k' },
+      });
+    }
+    if (method === 'getDatabases') {
+      return JSON.stringify({ success: true, data: ['bench'] });
+    }
+    if (method === 'getTables') {
+      const tables = [];
+      for (let i = 0; i < TABLE_COUNT; i++) {
+        tables.push({ schema: 'dbo', name: 'table_' + pad4(i), type: 'TABLE', comment: '' });
+      }
+      for (let i = 0; i < VIEW_COUNT; i++) {
+        tables.push({ schema: 'dbo', name: 'view_' + pad4(i), type: 'VIEW', comment: '' });
+      }
+      return JSON.stringify({ success: true, data: tables });
+    }
+    if (method === 'getColumns') {
+      const columns = [];
+      for (let i = 0; i < COLUMN_COUNT; i++) {
+        columns.push({
+          name: 'col_' + i,
+          type: 'int',
+          size: 4,
+          nullable: i !== 0,
+          isPrimaryKey: i === 0,
+        });
+      }
+      return JSON.stringify({ success: true, data: columns });
+    }
+    return JSON.stringify({ success: true, data: {} });
+  };
+`;
+
+/** tree-expand measure が index 件以上記録されるまで待ち、指定 index の duration を返す */
+async function waitForTreeExpandMeasure(page: Page, index: number): Promise<number | null> {
+  await page.waitForFunction(
+    (minCount) => performance.getEntriesByName('tree-expand', 'measure').length >= minCount,
+    index + 1,
+    { timeout: 300_000 }
+  );
+  return page.evaluate((i) => {
+    const entry = performance.getEntriesByName('tree-expand', 'measure')[i];
+    return entry ? Number(entry.duration.toFixed(2)) : null;
+  }, index);
+}
+
+test.describe('#502 tree 10k-node expand benchmark', () => {
+  test('should_record_tree_expand_durations_when_10k_node_schema_loaded', async ({ page }) => {
+    // 仮想化前のベースライン計測では 5,000 行の再帰レンダリングに数分かかるため長めに取る
+    test.setTimeout(600_000);
+    await page.addInitScript(MOCK_INVOKE_SCRIPT);
+    await page.goto('/');
+
+    await page.waitForFunction(
+      () => performance.getEntriesByName('startup', 'measure').length > 0,
+      { timeout: 15_000 }
+    );
+
+    // プロファイルをクリック → 接続確認ダイアログ → 接続
+    await page.locator('[data-testid="profile-node"]').click();
+    await page.getByRole('dialog').getByRole('button', { name: '接続', exact: true }).click();
+
+    // 接続完了後、DB ノードが自動展開され Tables/Views フォルダが表示される
+    const tablesFolder = page.getByText(`Tables (${TABLE_COUNT})`);
+    await expect(tablesFolder).toBeVisible({ timeout: 15_000 });
+
+    // --- 計測 1: Tables フォルダ展開 (5,000 行の commit 完了まで) ---
+    await tablesFolder.click();
+    const expandTablesMs = await waitForTreeExpandMeasure(page, 0);
+    await expect(page.getByText('table_0000')).toBeVisible();
+
+    // 仮想化の効果確認用に、マウント済み treeitem 行数を stdout へ残す (assertion はしない)
+    const mountedRowCount = await page.locator('[role="treeitem"]').count();
+
+    // --- 計測 2: 5,000 行表示中に先頭テーブルを展開 (カラム 50 件の遅延ロード込み) ---
+    await page
+      .locator('[role="treeitem"]')
+      .filter({ hasText: 'table_0000' })
+      .getByRole('button')
+      .click();
+    const expandColumnsMs = await waitForTreeExpandMeasure(page, 1);
+    await expect(page.getByText('col_0 (int, PK, NOT NULL)')).toBeVisible();
+
+    console.log(
+      `[#502 tree-10k] tables-5000=${expandTablesMs}ms columns-50=${expandColumnsMs}ms ` +
+        `mountedRows=${mountedRowCount}`
+    );
+
+    // assertion より前に docs/perf/e2e-benchmark.json へ記録 (fail しても実測値を残す)
+    recordBenchResults([
+      { scenario: 'tree-10k', metric: 'tree-expand-tables-5000', durationMs: expandTablesMs },
+      { scenario: 'tree-10k', metric: 'tree-expand-columns-50', durationMs: expandColumnsMs },
+    ]);
+    test.info().annotations.push({
+      type: 'perf-baseline',
+      description:
+        `tree-expand-tables-5000=${expandTablesMs}ms ` +
+        `tree-expand-columns-50=${expandColumnsMs}ms mountedRows=${mountedRowCount}`,
+    });
+
+    expect(expandTablesMs).not.toBeNull();
+    expect(expandTablesMs).toBeGreaterThan(0.1);
+    expect(expandColumnsMs).not.toBeNull();
+    expect(expandColumnsMs).toBeGreaterThan(0.1);
+  });
+});

--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -8,7 +8,7 @@ import { useConnectionStore } from '../../store/connectionStore';
 import { useToastStore } from '../../store/toastStore';
 import type { Connection, DatabaseObject } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
-import { flattenVisibleTree } from '../../utils/flattenVisibleTree';
+import { type FlattenedTreeRow, flattenVisibleTree } from '../../utils/flattenVisibleTree';
 import { log } from '../../utils/logger';
 import { markTreeExpandStart, useTreeExpandMeasure } from '../../utils/perfMarks';
 import {
@@ -20,7 +20,8 @@ import {
 import { ContextMenu } from './ContextMenu';
 import styles from './ObjectTree.module.css';
 import { TreeDialogs } from './TreeDialogs';
-import { TreeNode } from './TreeNode';
+import { TreeNodeRow } from './TreeNode';
+import { VirtualTreeList } from './VirtualTreeList';
 
 interface ConnectionTreeSectionProps {
   connection: Connection;
@@ -341,27 +342,42 @@ export function ConnectionTreeSection({
     [connection.server, connection.database]
   );
 
+  // #502: 可視範囲の行のみ DOM 化する (environment クラスは database ノードのみに適用されるため
+  // 全行へ渡しても従来のルートノード限定の挙動と等価)
+  const renderRow = useCallback(
+    ({ node, level }: FlattenedTreeRow) => (
+      <TreeNodeRow
+        node={node}
+        level={level}
+        expandedNodes={expandedNodes}
+        loadingNodes={loadingNodes}
+        selectedNodeId={selectedNodeId}
+        connectionColor={connColor}
+        environment={connection.environment}
+        onToggle={toggleNode}
+        onTableOpen={handleTableOpen}
+        onContextMenu={handleContextMenu}
+      />
+    ),
+    [
+      expandedNodes,
+      loadingNodes,
+      selectedNodeId,
+      connColor,
+      connection.environment,
+      toggleNode,
+      handleTableOpen,
+      handleContextMenu,
+    ]
+  );
+
   if (treeData.length === 0) {
     return <div className={styles.loading}>Loading...</div>;
   }
 
   return (
     <div>
-      {filteredData.map((node) => (
-        <TreeNode
-          key={node.id}
-          node={node}
-          level={0}
-          expandedNodes={expandedNodes}
-          loadingNodes={loadingNodes}
-          selectedNodeId={selectedNodeId}
-          connectionColor={connColor}
-          environment={connection.environment}
-          onToggle={toggleNode}
-          onTableOpen={handleTableOpen}
-          onContextMenu={handleContextMenu}
-        />
-      ))}
+      <VirtualTreeList rows={flatRows} renderRow={renderRow} />
       {contextMenu && (
         <ContextMenu
           x={contextMenu.x}

--- a/frontend/src/components/tree/ConnectionTreeSection.tsx
+++ b/frontend/src/components/tree/ConnectionTreeSection.tsx
@@ -8,7 +8,9 @@ import { useConnectionStore } from '../../store/connectionStore';
 import { useToastStore } from '../../store/toastStore';
 import type { Connection, DatabaseObject } from '../../types';
 import { connectionColor } from '../../utils/colorContrast';
+import { flattenVisibleTree } from '../../utils/flattenVisibleTree';
 import { log } from '../../utils/logger';
+import { markTreeExpandStart, useTreeExpandMeasure } from '../../utils/perfMarks';
 import {
   type ExpandableType,
   parseTableNodeId,
@@ -208,6 +210,11 @@ export function ConnectionTreeSection({
     async (id: string, node: DatabaseObject) => {
       const isExpanding = !expandedNodes.has(id);
 
+      // #502: 展開操作の応答時間計測 (可視行数が変化した commit 後に useTreeExpandMeasure が測定)
+      if (isExpanding) {
+        markTreeExpandStart();
+      }
+
       setExpandedNodes((prev) => {
         const next = new Set(prev);
         if (next.has(id)) {
@@ -282,7 +289,15 @@ export function ConnectionTreeSection({
     [filter]
   );
 
-  const filteredData = filterTree(treeData);
+  const filteredData = useMemo(() => filterTree(treeData), [filterTree, treeData]);
+
+  // #502: 展開中ノードのみをフラットな行リストへ変換 (仮想化レンダリングと計測の共通入力)
+  const flatRows = useMemo(
+    () => flattenVisibleTree(filteredData, expandedNodes),
+    [filteredData, expandedNodes]
+  );
+
+  useTreeExpandMeasure(flatRows.length);
 
   const handleTableOpen = useCallback(
     (nodeId: string, tableName: string, tableType: ExpandableType) => {

--- a/frontend/src/components/tree/TreeNode.tsx
+++ b/frontend/src/components/tree/TreeNode.tsx
@@ -63,7 +63,12 @@ const getIconClass = (type: DatabaseObject['type'] | 'folder'): string => {
   }
 };
 
-export const TreeNode = memo(function TreeNode({
+/**
+ * ツリー 1 行分の UI (展開矢印 + アイコン + 名前 + コメント)。
+ * #502: VirtualTreeList のフラットな行レンダリングから直接使えるよう、
+ * 再帰部分 (TreeNode) から分離した。
+ */
+export const TreeNodeRow = memo(function TreeNodeRow({
   node,
   level,
   expandedNodes,
@@ -124,40 +129,76 @@ export const TreeNode = memo(function TreeNode({
   );
 
   return (
-    <div className={styles.container}>
-      <div
-        className={nodeClasses}
-        style={nodeStyle}
-        onClick={handleClick}
-        onContextMenu={handleContextMenu}
-        onKeyDown={handleKeyDown}
-        role="treeitem"
-        aria-expanded={canExpand ? isExpanded : undefined}
-        aria-selected={isSelected}
-        tabIndex={0}
+    <div
+      className={nodeClasses}
+      style={nodeStyle}
+      onClick={handleClick}
+      onContextMenu={handleContextMenu}
+      onKeyDown={handleKeyDown}
+      role="treeitem"
+      aria-expanded={canExpand ? isExpanded : undefined}
+      aria-selected={isSelected}
+      tabIndex={0}
+    >
+      <button
+        type="button"
+        className={styles.expander}
+        onClick={handleExpanderClick}
+        tabIndex={-1}
+        aria-label={isExpanded ? 'Collapse' : 'Expand'}
+        style={canExpand ? EXPANDER_VISIBLE : EXPANDER_HIDDEN}
       >
-        <button
-          type="button"
-          className={styles.expander}
-          onClick={handleExpanderClick}
-          tabIndex={-1}
-          aria-label={isExpanded ? 'Collapse' : 'Expand'}
-          style={canExpand ? EXPANDER_VISIBLE : EXPANDER_HIDDEN}
-        >
-          {isLoading ? (
-            <TreeIcons.Loading className={styles.loadingSpinner} />
-          ) : isExpanded ? (
-            <TreeIcons.ChevronDown />
-          ) : (
-            <TreeIcons.ChevronRight />
-          )}
-        </button>
-        <span className={`${styles.icon} ${getIconClass(node.type)}`}>
-          {getIcon(node.type, isExpanded)}
-        </span>
-        <span className={nameClasses}>{node.name}</span>
-        {node.metadata?.comment && <span className={styles.comment}>{node.metadata.comment}</span>}
-      </div>
+        {isLoading ? (
+          <TreeIcons.Loading className={styles.loadingSpinner} />
+        ) : isExpanded ? (
+          <TreeIcons.ChevronDown />
+        ) : (
+          <TreeIcons.ChevronRight />
+        )}
+      </button>
+      <span className={`${styles.icon} ${getIconClass(node.type)}`}>
+        {getIcon(node.type, isExpanded)}
+      </span>
+      <span className={nameClasses}>{node.name}</span>
+      {node.metadata?.comment && <span className={styles.comment}>{node.metadata.comment}</span>}
+    </div>
+  );
+});
+
+/**
+ * 再帰レンダリング版ツリーノード。
+ * ConnectionTreeSection は #502 で VirtualTreeList + TreeNodeRow のフラット描画に移行済み。
+ * 少数ノードを DOM ネスト構造のまま表示したい場合のために従来 API を維持している。
+ */
+export const TreeNode = memo(function TreeNode({
+  node,
+  level,
+  expandedNodes,
+  loadingNodes,
+  selectedNodeId,
+  connectionColor: connColor,
+  environment,
+  onToggle,
+  onTableOpen,
+  onContextMenu,
+}: TreeNodeProps) {
+  const hasChildren = node.children && node.children.length > 0;
+  const isExpanded = expandedNodes.has(node.id);
+
+  return (
+    <div className={styles.container}>
+      <TreeNodeRow
+        node={node}
+        level={level}
+        expandedNodes={expandedNodes}
+        loadingNodes={loadingNodes}
+        selectedNodeId={selectedNodeId}
+        connectionColor={connColor}
+        environment={environment}
+        onToggle={onToggle}
+        onTableOpen={onTableOpen}
+        onContextMenu={onContextMenu}
+      />
 
       {hasChildren && isExpanded && (
         <div className={styles.children}>

--- a/frontend/src/components/tree/VirtualTreeList.module.css
+++ b/frontend/src/components/tree/VirtualTreeList.module.css
@@ -1,0 +1,10 @@
+.list {
+  position: relative;
+  user-select: none;
+}
+
+.row {
+  position: absolute;
+  left: 0;
+  right: 0;
+}

--- a/frontend/src/components/tree/VirtualTreeList.tsx
+++ b/frontend/src/components/tree/VirtualTreeList.tsx
@@ -1,0 +1,139 @@
+import { type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { computeWindowRange, type WindowRange } from '../../utils/computeWindowRange';
+import type { FlattenedTreeRow } from '../../utils/flattenVisibleTree';
+import styles from './VirtualTreeList.module.css';
+
+/**
+ * TreeNode 1 行分の高さ (px)。TreeNode.module.css の .node
+ * (padding 5px×2 + アイコン 18px = 28px) + 上下 margin 1px×2 に一致させる。
+ */
+export const TREE_ROW_HEIGHT = 30;
+
+const DEFAULT_OVERSCAN = 10;
+
+/** スクロール親もウィンドウ高さも取得できない場合のビューポート高さの見積もり (px) */
+const FALLBACK_VIEWPORT_HEIGHT = 800;
+
+interface VirtualTreeListProps {
+  rows: FlattenedTreeRow[];
+  renderRow: (row: FlattenedTreeRow) => ReactNode;
+  rowHeight?: number;
+  overscan?: number;
+}
+
+/** 最も近い縦スクロール可能な祖先要素を返す (なければ null = window スクロール扱い) */
+function findScrollParent(el: HTMLElement): HTMLElement | null {
+  let current = el.parentElement;
+  while (current) {
+    const { overflowY } = getComputedStyle(current);
+    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
+ * スキーマツリー用の手作りウィンドウイングリスト (#502)。
+ *
+ * 全行の合計高さを持つスペーサー div の中に、可視範囲 (+overscan) の行だけを
+ * absolute 配置で描画する。スクロールコンテナは自身ではなく最も近いスクロール可能な
+ * 祖先 (ObjectTree のコンテナ) なので、祖先の scroll イベントを rAF スロットルで購読し、
+ * 自身との相対位置から描画範囲を再計算する。
+ * スクロール親が見つからないレイアウト (テストや将来のレイアウト変更) でも、
+ * window スクロール + ビューポート高さの見積もりで先頭から描画されるため表示は壊れない。
+ */
+export function VirtualTreeList({
+  rows,
+  renderRow,
+  rowHeight = TREE_ROW_HEIGHT,
+  overscan = DEFAULT_OVERSCAN,
+}: VirtualTreeListProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const scrollParentRef = useRef<HTMLElement | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+  const [range, setRange] = useState<WindowRange>(() =>
+    computeWindowRange(0, FALLBACK_VIEWPORT_HEIGHT, rowHeight, rows.length, overscan)
+  );
+
+  const rowCount = rows.length;
+
+  const syncRange = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scrollParent = scrollParentRef.current;
+    const containerTop = container.getBoundingClientRect().top;
+    let scrollTop: number;
+    let viewportHeight: number;
+    if (scrollParent) {
+      scrollTop = scrollParent.getBoundingClientRect().top - containerTop;
+      viewportHeight = scrollParent.clientHeight || FALLBACK_VIEWPORT_HEIGHT;
+    } else {
+      scrollTop = -containerTop;
+      viewportHeight = window.innerHeight || FALLBACK_VIEWPORT_HEIGHT;
+    }
+
+    const next = computeWindowRange(scrollTop, viewportHeight, rowHeight, rowCount, overscan);
+    setRange((prev) => (prev.start === next.start && prev.end === next.end ? prev : next));
+  }, [rowHeight, rowCount, overscan]);
+
+  const scheduleSync = useCallback(() => {
+    if (rafIdRef.current !== null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      syncRange();
+    });
+  }, [syncRange]);
+
+  // スクロール親の特定とイベント購読 (mount 時)、および行数変化時の範囲再計算
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    scrollParentRef.current = findScrollParent(container);
+    const target: HTMLElement | Window = scrollParentRef.current ?? window;
+    target.addEventListener('scroll', scheduleSync, { passive: true });
+    window.addEventListener('resize', scheduleSync);
+    syncRange();
+
+    return () => {
+      target.removeEventListener('scroll', scheduleSync);
+      window.removeEventListener('resize', scheduleSync);
+    };
+  }, [scheduleSync, syncRange]);
+
+  // unmount 時に保留中の rAF を破棄
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
+  }, []);
+
+  const start = Math.min(range.start, rowCount);
+  const end = Math.min(range.end, rowCount);
+  const visibleRows = rows.slice(start, end);
+
+  return (
+    <div
+      ref={containerRef}
+      className={styles.list}
+      style={{ height: rowCount * rowHeight }}
+      role="tree"
+    >
+      {visibleRows.map((row, i) => (
+        <div
+          key={row.node.id}
+          className={styles.row}
+          style={{ top: (start + i) * rowHeight, height: rowHeight }}
+        >
+          {renderRow(row)}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/tests/tree/VirtualTreeList.test.tsx
+++ b/frontend/src/tests/tree/VirtualTreeList.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TREE_ROW_HEIGHT, VirtualTreeList } from '../../components/tree/VirtualTreeList';
+import type { FlattenedTreeRow } from '../../utils/flattenVisibleTree';
+
+const buildRows = (count: number): FlattenedTreeRow[] =>
+  Array.from({ length: count }, (_, i) => ({
+    node: { id: `n${i}`, name: `row-${i}`, type: 'table' as const },
+    level: 0,
+  }));
+
+const renderRow = (row: FlattenedTreeRow) => <span>{row.node.name}</span>;
+
+describe('VirtualTreeList', () => {
+  it('先頭付近の行のみを描画し、範囲外の行は DOM に存在しない', () => {
+    render(<VirtualTreeList rows={buildRows(1000)} renderRow={renderRow} />);
+
+    expect(screen.getByText('row-0')).toBeInTheDocument();
+    // jsdom ではスクロール親が見つからず window フォールバック (viewport ~768px) になるため
+    // 描画されるのは先頭 40 行前後。500 行目は描画されない
+    expect(screen.queryByText('row-500')).not.toBeInTheDocument();
+    expect(screen.queryByText('row-999')).not.toBeInTheDocument();
+  });
+
+  it('スペーサーの高さは全行数 × 行高になる', () => {
+    render(<VirtualTreeList rows={buildRows(1000)} renderRow={renderRow} />);
+    const list = screen.getByRole('tree');
+    expect(list.style.height).toBe(`${1000 * TREE_ROW_HEIGHT}px`);
+  });
+
+  it('行数がビューポートより少なければ全行を描画する', () => {
+    render(<VirtualTreeList rows={buildRows(5)} renderRow={renderRow} />);
+    for (let i = 0; i < 5; i++) {
+      expect(screen.getByText(`row-${i}`)).toBeInTheDocument();
+    }
+  });
+
+  it('行は index × 行高の位置に absolute 配置される', () => {
+    render(<VirtualTreeList rows={buildRows(3)} renderRow={renderRow} />);
+    const secondRow = screen.getByText('row-1').parentElement;
+    expect(secondRow).not.toBeNull();
+    expect(secondRow?.style.top).toBe(`${TREE_ROW_HEIGHT}px`);
+    expect(secondRow?.style.height).toBe(`${TREE_ROW_HEIGHT}px`);
+  });
+
+  it('空の行リストでも描画が壊れない', () => {
+    render(<VirtualTreeList rows={[]} renderRow={renderRow} />);
+    const list = screen.getByRole('tree');
+    expect(list.style.height).toBe('0px');
+    expect(list.childElementCount).toBe(0);
+  });
+});

--- a/frontend/src/tests/utils/computeWindowRange.test.ts
+++ b/frontend/src/tests/utils/computeWindowRange.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { computeWindowRange } from '../../utils/computeWindowRange';
+
+describe('computeWindowRange', () => {
+  it('行数 0 なら空範囲を返す', () => {
+    expect(computeWindowRange(0, 600, 30, 0, 10)).toEqual({ start: 0, end: 0 });
+  });
+
+  it('rowHeight が 0 以下なら空範囲を返す (0 除算防止)', () => {
+    expect(computeWindowRange(0, 600, 0, 100, 10)).toEqual({ start: 0, end: 0 });
+    expect(computeWindowRange(0, 600, -5, 100, 10)).toEqual({ start: 0, end: 0 });
+  });
+
+  it('スクロール位置 0 では先頭行から可視行数 + overscan を返す', () => {
+    // viewport 300 / rowHeight 30 = 10 行 + 部分表示 1 行 + overscan 5
+    expect(computeWindowRange(0, 300, 30, 1000, 5)).toEqual({ start: 0, end: 16 });
+  });
+
+  it('スクロール中間では前後 overscan を含む範囲を返す', () => {
+    // scrollTop 900 → 先頭可視行 30。start = 30-5, end = 30+11+5
+    expect(computeWindowRange(900, 300, 30, 1000, 5)).toEqual({ start: 25, end: 46 });
+  });
+
+  it('行境界の途中のスクロール位置は切り捨てて先頭可視行を決める', () => {
+    expect(computeWindowRange(929, 300, 30, 1000, 0)).toEqual({ start: 30, end: 41 });
+  });
+
+  it('負の scrollTop (オーバースクロール) は 0 として扱う', () => {
+    expect(computeWindowRange(-120, 300, 30, 1000, 5)).toEqual({ start: 0, end: 16 });
+  });
+
+  it('末尾付近では end を行数でクランプする', () => {
+    expect(computeWindowRange(29_700, 300, 30, 1000, 5)).toEqual({ start: 985, end: 1000 });
+  });
+
+  it('コンテンツ末尾を超える scrollTop でも start <= end の有効範囲を返す', () => {
+    const range = computeWindowRange(999_999, 300, 30, 1000, 5);
+    expect(range.start).toBeLessThanOrEqual(range.end);
+    expect(range.end).toBe(1000);
+    expect(range.start).toBe(994); // 最終行 999 - overscan 5
+  });
+
+  it('viewport 高さ 0 でも最低 1 行は描画対象に含める', () => {
+    expect(computeWindowRange(0, 0, 30, 1000, 0)).toEqual({ start: 0, end: 1 });
+  });
+
+  it('行数が viewport より少なければ全行を返す', () => {
+    expect(computeWindowRange(0, 600, 30, 3, 10)).toEqual({ start: 0, end: 3 });
+  });
+
+  it('負の overscan は 0 として扱う', () => {
+    expect(computeWindowRange(900, 300, 30, 1000, -5)).toEqual({ start: 30, end: 41 });
+  });
+});

--- a/frontend/src/tests/utils/flattenVisibleTree.test.ts
+++ b/frontend/src/tests/utils/flattenVisibleTree.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { DatabaseObject } from '../../types';
+import { flattenVisibleTree } from '../../utils/flattenVisibleTree';
+
+const node = (
+  id: string,
+  type: DatabaseObject['type'],
+  children?: DatabaseObject[]
+): DatabaseObject => ({ id, name: id, type, children });
+
+const TREE: DatabaseObject[] = [
+  node('db1', 'database', [
+    node('db1-tables', 'folder', [
+      node('t1', 'table', [node('t1-c1', 'column'), node('t1-c2', 'column')]),
+      node('t2', 'table', []),
+    ]),
+    node('db1-views', 'folder', [node('v1', 'view', [])]),
+  ]),
+];
+
+describe('flattenVisibleTree', () => {
+  it('何も展開されていなければルートノードのみを level 0 で返す', () => {
+    const rows = flattenVisibleTree(TREE, new Set());
+    expect(rows.map((r) => r.node.id)).toEqual(['db1']);
+    expect(rows[0].level).toBe(0);
+  });
+
+  it('展開されたノードの子を DFS 順で挿入し level を +1 する', () => {
+    const rows = flattenVisibleTree(TREE, new Set(['db1', 'db1-tables']));
+    expect(rows.map((r) => r.node.id)).toEqual(['db1', 'db1-tables', 't1', 't2', 'db1-views']);
+    expect(rows.map((r) => r.level)).toEqual([0, 1, 2, 2, 1]);
+  });
+
+  it('折りたたまれた祖先の配下は子孫が展開集合に含まれていても現れない', () => {
+    // db1 は折りたたみ状態 → db1-tables/t1 が展開扱いでも行は増えない
+    const rows = flattenVisibleTree(TREE, new Set(['db1-tables', 't1']));
+    expect(rows.map((r) => r.node.id)).toEqual(['db1']);
+  });
+
+  it('children が空のノードは展開中でも子行を持たない (未ロードテーブル)', () => {
+    const rows = flattenVisibleTree(TREE, new Set(['db1', 'db1-tables', 't2']));
+    expect(rows.map((r) => r.node.id)).toEqual(['db1', 'db1-tables', 't1', 't2', 'db1-views']);
+  });
+
+  it('全展開時は全ノードを DFS 順で返し level が深さと一致する', () => {
+    const rows = flattenVisibleTree(TREE, new Set(['db1', 'db1-tables', 'db1-views', 't1', 'v1']));
+    expect(rows.map((r) => r.node.id)).toEqual([
+      'db1',
+      'db1-tables',
+      't1',
+      't1-c1',
+      't1-c2',
+      't2',
+      'db1-views',
+      'v1',
+    ]);
+    expect(rows.map((r) => r.level)).toEqual([0, 1, 2, 3, 3, 2, 1, 2]);
+  });
+
+  it('空ツリーは空配列を返す', () => {
+    expect(flattenVisibleTree([], new Set(['x']))).toEqual([]);
+  });
+
+  it('複数ルート (複数 DB ノード) を順序どおり並べる', () => {
+    const forest = [node('a', 'database', [node('a-1', 'folder')]), node('b', 'database')];
+    const rows = flattenVisibleTree(forest, new Set(['a']));
+    expect(rows.map((r) => r.node.id)).toEqual(['a', 'a-1', 'b']);
+  });
+});

--- a/frontend/src/utils/computeWindowRange.ts
+++ b/frontend/src/utils/computeWindowRange.ts
@@ -1,0 +1,36 @@
+/** 仮想化リストの描画対象インデックス範囲 (end は exclusive) */
+export interface WindowRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * スクロール位置から描画すべき行インデックス範囲を計算する純関数 (#502)。
+ *
+ * @param scrollTop リスト先頭からのスクロールオフセット (px)。負値 (オーバースクロール) は 0 扱い
+ * @param viewportHeight 可視領域の高さ (px)。0 以下でも最低 1 行は描画する
+ * @param rowHeight 1 行の高さ (px)。0 以下は不正入力として空範囲を返す
+ * @param totalCount 全行数
+ * @param overscan 可視範囲の前後に余分に描画する行数
+ */
+export function computeWindowRange(
+  scrollTop: number,
+  viewportHeight: number,
+  rowHeight: number,
+  totalCount: number,
+  overscan: number
+): WindowRange {
+  if (totalCount <= 0 || rowHeight <= 0) {
+    return { start: 0, end: 0 };
+  }
+
+  const safeScrollTop = Math.max(0, scrollTop);
+  const safeOverscan = Math.max(0, overscan);
+  const firstVisible = Math.min(Math.floor(safeScrollTop / rowHeight), totalCount - 1);
+  // +1: 行境界をまたいで部分表示される行の分
+  const visibleCount = Math.max(1, Math.ceil(Math.max(0, viewportHeight) / rowHeight) + 1);
+
+  const start = Math.max(0, firstVisible - safeOverscan);
+  const end = Math.min(totalCount, firstVisible + visibleCount + safeOverscan);
+  return { start, end };
+}

--- a/frontend/src/utils/flattenVisibleTree.ts
+++ b/frontend/src/utils/flattenVisibleTree.ts
@@ -1,0 +1,34 @@
+import type { DatabaseObject } from '../types';
+
+/** スキーマツリーの可視 1 行分 (ノード + インデントレベル) */
+export interface FlattenedTreeRow {
+  node: DatabaseObject;
+  level: number;
+}
+
+/**
+ * 展開中のノードだけを深さ優先で辿り、可視ノードをフラットな行リストに変換する (#502)。
+ *
+ * TreeNode の再帰レンダリングと同じ規則に従う:
+ * 子行が現れるのは「children が 1 件以上あり、かつ展開中」のノードのみ。
+ * 未ロード (children が空) のテーブルは展開中でも子行を持たない。
+ * 折りたたまれたノードの配下は、子孫が expandedIds に含まれていても現れない。
+ */
+export function flattenVisibleTree(
+  nodes: DatabaseObject[],
+  expandedIds: ReadonlySet<string>
+): FlattenedTreeRow[] {
+  const rows: FlattenedTreeRow[] = [];
+
+  const visit = (list: DatabaseObject[], level: number): void => {
+    for (const node of list) {
+      rows.push({ node, level });
+      if (node.children && node.children.length > 0 && expandedIds.has(node.id)) {
+        visit(node.children, level + 1);
+      }
+    }
+  };
+
+  visit(nodes, 0);
+  return rows;
+}

--- a/frontend/src/utils/perfMarks.ts
+++ b/frontend/src/utils/perfMarks.ts
@@ -34,6 +34,46 @@ export function useStartupMark(): void {
   useFirstRenderMark('startup');
 }
 
+const TREE_EXPAND_MEASURE = 'tree-expand';
+
+let treeExpandPending = false;
+
+/**
+ * スキーマツリーの展開操作の開始時刻を記録する (#502)。
+ * ConnectionTreeSection.toggleNode の展開分岐から呼ぶ。
+ */
+export function markTreeExpandStart(): void {
+  treeExpandPending = true;
+  performance.mark(`${TREE_EXPAND_MEASURE}:start`);
+}
+
+/**
+ * 展開操作で可視行数が変化した commit の直後に `tree-expand` measure を記録する (#502)。
+ * visibleRowCount には flattenVisibleTree の結果行数を渡す。行数が変化しない再レンダリング
+ * (選択変更など) では effect が発火しないため、直前の markTreeExpandStart とだけ対になる。
+ * 展開のたびに measure entry が追加されるので、計測側は entry の index で識別する。
+ */
+export function useTreeExpandMeasure(visibleRowCount: number): void {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: visibleRowCount の変化自体を commit 検知トリガーとして使う (effect 本体では参照しない)
+  useEffect(() => {
+    if (!treeExpandPending) return;
+    treeExpandPending = false;
+
+    const hasStart =
+      performance.getEntriesByName(`${TREE_EXPAND_MEASURE}:start`, 'mark').length > 0;
+    if (!hasStart) return;
+
+    performance.mark(`${TREE_EXPAND_MEASURE}:end`);
+    performance.measure(
+      TREE_EXPAND_MEASURE,
+      `${TREE_EXPAND_MEASURE}:start`,
+      `${TREE_EXPAND_MEASURE}:end`
+    );
+    performance.clearMarks(`${TREE_EXPAND_MEASURE}:start`);
+    performance.clearMarks(`${TREE_EXPAND_MEASURE}:end`);
+  }, [visibleRowCount]);
+}
+
 /**
  * ER 図のテーブル数が閾値を満たした最初のレンダリングを measure として記録する。
  * 閾値未達のレンダリングでは mark を打たず、達成した時点で start、その直後の effect で end と measure を記録する。


### PR DESCRIPTION
## 概要

スキーマツリーを手作りウィンドウイングで仮想化し、大量ノード時の展開応答を改善する (#502)。

## 変更内容

- **`utils/computeWindowRange.ts`**: スクロール位置 → 描画すべき行範囲を計算する純関数 (境界・不正入力・overscan 対応)
- **`components/tree/VirtualTreeList.tsx`**: flattenVisibleTree のフラット行リストを入力に、可視範囲 + overscan の行だけを absolute 配置で描画。最近傍スクロール祖先の scroll イベントを rAF スロットルで購読し、スクロール親が無いレイアウトでは window スクロールへフォールバック
- **`TreeNode.tsx`**: 行 UI (`TreeNodeRow`) と再帰構造 (`TreeNode`) に分離。ConnectionTreeSection はフラット描画に移行
- 計測基盤 (perfMarks / flattenVisibleTree / e2e perf-tree-10k.spec.ts) は前段コミットで導入済み

## ベンチマーク (5,000 テーブル + 5,000 ビュー、Docker Playwright)

| 操作 | 仮想化前 | 仮想化後 |
| --- | --- | --- |
| Tables (5000) フォルダ展開 | 24,369.8ms | **21.7ms** |
| カラム 50 件の遅延ロード展開 | 22,278.2ms | **161.7ms** |

可視 DOM 行数 31 行 (overscan 込み)。完了条件「1万ノード規模で展開操作の応答時間ベースライン比 50% 改善」を達成。

## テスト

- VirtualTreeList / computeWindowRange の新規ユニットテスト含む全 1292+ テスト通過 (pre-push フック)
- typecheck / biome / clang-format 通過

Fixes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)