### PR TITLE
perf(ipc): スキーマ系レスポンスのタプル化でペイロード 59% 削減

### DIFF
--- a/backend/providers/schema_provider.cpp
+++ b/backend/providers/schema_provider.cpp
@@ -38,6 +38,16 @@ namespace {
     return result;
 }
 
+/// #514: カラム定義 1 件を [name, type, size, nullable, isPrimaryKey, comment] の
+/// タプルとして出力する。オブジェクト形式のキー重複を排除したワイヤ形式で、
+/// frontend 側は api/providers/schema.ts が ColumnInfo へ復元する。
+void appendColumnTuple(std::string& out, std::string_view name, std::string_view type, std::string_view sizeStr, std::string_view nullableFlag, std::string_view pkFlag, std::string_view comment) {
+    int colSize = 0;
+    std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), colSize);
+    out += std::format(R"(["{}","{}",{},{},{},"{}"])", JsonUtils::escapeString(name), JsonUtils::escapeString(type), colSize, nullableFlag == "1" ? "true" : "false", pkFlag == "1" ? "true" : "false",
+                       JsonUtils::escapeString(comment));
+}
+
 struct TableQueryParams {
     std::string schema;
     std::string table;
@@ -169,10 +179,11 @@ std::string SchemaProvider::getTables(std::string_view params) {
         auto dialect = DriverFactory::createSchemaQueryable(driverType);
         auto sql = dialect->getTablesQuery();
         auto queryResult = driver->execute(sql);
+        // #514: [schema, name, type, comment] のタプル配列 (キー重複を排除したワイヤ形式)
         return JsonUtils::buildRowArray(queryResult.rows, 3, [](std::string& out, const ResultRow& row) {
             auto comment = row.values.size() >= 4 ? row.values[3] : std::string{};
-            out += std::format(R"({{"schema":"{}","name":"{}","type":"{}","comment":"{}"}})", JsonUtils::escapeString(row.values[0]), JsonUtils::escapeString(row.values[1]),
-                               JsonUtils::escapeString(row.values[2]), JsonUtils::escapeString(comment));
+            out += std::format(R"(["{}","{}","{}","{}"])", JsonUtils::escapeString(row.values[0]), JsonUtils::escapeString(row.values[1]), JsonUtils::escapeString(row.values[2]),
+                               JsonUtils::escapeString(comment));
         });
     });
 }
@@ -192,15 +203,9 @@ std::string SchemaProvider::getColumns(std::string_view params) {
         auto sql = dialect->getColumnsQuery(schema, tbl);
         auto columnResult = driver->execute(sql);
 
+        // #514: [name, type, size, nullable, isPrimaryKey, comment] のタプル配列
         return JsonUtils::buildRowArray(columnResult.rows, 5, [](std::string& out, const ResultRow& row) {
-            std::string_view sizeStr = row.values[2];
-            int colSize = 0;
-            std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), colSize);
-            auto comment = row.values.size() >= 6 ? row.values[5] : std::string{};
-            auto nullable = row.values[3] == "1" ? "true" : "false";
-            auto isPk = row.values[4] == "1" ? "true" : "false";
-            out += std::format(R"({{"name":"{}","type":"{}","size":{},"nullable":{},"isPrimaryKey":{},"comment":"{}"}})", JsonUtils::escapeString(row.values[0]),
-                               JsonUtils::escapeString(row.values[1]), colSize, nullable, isPk, JsonUtils::escapeString(comment));
+            appendColumnTuple(out, row.values[0], row.values[1], row.values[2], row.values[3], row.values[4], row.values.size() >= 6 ? std::string_view{row.values[5]} : std::string_view{});
         });
     });
 }
@@ -220,7 +225,8 @@ std::string SchemaProvider::getAllColumns(std::string_view params) {
         auto dialect = DriverFactory::createSchemaQueryable(driverType);
         auto queryResult = driver->execute(dialect->getAllColumnsQuery());
 
-        // (schema, table) でソート済みの行を走査し、テーブル毎の配列にグルーピングする
+        // (schema, table) でソート済みの行を走査し、テーブル毎の配列にグルーピングする。
+        // #514: [schema, table, [カラムタプル...]] のタプル配列 (キー重複を排除したワイヤ形式)
         std::string json = "[";
         std::string_view currentSchema;
         std::string_view currentTable;
@@ -233,10 +239,8 @@ std::string SchemaProvider::getAllColumns(std::string_view params) {
             auto table = row.values[1];
             if (firstTable || schema != currentSchema || table != currentTable) {
                 if (!firstTable)
-                    json += "]}";
-                if (!firstTable)
-                    json += ",";
-                json += std::format(R"({{"schema":"{}","table":"{}","columns":[)", JsonUtils::escapeString(schema), JsonUtils::escapeString(table));
+                    json += "]],";
+                json += std::format(R"(["{}","{}",[)", JsonUtils::escapeString(schema), JsonUtils::escapeString(table));
                 currentSchema = schema;
                 currentTable = table;
                 firstTable = false;
@@ -245,17 +249,10 @@ std::string SchemaProvider::getAllColumns(std::string_view params) {
             if (!firstColumn)
                 json += ",";
             firstColumn = false;
-            std::string_view sizeStr = row.values[4];
-            int colSize = 0;
-            std::from_chars(sizeStr.data(), sizeStr.data() + sizeStr.size(), colSize);
-            auto comment = row.values.size() >= 8 ? row.values[7] : std::string_view{};
-            auto nullable = row.values[5] == "1" ? "true" : "false";
-            auto isPk = row.values[6] == "1" ? "true" : "false";
-            json += std::format(R"({{"name":"{}","type":"{}","size":{},"nullable":{},"isPrimaryKey":{},"comment":"{}"}})", JsonUtils::escapeString(row.values[2]),
-                                JsonUtils::escapeString(row.values[3]), colSize, nullable, isPk, JsonUtils::escapeString(comment));
+            appendColumnTuple(json, row.values[2], row.values[3], row.values[4], row.values[5], row.values[6], row.values.size() >= 8 ? std::string_view{row.values[7]} : std::string_view{});
         }
         if (!firstTable)
-            json += "]}";
+            json += "]]";
         json += "]";
         return json;
     });

--- a/frontend/e2e/grid-column-width.spec.ts
+++ b/frontend/e2e/grid-column-width.spec.ts
@@ -33,11 +33,12 @@ function makeMockInvoke(): string {
       },
       getDatabases: ['testdb'],
       getSchemas: ['dbo'],
-      getTables: [{ schema: 'dbo', name: 'TestTable', type: 'TABLE' }],
+      // #514 ワイヤ形式: getTables=[schema,name,type,comment], getColumns=[name,type,size,nullable,isPK,comment]
+      getTables: [['dbo', 'TestTable', 'TABLE', '']],
       getColumns: [
-        { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
-        { name: 'name', type: 'nvarchar', size: 255, nullable: true, isPrimaryKey: false },
-        { name: 'created_at', type: 'datetime', size: 8, nullable: true, isPrimaryKey: false },
+        ['id', 'int', 4, false, true, ''],
+        ['name', 'nvarchar', 255, true, false, ''],
+        ['created_at', 'datetime', 8, true, false, ''],
       ],
       getSettings: {},
       writeFrontendLog: {},

--- a/frontend/src/api/mockData.ts
+++ b/frontend/src/api/mockData.ts
@@ -57,42 +57,27 @@ export const mockData: Record<string, unknown> = {
     simdAvailable: true,
   },
   getDatabases: ['master', 'tempdb', 'model', 'msdb'],
+  // #514 ワイヤ形式: getTables=[schema,name,type,comment], getColumns=[name,type,size,nullable,isPK,comment]
   getTables: [
-    { schema: 'dbo', name: 'Users', type: 'TABLE' },
-    { schema: 'dbo', name: 'Orders', type: 'TABLE' },
-    { schema: 'dbo', name: 'Products', type: 'TABLE' },
+    ['dbo', 'Users', 'TABLE', ''],
+    ['dbo', 'Orders', 'TABLE', ''],
+    ['dbo', 'Products', 'TABLE', ''],
   ],
   getColumns: [
-    { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
-    {
-      name: 'name',
-      type: 'nvarchar',
-      size: 255,
-      nullable: false,
-      isPrimaryKey: false,
-    },
-    {
-      name: 'created_at',
-      type: 'datetime',
-      size: 8,
-      nullable: true,
-      isPrimaryKey: false,
-    },
+    ['id', 'int', 4, false, true, ''],
+    ['name', 'nvarchar', 255, false, false, ''],
+    ['created_at', 'datetime', 8, true, false, ''],
   ],
   getAllColumns: [
-    {
-      schema: 'dbo',
-      table: 'Users',
-      columns: [
-        { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
-        { name: 'name', type: 'nvarchar', size: 255, nullable: false, isPrimaryKey: false },
+    [
+      'dbo',
+      'Users',
+      [
+        ['id', 'int', 4, false, true, ''],
+        ['name', 'nvarchar', 255, false, false, ''],
       ],
-    },
-    {
-      schema: 'dbo',
-      table: 'Orders',
-      columns: [{ name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true }],
-    },
+    ],
+    ['dbo', 'Orders', [['id', 'int', 4, false, true, '']]],
   ],
   getQueryHistory: [],
   parseERDiagram: { name: '', databaseType: '', tables: [], relations: [], shapes: [], ddl: '' },

--- a/frontend/src/api/providers/schema.ts
+++ b/frontend/src/api/providers/schema.ts
@@ -118,6 +118,22 @@ export interface TableColumns {
   columns: ColumnInfo[];
 }
 
+/** #514 ワイヤ形式のカラムタプル [name, type, size, nullable, isPrimaryKey, comment] */
+type ColumnTuple = [string, string, number, boolean, boolean, string];
+
+function decodeColumnTuple([
+  name,
+  type,
+  size,
+  nullable,
+  isPrimaryKey,
+  comment,
+]: ColumnTuple): ColumnInfo {
+  return comment === ''
+    ? { name, type, size, nullable, isPrimaryKey }
+    : { name, type, size, nullable, isPrimaryKey, comment };
+}
+
 export interface SchemaProvider {
   getDatabases(connectionId: string): Promise<string[]>;
   getTables(connectionId: string, database: string): Promise<GetTablesResult>;
@@ -159,18 +175,28 @@ class SchemaProviderImpl extends BaseProvider implements SchemaProvider {
       `[Bridge] Getting tables for connection: ${connectionId}, database: ${database}`
     );
     const startTime = performance.now();
-    const tables = await this.invokeAndParse('getTables', { connectionId, database }, S.getTables);
+    const rows = await this.invokeAndParse('getTables', { connectionId, database }, S.getTables);
+    const tables = rows.map(
+      ([schema, name, type, comment]): TableInfo =>
+        comment === '' ? { schema, name, type } : { schema, name, type, comment }
+    );
     const loadTimeMs = performance.now() - startTime;
     this.logger.info(`[Bridge] Received ${tables.length} tables in ${loadTimeMs.toFixed(2)}ms`);
     return { tables, loadTimeMs };
   }
 
   async getColumns(connectionId: string, table: string): Promise<ColumnInfo[]> {
-    return this.invokeAndParse('getColumns', { connectionId, table }, S.getColumns);
+    const rows = await this.invokeAndParse('getColumns', { connectionId, table }, S.getColumns);
+    return rows.map(decodeColumnTuple);
   }
 
   async getAllColumns(connectionId: string): Promise<TableColumns[]> {
-    return this.invokeAndParse('getAllColumns', { connectionId }, S.getAllColumns);
+    const rows = await this.invokeAndParse('getAllColumns', { connectionId }, S.getAllColumns);
+    return rows.map(([schema, table, columns]) => ({
+      schema,
+      table,
+      columns: columns.map(decodeColumnTuple),
+    }));
   }
 
   async getIndexes(connectionId: string, table: string): Promise<IndexInfo[]> {

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -56,31 +56,16 @@ export const cancelQuery = zVoidResponse;
 
 // --- Schema ---
 export const getDatabases = z.array(z.string());
-export const getTables = z.array(
-  z.object({
-    schema: z.string(),
-    name: z.string(),
-    type: z.string(),
-    comment: z.string().optional(),
-  })
-);
+// #514: schema 系の大容量レスポンスはキー重複を排除したタプルのワイヤ形式。
+// api/providers/schema.ts が TableInfo / ColumnInfo オブジェクトへ復元する。
+/** [schema, name, type, comment] */
+export const getTables = z.array(z.tuple([z.string(), z.string(), z.string(), z.string()]));
+/** [name, type, size, nullable, isPrimaryKey, comment] */
 export const getColumns = z.array(
-  z.object({
-    name: z.string(),
-    type: z.string(),
-    size: z.number(),
-    nullable: z.boolean(),
-    isPrimaryKey: z.boolean(),
-    comment: z.string().optional(),
-  })
+  z.tuple([z.string(), z.string(), z.number(), z.boolean(), z.boolean(), z.string()])
 );
-export const getAllColumns = z.array(
-  z.object({
-    schema: z.string(),
-    table: z.string(),
-    columns: getColumns,
-  })
-);
+/** [schema, table, カラムタプル配列] */
+export const getAllColumns = z.array(z.tuple([z.string(), z.string(), getColumns]));
 
 // --- Transaction ---
 export const beginTransaction = zVoidResponse;

--- a/frontend/src/tests/api/schemaProvider.test.ts
+++ b/frontend/src/tests/api/schemaProvider.test.ts
@@ -33,16 +33,17 @@ describe('schemaProvider', () => {
     await expect(schemaProvider.getDatabases('conn-1')).rejects.toThrow();
   });
 
-  it('getTables は loadTimeMs を含む結果を返し log.info を 2 回出す', async () => {
+  it('getTables はタプル応答をオブジェクトへ復元し loadTimeMs を含む結果を返す (#514)', async () => {
     mock.setResponse('getTables', [
-      { schema: 'public', name: 't1', type: 'TABLE' },
-      { schema: 'public', name: 't2', type: 'VIEW', comment: 'c' },
+      ['public', 't1', 'TABLE', ''],
+      ['public', 't2', 'VIEW', 'c'],
     ]);
 
     const result = await schemaProvider.getTables('conn-1', 'db1');
 
     expect(result.tables).toHaveLength(2);
-    expect(result.tables[0]).toMatchObject({ schema: 'public', name: 't1', type: 'TABLE' });
+    expect(result.tables[0]).toEqual({ schema: 'public', name: 't1', type: 'TABLE' });
+    expect(result.tables[1]).toEqual({ schema: 'public', name: 't2', type: 'VIEW', comment: 'c' });
     expect(typeof result.loadTimeMs).toBe('number');
     expect(result.loadTimeMs).toBeGreaterThanOrEqual(0);
     expect(mock.calls[0]).toEqual({
@@ -51,10 +52,14 @@ describe('schemaProvider', () => {
     });
   });
 
-  it('getColumns は connectionId と table を渡す', async () => {
-    mock.setResponse('getColumns', [
-      { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
-    ]);
+  it('getTables は旧オブジェクト形式の応答に対して throw する (#514 ワイヤ形式検証)', async () => {
+    mock.setResponse('getTables', [{ schema: 'public', name: 't1', type: 'TABLE' }]);
+
+    await expect(schemaProvider.getTables('conn-1', 'db1')).rejects.toThrow();
+  });
+
+  it('getColumns はタプル応答を ColumnInfo へ復元する (#514)', async () => {
+    mock.setResponse('getColumns', [['id', 'int', 4, false, true, '']]);
 
     const result = await schemaProvider.getColumns('conn-1', 'users');
 
@@ -64,20 +69,24 @@ describe('schemaProvider', () => {
     expect(mock.calls[0]?.params).toEqual({ connectionId: 'conn-1', table: 'users' });
   });
 
-  it('getAllColumns は connectionId を渡しテーブル毎の列配列を返す (#512)', async () => {
-    mock.setResponse('getAllColumns', [
-      {
-        schema: 'dbo',
-        table: 'users',
-        columns: [{ name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true }],
-      },
-    ]);
+  it('getColumns は comment 付きタプルの comment を保持する (#514)', async () => {
+    mock.setResponse('getColumns', [['id', 'int', 4, false, true, '主キー']]);
+
+    const result = await schemaProvider.getColumns('conn-1', 'users');
+
+    expect(result[0]?.comment).toBe('主キー');
+  });
+
+  it('getAllColumns は connectionId を渡しテーブル毎の列配列を返す (#512, #514)', async () => {
+    mock.setResponse('getAllColumns', [['dbo', 'users', [['id', 'int', 4, false, true, '']]]]);
 
     const result = await schemaProvider.getAllColumns('conn-1');
 
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({ schema: 'dbo', table: 'users' });
-    expect(result[0].columns).toHaveLength(1);
+    expect(result[0].columns).toEqual([
+      { name: 'id', type: 'int', size: 4, nullable: false, isPrimaryKey: true },
+    ]);
     expect(mock.calls[0]).toEqual({ method: 'getAllColumns', params: { connectionId: 'conn-1' } });
   });
 

--- a/tests/providers/test_schema_provider.cpp
+++ b/tests/providers/test_schema_provider.cpp
@@ -142,7 +142,7 @@ TEST_F(SchemaProviderCacheTest, ErrorResponseIsNotCached) {
 
 // --- getAllColumns (#512) ---
 
-// (schema, table) ソート済み行がテーブル毎にグルーピングされる
+// (schema, table) ソート済み行がテーブル毎にグルーピングされ、#514 のタプル形式で出力される
 TEST_F(SchemaProviderCacheTest, GetAllColumnsGroupsRowsByTable) {
     resolveDriverByDefault();
     // 行レイアウト: schema, table, column, type, size, nullable, isPk, comment
@@ -156,11 +156,85 @@ TEST_F(SchemaProviderCacheTest, GetAllColumnsGroupsRowsByTable) {
     SchemaProvider provider(connections);
     const auto json = provider.getAllColumns(R"({"connectionId":"db_1"})");
 
-    EXPECT_NE(json.find(R"("schema":"dbo","table":"orders")"), std::string::npos);
-    EXPECT_NE(json.find(R"("schema":"dbo","table":"users")"), std::string::npos);
-    EXPECT_NE(json.find(R"("name":"user_id","type":"int","size":4,"nullable":true,"isPrimaryKey":false,"comment":"FK")"), std::string::npos);
+    EXPECT_NE(json.find(R"(["dbo","orders",[)"), std::string::npos);
+    EXPECT_NE(json.find(R"(["dbo","users",[)"), std::string::npos);
+    EXPECT_NE(json.find(R"(["user_id","int",4,true,false,"FK"])"), std::string::npos);
     // orders グループが users より先 (ソート順保持)
-    EXPECT_LT(json.find(R"("table":"orders")"), json.find(R"("table":"users")"));
+    EXPECT_LT(json.find(R"("orders")"), json.find(R"("users")"));
+}
+
+// --- ワイヤ形式のタプル化 (#514) ---
+
+// getTables は [schema, name, type, comment] のタプル配列を返す
+TEST_F(SchemaProviderCacheTest, GetTablesReturnsTupleRows) {
+    resolveDriverByDefault();
+    auto rows = makeResultSet({
+        {"dbo", "Users", "TABLE", ""},
+        {"dbo", "ActiveUsers", "VIEW", "抽出ビュー"},
+    });
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(rows));
+
+    SchemaProvider provider(connections);
+    const auto json = provider.getTables(R"({"connectionId":"db_1"})");
+
+    EXPECT_NE(json.find(R"(["dbo","Users","TABLE",""])"), std::string::npos);
+    EXPECT_NE(json.find(R"(["dbo","ActiveUsers","VIEW","抽出ビュー"])"), std::string::npos);
+    EXPECT_EQ(json.find(R"("schema":)"), std::string::npos);
+}
+
+// getColumns は [name, type, size, nullable, isPrimaryKey, comment] のタプル配列を返す
+TEST_F(SchemaProviderCacheTest, GetColumnsReturnsTupleRows) {
+    resolveDriverByDefault();
+    // 行レイアウト: name, type, size, nullable, isPk, comment
+    auto rows = makeResultSet({
+        {"id", "int", "4", "0", "1", ""},
+        {"name", "nvarchar", "255", "1", "0", "表示名"},
+    });
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(rows));
+
+    SchemaProvider provider(connections);
+    const auto json = provider.getColumns(R"({"connectionId":"db_1","table":"Users"})");
+
+    EXPECT_NE(json.find(R"(["id","int",4,false,true,""])"), std::string::npos);
+    EXPECT_NE(json.find(R"(["name","nvarchar",255,true,false,"表示名"])"), std::string::npos);
+    EXPECT_EQ(json.find(R"("isPrimaryKey":)"), std::string::npos);
+}
+
+// タプル形式は旧オブジェクト形式 (キーを全行で重複) と比べ 30% 以上小さい (#514 完了条件)
+TEST_F(SchemaProviderCacheTest, TupleFormatReducesPayloadOverLegacyByThirtyPercent) {
+    resolveDriverByDefault();
+    // 現実的なカラム名/型で 40 テーブル x 25 カラムを生成
+    std::vector<std::vector<std::string>> cells;
+    for (int t = 0; t < 40; ++t) {
+        for (int c = 0; c < 25; ++c) {
+            cells.push_back({"dbo", std::format("table_{:02}", t), std::format("column_{:02}", c), c % 2 == 0 ? "int" : "nvarchar", c % 2 == 0 ? "4" : "255",
+                             c % 3 == 0 ? "0" : "1", c == 0 ? "1" : "0", ""});
+        }
+    }
+    auto rows = makeResultSet(cells);
+    EXPECT_CALL(*driver, execute(::testing::_)).Times(1).WillOnce(::testing::Return(rows));
+
+    SchemaProvider provider(connections);
+    const auto json = provider.getAllColumns(R"({"connectionId":"db_1"})");
+
+    // 旧形式 ({"schema":..,"table":..,"columns":[{"name":..,...},...]}) を同一データから構築
+    std::string legacy = "[";
+    for (int t = 0; t < 40; ++t) {
+        if (t > 0)
+            legacy += ",";
+        legacy += std::format(R"({{"schema":"dbo","table":"table_{:02}","columns":[)", t);
+        for (int c = 0; c < 25; ++c) {
+            if (c > 0)
+                legacy += ",";
+            legacy += std::format(R"({{"name":"column_{:02}","type":"{}","size":{},"nullable":{},"isPrimaryKey":{},"comment":""}})", c, c % 2 == 0 ? "int" : "nvarchar",
+                                  c % 2 == 0 ? 4 : 255, c % 3 == 0 ? "false" : "true", c == 0 ? "true" : "false");
+        }
+        legacy += "]}";
+    }
+    legacy += "]";
+
+    EXPECT_LT(static_cast<double>(json.size()), static_cast<double>(legacy.size()) * 0.7)
+        << "tuple=" << json.size() << " bytes, legacy=" << legacy.size() << " bytes";
 }
 
 // 2 回目はキャッシュ命中し driver->execute は 1 回


### PR DESCRIPTION
## 概要

Frontend ↔ Backend 間のスキーマ系 JSON ペイロードを削減する (#514)。

## 変更内容

`getTables` / `getColumns` / `getAllColumns` はオブジェクト配列でキー名を全行に重複させていた。キーを排除したタプル配列のワイヤ形式に変更:

| メソッド | 旧形式 (1 要素あたり) | 新形式 |
| --- | --- | --- |
| getTables | `{"schema":..,"name":..,"type":..,"comment":..}` | `[schema, name, type, comment]` |
| getColumns | `{"name":..,"type":..,"size":..,"nullable":..,"isPrimaryKey":..,"comment":..}` | `[name, type, size, nullable, isPrimaryKey, comment]` |
| getAllColumns | `{"schema":..,"table":..,"columns":[{...}]}` | `[schema, table, [カラムタプル...]]` |

- **Frontend への影響なし**: `api/providers/schema.ts` の境界で従来の `TableInfo` / `ColumnInfo` オブジェクトへ復元するため、store / UI は無変更。zod スキーマがワイヤ形式を検証。
- クエリ結果 (`rows`) は既にタプル形式のため対象外。

## 削減効果

代表ペイロード (40 テーブル × 25 カラムの getAllColumns): **98,601B → 40,521B (58.9% 削減)** — 完了条件の 30% を大幅達成。gtest `TupleFormatReducesPayloadOverLegacyByThirtyPercent` で旧形式比 30% 以上の削減を恒常的に保証。

## テスト

- C++: 418 テスト全パス (新形式の検証テスト追加)
- Frontend: 全テスト通過 (pre-push フック)、schemaProvider テストをワイヤ形式に更新
- e2e モック (grid-column-width.spec.ts) も新形式に更新

## マージ順の注意

PR #651 (Tree 仮想化) が先にマージされた場合、この PR に main を取り込む際 `e2e/perf-tree-10k.spec.ts` の getTables/getColumns モックをタプル形式へ更新する必要があります (このブランチで対応します)。

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)
