### PR TITLE
feat(schema): DDL ファイルをスキーマ比較のデータソースに対応

### DIFF
--- a/frontend/src/components/dialogs/SchemaCompareDialog.module.css
+++ b/frontend/src/components/dialogs/SchemaCompareDialog.module.css
@@ -117,6 +117,23 @@
   margin-bottom: 12px;
 }
 
+.fileInput {
+  width: 100%;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.fileInfo {
+  color: var(--text-secondary);
+  font-size: 12px;
+  word-break: break-all;
+}
+
+.fileError {
+  color: var(--error-color, #f75464);
+  font-size: 12px;
+}
+
 /* Compare row */
 .compareRow {
   display: flex;

--- a/frontend/src/components/dialogs/SchemaCompareDialog.tsx
+++ b/frontend/src/components/dialogs/SchemaCompareDialog.tsx
@@ -3,6 +3,7 @@ import { ioProvider, schemaProvider } from '../../api/providers';
 import { useDialogKeyboard } from '../../hooks/useDialogKeyboard';
 import { useConnections } from '../../store/connectionStore';
 import type { Connection } from '../../types';
+import { normalizeTablesForDdlComparison, parseDdl } from '../../utils/ddlParser';
 import {
   generateMigrationDdl,
   type MigrationDialect,
@@ -30,6 +31,18 @@ interface CompareResult {
   targetLabel: string;
   generatedAt: string;
 }
+
+/** 比較ソースの種別: 接続中の DB か、DDL ファイル (.sql) か */
+type SourceKind = 'connection' | 'ddl';
+
+/** DDL ファイルソースの読み込み状態 */
+interface DdlSource {
+  fileName: string;
+  tables: SchemaTable[];
+  error: string | null;
+}
+
+const EMPTY_DDL_SOURCE: DdlSource = { fileName: '', tables: [], error: null };
 
 /** getColumns 同時実行数の上限 (バックエンド ODBC 接続への負荷を抑制) */
 const COLUMN_FETCH_CONCURRENCY = 4;
@@ -71,6 +84,26 @@ async function fetchSchemaTables(
   return results;
 }
 
+/** FileReader でテキストファイルを読み込む (backend IPC 不要) */
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(reader.error ?? new Error('ファイルの読み込みに失敗しました'));
+    reader.readAsText(file);
+  });
+}
+
+function isSourceReady(
+  kind: SourceKind,
+  connectionId: string,
+  database: string,
+  ddl: DdlSource
+): boolean {
+  if (kind === 'connection') return connectionId !== '' && database !== '';
+  return ddl.error === null && ddl.tables.length > 0;
+}
+
 function describeColumnChange(change: ColumnChange): string {
   const parts: string[] = [];
   if (change.changes.includes('type') || change.changes.includes('size')) {
@@ -89,11 +122,15 @@ interface SourcePickerProps {
   title: string;
   idPrefix: string;
   connections: Connection[];
+  sourceKind: SourceKind;
+  onSourceKindChange: (kind: SourceKind) => void;
   connectionId: string;
   database: string;
   databases: string[];
   onConnectionChange: (connectionId: string) => void;
   onDatabaseChange: (database: string) => void;
+  ddl: DdlSource;
+  onDdlFileSelect: (file: File) => void;
   disabled: boolean;
 }
 
@@ -101,53 +138,102 @@ function SourcePicker({
   title,
   idPrefix,
   connections,
+  sourceKind,
+  onSourceKindChange,
   connectionId,
   database,
   databases,
   onConnectionChange,
   onDatabaseChange,
+  ddl,
+  onDdlFileSelect,
   disabled,
 }: SourcePickerProps) {
   return (
     <div className={styles.sourcePicker}>
       <h3>{title}</h3>
       <div className={styles.formGroup}>
-        <label className={styles.label} htmlFor={`${idPrefix}-connection`}>
-          接続
+        <label className={styles.label} htmlFor={`${idPrefix}-source-kind`}>
+          ソース種別
         </label>
         <select
-          id={`${idPrefix}-connection`}
+          id={`${idPrefix}-source-kind`}
           className={styles.select}
-          value={connectionId}
-          onChange={(e) => onConnectionChange(e.target.value)}
+          value={sourceKind}
+          onChange={(e) => onSourceKindChange(e.target.value as SourceKind)}
           disabled={disabled}
         >
-          <option value="">選択してください</option>
-          {connections.map((conn) => (
-            <option key={conn.id} value={conn.id}>
-              {conn.name} ({conn.server})
-            </option>
-          ))}
+          <option value="connection">接続/データベース</option>
+          <option value="ddl">DDL ファイル (.sql)</option>
         </select>
       </div>
-      <div className={styles.formGroup}>
-        <label className={styles.label} htmlFor={`${idPrefix}-database`}>
-          データベース
-        </label>
-        <select
-          id={`${idPrefix}-database`}
-          className={styles.select}
-          value={database}
-          onChange={(e) => onDatabaseChange(e.target.value)}
-          disabled={disabled || connectionId === ''}
-        >
-          {databases.map((db) => (
-            <option key={db} value={db}>
-              {db}
-            </option>
-          ))}
-        </select>
-      </div>
+      {sourceKind === 'connection' ? (
+        <>
+          <div className={styles.formGroup}>
+            <label className={styles.label} htmlFor={`${idPrefix}-connection`}>
+              接続
+            </label>
+            <select
+              id={`${idPrefix}-connection`}
+              className={styles.select}
+              value={connectionId}
+              onChange={(e) => onConnectionChange(e.target.value)}
+              disabled={disabled}
+            >
+              <option value="">選択してください</option>
+              {connections.map((conn) => (
+                <option key={conn.id} value={conn.id}>
+                  {conn.name} ({conn.server})
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className={styles.formGroup}>
+            <label className={styles.label} htmlFor={`${idPrefix}-database`}>
+              データベース
+            </label>
+            <select
+              id={`${idPrefix}-database`}
+              className={styles.select}
+              value={database}
+              onChange={(e) => onDatabaseChange(e.target.value)}
+              disabled={disabled || connectionId === ''}
+            >
+              {databases.map((db) => (
+                <option key={db} value={db}>
+                  {db}
+                </option>
+              ))}
+            </select>
+          </div>
+        </>
+      ) : (
+        <div className={styles.formGroup}>
+          <label className={styles.label} htmlFor={`${idPrefix}-ddl-file`}>
+            DDL ファイル
+          </label>
+          <input
+            id={`${idPrefix}-ddl-file`}
+            type="file"
+            accept=".sql,.ddl,.txt"
+            className={styles.fileInput}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) onDdlFileSelect(file);
+              e.target.value = '';
+            }}
+            disabled={disabled}
+          />
+          {ddl.fileName !== '' && (
+            <div className={styles.fileInfo}>
+              {ddl.error === null
+                ? `${ddl.fileName} (${ddl.tables.length} テーブル)`
+                : ddl.fileName}
+            </div>
+          )}
+          {ddl.error !== null && <div className={styles.fileError}>{ddl.error}</div>}
+        </div>
+      )}
     </div>
   );
 }
@@ -156,12 +242,16 @@ export function SchemaCompareDialog({ isOpen, onClose }: SchemaCompareDialogProp
   useDialogKeyboard({ isOpen, onEscape: onClose });
   const connections = useConnections();
 
+  const [sourceKindA, setSourceKindA] = useState<SourceKind>('connection');
+  const [sourceKindB, setSourceKindB] = useState<SourceKind>('connection');
   const [connectionIdA, setConnectionIdA] = useState('');
   const [databaseA, setDatabaseA] = useState('');
   const [databasesA, setDatabasesA] = useState<string[]>([]);
   const [connectionIdB, setConnectionIdB] = useState('');
   const [databaseB, setDatabaseB] = useState('');
   const [databasesB, setDatabasesB] = useState<string[]>([]);
+  const [ddlA, setDdlA] = useState<DdlSource>(EMPTY_DDL_SOURCE);
+  const [ddlB, setDdlB] = useState<DdlSource>(EMPTY_DDL_SOURCE);
 
   const [dialect, setDialect] = useState<MigrationDialect>('sqlserver');
   const [isComparing, setIsComparing] = useState(false);
@@ -222,26 +312,69 @@ export function SchemaCompareDialog({ isOpen, onClose }: SchemaCompareDialogProp
     [selectConnection, connections]
   );
 
+  const loadDdlFile = useCallback(async (file: File, setDdl: (v: DdlSource) => void) => {
+    try {
+      const text = await readFileAsText(file);
+      const tables = parseDdl(text);
+      if (tables.length === 0) {
+        setDdl({
+          fileName: file.name,
+          tables: [],
+          error: 'CREATE TABLE 文を検出できませんでした',
+        });
+        return;
+      }
+      setDdl({ fileName: file.name, tables, error: null });
+    } catch (err) {
+      setDdl({
+        fileName: file.name,
+        tables: [],
+        error:
+          err instanceof Error
+            ? `DDL ファイルの読み込みに失敗しました: ${err.message}`
+            : 'DDL ファイルの読み込みに失敗しました',
+      });
+    }
+  }, []);
+
   const compare = useCallback(async () => {
     const connA = connections.find((c) => c.id === connectionIdA);
     const connB = connections.find((c) => c.id === connectionIdB);
-    if (!connA || !connB) return;
+    if (sourceKindA === 'connection' && !connA) return;
+    if (sourceKindB === 'connection' && !connB) return;
 
     setIsComparing(true);
     setError(null);
     setResult(null);
     setSaveMessage(null);
     try {
-      const fromTables = await fetchSchemaTables(connA.id, databaseA, (done, total) => {
-        setProgressText(`移行元スキーマ取得中... (${done}/${total})`);
-      });
-      const toTables = await fetchSchemaTables(connB.id, databaseB, (done, total) => {
-        setProgressText(`移行先スキーマ取得中... (${done}/${total})`);
-      });
+      const fromTables =
+        sourceKindA === 'connection' && connA
+          ? await fetchSchemaTables(connA.id, databaseA, (done, total) => {
+              setProgressText(`移行元スキーマ取得中... (${done}/${total})`);
+            })
+          : ddlA.tables;
+      const toTables =
+        sourceKindB === 'connection' && connB
+          ? await fetchSchemaTables(connB.id, databaseB, (done, total) => {
+              setProgressText(`移行先スキーマ取得中... (${done}/${total})`);
+            })
+          : ddlB.tables;
+      // DDL ソースを含む比較では、取得元 (ODBC / DDL) 間で意味の揃わない属性を正規化する
+      const useDdlNormalization = sourceKindA === 'ddl' || sourceKindB === 'ddl';
       setResult({
-        diff: diffSchemas(fromTables, toTables),
-        sourceLabel: `${connA.name}/${databaseA}`,
-        targetLabel: `${connB.name}/${databaseB}`,
+        diff: diffSchemas(
+          useDdlNormalization ? normalizeTablesForDdlComparison(fromTables) : fromTables,
+          useDdlNormalization ? normalizeTablesForDdlComparison(toTables) : toTables
+        ),
+        sourceLabel:
+          sourceKindA === 'connection' && connA
+            ? `${connA.name}/${databaseA}`
+            : `DDL: ${ddlA.fileName}`,
+        targetLabel:
+          sourceKindB === 'connection' && connB
+            ? `${connB.name}/${databaseB}`
+            : `DDL: ${ddlB.fileName}`,
         generatedAt: new Date().toISOString(),
       });
     } catch (err) {
@@ -250,7 +383,17 @@ export function SchemaCompareDialog({ isOpen, onClose }: SchemaCompareDialogProp
       setIsComparing(false);
       setProgressText('');
     }
-  }, [connections, connectionIdA, connectionIdB, databaseA, databaseB]);
+  }, [
+    connections,
+    connectionIdA,
+    connectionIdB,
+    databaseA,
+    databaseB,
+    sourceKindA,
+    sourceKindB,
+    ddlA,
+    ddlB,
+  ]);
 
   const copyDdl = useCallback(async () => {
     try {
@@ -277,10 +420,8 @@ export function SchemaCompareDialog({ isOpen, onClose }: SchemaCompareDialogProp
 
   const canCompare =
     !isComparing &&
-    connectionIdA !== '' &&
-    connectionIdB !== '' &&
-    databaseA !== '' &&
-    databaseB !== '';
+    isSourceReady(sourceKindA, connectionIdA, databaseA, ddlA) &&
+    isSourceReady(sourceKindB, connectionIdB, databaseB, ddlB);
 
   return (
     <DialogOverlay
@@ -302,11 +443,15 @@ export function SchemaCompareDialog({ isOpen, onClose }: SchemaCompareDialogProp
             title="移行元 (A)"
             idPrefix="schema-compare-a"
             connections={connections}
+            sourceKind={sourceKindA}
+            onSourceKindChange={setSourceKindA}
             connectionId={connectionIdA}
             database={databaseA}
             databases={databasesA}
             onConnectionChange={(id) => void selectConnectionA(id)}
             onDatabaseChange={setDatabaseA}
+            ddl={ddlA}
+            onDdlFileSelect={(file) => void loadDdlFile(file, setDdlA)}
             disabled={isComparing}
           />
           <div className={styles.sourceArrow}>{'→'}</div>
@@ -314,18 +459,23 @@ export function SchemaCompareDialog({ isOpen, onClose }: SchemaCompareDialogProp
             title="移行先 (B)"
             idPrefix="schema-compare-b"
             connections={connections}
+            sourceKind={sourceKindB}
+            onSourceKindChange={setSourceKindB}
             connectionId={connectionIdB}
             database={databaseB}
             databases={databasesB}
             onConnectionChange={selectConnectionB}
             onDatabaseChange={setDatabaseB}
+            ddl={ddlB}
+            onDdlFileSelect={(file) => void loadDdlFile(file, setDdlB)}
             disabled={isComparing}
           />
         </div>
 
-        {connections.length === 0 && (
-          <div className={styles.hint}>比較するには先にデータベースへ接続してください。</div>
-        )}
+        {connections.length === 0 &&
+          (sourceKindA === 'connection' || sourceKindB === 'connection') && (
+            <div className={styles.hint}>比較するには先にデータベースへ接続してください。</div>
+          )}
 
         <div className={styles.compareRow}>
           <button

--- a/frontend/src/tests/dialogs/SchemaCompareDialog.test.tsx
+++ b/frontend/src/tests/dialogs/SchemaCompareDialog.test.tsx
@@ -219,4 +219,115 @@ describe('SchemaCompareDialog', () => {
       screen.getByText('比較するには先にデータベースへ接続してください。')
     ).toBeInTheDocument();
   });
+
+  describe('DDLソース', () => {
+    // 移行先 (B) 相当: conn-b のスキーマと同一内容の DDL
+    const DDL_TARGET = `
+      CREATE TABLE [dbo].[users] (
+        [id] int NOT NULL PRIMARY KEY,
+        [name] varchar(100) NOT NULL,
+        [email] varchar(255) NULL
+      );
+      CREATE TABLE [dbo].[orders] (
+        [id] int NOT NULL PRIMARY KEY
+      );
+    `;
+
+    function selectSourceKind(index: number, kind: 'connection' | 'ddl') {
+      const kindSelects = screen.getAllByLabelText('ソース種別');
+      fireEvent.change(kindSelects[index], { target: { value: kind } });
+    }
+
+    function chooseDdlFile(content: string, fileName: string, index = 0) {
+      const inputs = screen.getAllByLabelText('DDL ファイル');
+      const file = new File([content], fileName, { type: 'application/sql' });
+      fireEvent.change(inputs[index], { target: { files: [file] } });
+    }
+
+    it('ソース種別で DDL を選ぶと接続セレクタの代わりにファイル入力を表示する', () => {
+      render(<SchemaCompareDialog {...defaultProps} />);
+      expect(screen.getAllByLabelText('接続')).toHaveLength(2);
+      selectSourceKind(1, 'ddl');
+      expect(screen.getAllByLabelText('接続')).toHaveLength(1);
+      expect(screen.getByLabelText('DDL ファイル')).toBeInTheDocument();
+    });
+
+    it('DDL ファイル読込でファイル名とテーブル数を表示する', async () => {
+      render(<SchemaCompareDialog {...defaultProps} />);
+      selectSourceKind(0, 'ddl');
+      chooseDdlFile('CREATE TABLE a (id int); CREATE TABLE b (id int);', 'schema.sql');
+      expect(await screen.findByText('schema.sql (2 テーブル)')).toBeInTheDocument();
+    });
+
+    it('CREATE TABLE を含まないファイルはエラーを表示し比較できない', async () => {
+      render(<SchemaCompareDialog {...defaultProps} />);
+      selectSourceKind(0, 'ddl');
+      fireEvent.change(screen.getByLabelText('接続'), { target: { value: 'conn-b' } });
+      await waitFor(() => {
+        expect(schemaProvider.getDatabases).toHaveBeenCalledWith('conn-b');
+      });
+      chooseDdlFile('SELECT 1;', 'not_ddl.sql');
+      expect(await screen.findByText('CREATE TABLE 文を検出できませんでした')).toBeInTheDocument();
+      expect(screen.getByText('比較')).toBeDisabled();
+    });
+
+    it('接続 (A) と DDL ファイル (B) の比較で差分と移行DDLを生成する', async () => {
+      render(<SchemaCompareDialog {...defaultProps} />);
+      selectSourceKind(1, 'ddl');
+      fireEvent.change(screen.getByLabelText('接続'), { target: { value: 'conn-a' } });
+      chooseDdlFile(DDL_TARGET, 'target.sql');
+      await screen.findByText('target.sql (2 テーブル)');
+      await waitFor(() => {
+        expect(screen.getByText('比較')).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText('比較'));
+      await waitFor(() => {
+        expect(screen.getByText('比較結果')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('dbo.orders')).toBeInTheDocument();
+      expect(screen.getByText('dbo.legacy')).toBeInTheDocument();
+      expect(screen.getByText(/\+ email : varchar\(255\)/)).toBeInTheDocument();
+      expect(screen.getByText(/~ name : varchar\(50\) -> varchar\(100\)/)).toBeInTheDocument();
+
+      const ddl = (screen.getByLabelText('生成された移行DDL') as HTMLTextAreaElement).value;
+      expect(ddl).toContain('-- 移行元 (from): DevServer/AppDb');
+      expect(ddl).toContain('-- 移行先 (to):   DDL: target.sql');
+      expect(ddl).toContain('ALTER TABLE [dbo].[users] ADD [email] varchar(255);');
+      expect(ddl).toContain('CREATE TABLE [dbo].[orders] (');
+    });
+
+    it('DDL ファイル同士の比較は接続不要でスキーマ取得も行わない', async () => {
+      useConnectionStore.setState({ connections: [], activeConnectionId: null });
+      render(<SchemaCompareDialog {...defaultProps} />);
+      selectSourceKind(0, 'ddl');
+      selectSourceKind(1, 'ddl');
+      expect(
+        screen.queryByText('比較するには先にデータベースへ接続してください。')
+      ).not.toBeInTheDocument();
+
+      chooseDdlFile(
+        'CREATE TABLE users (id int NOT NULL PRIMARY KEY, name varchar(50));',
+        'from.sql',
+        0
+      );
+      chooseDdlFile(
+        'CREATE TABLE users (id int NOT NULL PRIMARY KEY, name varchar(100));',
+        'to.sql',
+        1
+      );
+      await screen.findByText('from.sql (1 テーブル)');
+      await screen.findByText('to.sql (1 テーブル)');
+      await waitFor(() => {
+        expect(screen.getByText('比較')).not.toBeDisabled();
+      });
+      fireEvent.click(screen.getByText('比較'));
+      await waitFor(() => {
+        expect(screen.getByText('比較結果')).toBeInTheDocument();
+      });
+
+      expect(schemaProvider.getTables).not.toHaveBeenCalled();
+      expect(screen.getByText(/~ name : varchar\(50\) -> varchar\(100\)/)).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/tests/utils/ddlParser.test.ts
+++ b/frontend/src/tests/utils/ddlParser.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from 'vitest';
+import { parseDdl } from '../../utils/ddlParser';
+
+/** 先頭テーブルの指定カラムを取得するヘルパー */
+function columnOf(sql: string, columnName: string) {
+  const tables = parseDdl(sql);
+  expect(tables.length).toBeGreaterThan(0);
+  const column = tables[0].columns.find((c) => c.name === columnName);
+  expect(column).toBeDefined();
+  if (!column) throw new Error(`column not found: ${columnName}`);
+  return column;
+}
+
+describe('parseDdl', () => {
+  describe('基本', () => {
+    it('単純な CREATE TABLE をパースする', () => {
+      const tables = parseDdl('CREATE TABLE users (id int, name varchar(50));');
+      expect(tables).toHaveLength(1);
+      expect(tables[0].name).toBe('users');
+      expect(tables[0].columns).toEqual([
+        { name: 'id', type: 'int', size: 0, nullable: true, isPrimaryKey: false },
+        { name: 'name', type: 'varchar', size: 50, nullable: true, isPrimaryKey: false },
+      ]);
+    });
+
+    it('schema プレフィックスなしは schema が空文字になる', () => {
+      const tables = parseDdl('CREATE TABLE users (id int);');
+      expect(tables[0].schema).toBe('');
+    });
+
+    it('db.schema.table の 3 階層修飾は末尾 2 要素を schema.name とする', () => {
+      const tables = parseDdl('CREATE TABLE mydb.dbo.Users (Id int);');
+      expect(tables[0].schema).toBe('dbo');
+      expect(tables[0].name).toBe('Users');
+    });
+
+    it('空入力は空配列を返す', () => {
+      expect(parseDdl('')).toEqual([]);
+    });
+
+    it('CREATE TABLE を含まない SQL は空配列を返す', () => {
+      expect(
+        parseDdl('SELECT * FROM users; UPDATE t SET x = 1; CREATE INDEX ix ON t (x);')
+      ).toEqual([]);
+    });
+
+    it('複数テーブルと GO 区切りをパースする', () => {
+      const sql = `
+        CREATE TABLE a (id int);
+        GO
+        CREATE TABLE b (id int);
+        GO
+      `;
+      const tables = parseDdl(sql);
+      expect(tables.map((t) => t.name)).toEqual(['a', 'b']);
+    });
+
+    it('同名テーブルが重複した場合は後の定義が勝つ', () => {
+      const sql = `
+        CREATE TABLE users (id int);
+        CREATE TABLE users (id int, name varchar(10));
+      `;
+      const tables = parseDdl(sql);
+      expect(tables).toHaveLength(1);
+      expect(tables[0].columns).toHaveLength(2);
+    });
+  });
+
+  describe('方言クォート', () => {
+    it('SQL Server の [dbo].[Users] をパースする', () => {
+      const sql = 'CREATE TABLE [dbo].[Users] ([Id] INT NOT NULL, [Name] NVARCHAR(100) NULL);';
+      const tables = parseDdl(sql);
+      expect(tables[0].schema).toBe('dbo');
+      expect(tables[0].name).toBe('Users');
+      expect(tables[0].columns[0]).toEqual({
+        name: 'Id',
+        type: 'int',
+        size: 0,
+        nullable: false,
+        isPrimaryKey: false,
+      });
+      expect(tables[0].columns[1]).toEqual({
+        name: 'Name',
+        type: 'nvarchar',
+        size: 100,
+        nullable: true,
+        isPrimaryKey: false,
+      });
+    });
+
+    it('PostgreSQL の "public"."users" をパースする ("" エスケープ対応)', () => {
+      const sql = 'CREATE TABLE "public"."users" ("id" integer, "say""hi" text);';
+      const tables = parseDdl(sql);
+      expect(tables[0].schema).toBe('public');
+      expect(tables[0].name).toBe('users');
+      expect(tables[0].columns.map((c) => c.name)).toEqual(['id', 'say"hi']);
+    });
+
+    it('MySQL のバッククォートと ENGINE オプションをパースする', () => {
+      const sql =
+        'CREATE TABLE `mydb`.`users` (`id` int NOT NULL) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;';
+      const tables = parseDdl(sql);
+      expect(tables[0].schema).toBe('mydb');
+      expect(tables[0].name).toBe('users');
+      expect(tables[0].columns.map((c) => c.name)).toEqual(['id']);
+    });
+
+    it('空白や ]] エスケープを含むブラケット識別子をパースする', () => {
+      const sql = 'CREATE TABLE [User Table] ([User Name] varchar(10), [a]]b] int);';
+      const tables = parseDdl(sql);
+      expect(tables[0].name).toBe('User Table');
+      expect(tables[0].columns.map((c) => c.name)).toEqual(['User Name', 'a]b']);
+    });
+  });
+
+  describe('型', () => {
+    it('varchar(50) は type と size に分離する', () => {
+      expect(columnOf('CREATE TABLE t (c varchar(50));', 'c')).toMatchObject({
+        type: 'varchar',
+        size: 50,
+      });
+    });
+
+    it('nvarchar / varbinary も size を分離する', () => {
+      const tables = parseDdl('CREATE TABLE t (a nvarchar(100), b varbinary(16));');
+      expect(tables[0].columns[0]).toMatchObject({ type: 'nvarchar', size: 100 });
+      expect(tables[0].columns[1]).toMatchObject({ type: 'varbinary', size: 16 });
+    });
+
+    it('decimal(10,2) は型名に括弧ごと保持する', () => {
+      expect(columnOf('CREATE TABLE t (c decimal(10,2));', 'c')).toMatchObject({
+        type: 'decimal(10,2)',
+        size: 0,
+      });
+    });
+
+    it('varchar(max) は型名に括弧ごと保持する', () => {
+      expect(columnOf('CREATE TABLE t (c varchar(MAX));', 'c')).toMatchObject({
+        type: 'varchar(max)',
+        size: 0,
+      });
+    });
+
+    it('character varying(50) は size を分離する', () => {
+      expect(columnOf('CREATE TABLE t (c character varying(50));', 'c')).toMatchObject({
+        type: 'character varying',
+        size: 50,
+      });
+    });
+
+    it('double precision / timestamp with time zone の複数語型をパースする', () => {
+      const tables = parseDdl('CREATE TABLE t (a double precision, b timestamp with time zone);');
+      expect(tables[0].columns[0].type).toBe('double precision');
+      expect(tables[0].columns[1].type).toBe('timestamp with time zone');
+    });
+
+    it('MySQL の整数表示幅 int(11) は無視して int に正規化する', () => {
+      expect(columnOf('CREATE TABLE t (c int(11));', 'c')).toMatchObject({ type: 'int', size: 0 });
+    });
+
+    it('int unsigned / bigint(20) unsigned をパースする', () => {
+      const tables = parseDdl('CREATE TABLE t (a int unsigned NOT NULL, b bigint(20) unsigned);');
+      expect(tables[0].columns[0]).toMatchObject({ type: 'int unsigned', nullable: false });
+      expect(tables[0].columns[1]).toMatchObject({ type: 'bigint unsigned', size: 0 });
+    });
+
+    it('型名は小文字に正規化する', () => {
+      expect(columnOf('CREATE TABLE t (c DATETIME2);', 'c').type).toBe('datetime2');
+    });
+
+    it('PostgreSQL の配列型 text[] をパースする', () => {
+      expect(columnOf('CREATE TABLE t (c text[]);', 'c').type).toBe('text[]');
+    });
+  });
+
+  describe('NULL / PRIMARY KEY', () => {
+    it('NOT NULL / NULL / 省略時のデフォルト (nullable) を判定する', () => {
+      const tables = parseDdl('CREATE TABLE t (a int NOT NULL, b int NULL, c int);');
+      expect(tables[0].columns.map((c) => c.nullable)).toEqual([false, true, true]);
+    });
+
+    it('列内 PRIMARY KEY は isPrimaryKey と nullable=false になる', () => {
+      expect(columnOf('CREATE TABLE t (id int PRIMARY KEY, x int);', 'id')).toMatchObject({
+        isPrimaryKey: true,
+        nullable: false,
+      });
+    });
+
+    it('テーブル制約 PRIMARY KEY (a, b) で複合キーを判定する', () => {
+      const tables = parseDdl('CREATE TABLE t (a int, b int, c int, PRIMARY KEY (a, b));');
+      expect(tables[0].columns.map((c) => c.isPrimaryKey)).toEqual([true, true, false]);
+      expect(tables[0].columns.map((c) => c.nullable)).toEqual([false, false, true]);
+    });
+
+    it('CONSTRAINT ... PRIMARY KEY CLUSTERED ([Id] ASC) を判定する', () => {
+      const sql = `CREATE TABLE [dbo].[T] (
+        [Id] int NOT NULL,
+        [X] int NULL,
+        CONSTRAINT [PK_T] PRIMARY KEY CLUSTERED ([Id] ASC)
+      );`;
+      const tables = parseDdl(sql);
+      expect(tables[0].columns[0]).toMatchObject({ name: 'Id', isPrimaryKey: true });
+      expect(tables[0].columns[1]).toMatchObject({ name: 'X', isPrimaryKey: false });
+    });
+
+    it('DEFAULT NULL は nullable 判定に影響しない', () => {
+      expect(columnOf('CREATE TABLE t (c datetime DEFAULT NULL);', 'c').nullable).toBe(true);
+    });
+
+    it("DEFAULT 'value' の後の NOT NULL を正しく判定する", () => {
+      expect(columnOf("CREATE TABLE t (c varchar(10) DEFAULT 'x' NOT NULL);", 'c')).toMatchObject({
+        type: 'varchar',
+        size: 10,
+        nullable: false,
+      });
+    });
+  });
+
+  describe('堅牢性', () => {
+    it('行コメント内の CREATE TABLE は無視する', () => {
+      const sql = `
+        -- CREATE TABLE commented_out (id int);
+        CREATE TABLE real_table (id int);
+      `;
+      expect(parseDdl(sql).map((t) => t.name)).toEqual(['real_table']);
+    });
+
+    it('ネストしたブロックコメント内の CREATE TABLE は無視する', () => {
+      const sql = `
+        /* outer /* nested CREATE TABLE fake (x int); */ still comment */
+        CREATE TABLE real_table (id int);
+      `;
+      expect(parseDdl(sql).map((t) => t.name)).toEqual(['real_table']);
+    });
+
+    it("文字列リテラル内の CREATE TABLE は無視する ('' エスケープ対応)", () => {
+      const sql = `
+        INSERT INTO log (msg) VALUES ('it''s a CREATE TABLE fake (x int)');
+        CREATE TABLE real_table (id int);
+      `;
+      expect(parseDdl(sql).map((t) => t.name)).toEqual(['real_table']);
+    });
+
+    it('PostgreSQL のドル引用符内の CREATE TABLE は無視する', () => {
+      const sql = `
+        CREATE FUNCTION f() RETURNS void AS $$
+          CREATE TABLE fake (x int);
+        $$ LANGUAGE sql;
+        CREATE TABLE real_table (id int);
+      `;
+      expect(parseDdl(sql).map((t) => t.name)).toEqual(['real_table']);
+    });
+
+    it('IF NOT EXISTS をスキップしてテーブル名を取得する', () => {
+      const tables = parseDdl('CREATE TABLE IF NOT EXISTS users (id int);');
+      expect(tables[0].name).toBe('users');
+    });
+
+    it('CREATE TABLE ... AS SELECT はスキップし後続のテーブルはパースする', () => {
+      const sql = `
+        CREATE TABLE backup_users AS SELECT * FROM users;
+        CREATE TABLE t2 (id int);
+      `;
+      expect(parseDdl(sql).map((t) => t.name)).toEqual(['t2']);
+    });
+
+    it('FOREIGN KEY / UNIQUE / CHECK / KEY / INDEX 行は無視する (MySQL ダンプ風)', () => {
+      const sql = `CREATE TABLE orders (
+        id int NOT NULL,
+        user_id int NOT NULL,
+        code varchar(20),
+        amount decimal(10,2) CHECK (amount >= 0),
+        PRIMARY KEY (id),
+        UNIQUE KEY uq_code (code),
+        KEY idx_user (user_id),
+        INDEX idx_amount (amount),
+        FULLTEXT KEY ft_code (code),
+        CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE,
+        CHECK (id > 0)
+      );`;
+      const tables = parseDdl(sql);
+      expect(tables[0].columns.map((c) => c.name)).toEqual(['id', 'user_id', 'code', 'amount']);
+      expect(tables[0].columns[0].isPrimaryKey).toBe(true);
+      expect(tables[0].columns[1].isPrimaryKey).toBe(false);
+    });
+
+    it('IDENTITY(1,1) / AUTO_INCREMENT / インライン REFERENCES を無視する', () => {
+      const sql = `CREATE TABLE t (
+        id int IDENTITY(1,1) NOT NULL,
+        seq bigint AUTO_INCREMENT,
+        user_id int REFERENCES users (id)
+      );`;
+      const tables = parseDdl(sql);
+      expect(tables[0].columns).toHaveLength(3);
+      expect(tables[0].columns[0]).toMatchObject({ name: 'id', type: 'int', nullable: false });
+      expect(tables[0].columns[2]).toMatchObject({ name: 'user_id', type: 'int' });
+    });
+
+    it('末尾カンマなど多少崩れた定義でも残りをパースする', () => {
+      const tables = parseDdl('CREATE TABLE t (id int, );');
+      expect(tables[0].columns.map((c) => c.name)).toEqual(['id']);
+    });
+
+    it('カラム 0 件のテーブルは結果に含めない', () => {
+      expect(parseDdl('CREATE TABLE empty_t (); CREATE TABLE t (id int);')).toHaveLength(1);
+    });
+
+    it('クォート付きの PK 制約カラム名を解決する', () => {
+      const sql = 'CREATE TABLE t ("id" int, PRIMARY KEY ("id"));';
+      const tables = parseDdl(sql);
+      expect(tables[0].columns[0]).toMatchObject({ isPrimaryKey: true, nullable: false });
+    });
+  });
+});

--- a/frontend/src/utils/ddlParser.ts
+++ b/frontend/src/utils/ddlParser.ts
@@ -1,0 +1,545 @@
+// DDL パーサ (純関数層)。
+// SQL テキスト (DDL ダンプ) から CREATE TABLE 文を抽出し、スキーマ比較 (utils/schemaDiff.ts)
+// が受け取る SchemaTable[] へ変換する。SQL を実行せずファイルだけをスキーマ情報の
+// ソースとして扱う「DDL データソース」(#261) の中核。
+//
+// 対応方言: SQL Server ([quoted]) / PostgreSQL・標準 SQL ("quoted") / MySQL (`quoted`)。
+// コメント (-- / ネスト対応 block comment)・文字列リテラル・PostgreSQL のドル引用符を
+// スキップし、FOREIGN KEY / UNIQUE / CHECK / INDEX 等の制約行と
+// CREATE TABLE ... AS SELECT は無視する。型名は小文字へ正規化する
+// (ODBC 経由の getColumns が返す型名表記に合わせるため)。
+
+import type { Column } from '../types';
+import { type SchemaTable, tableKey } from './schemaDiff';
+
+interface Token {
+  /** word: 生の単語 / number: 数値 / ident: クォート解除済み識別子 / string: 文字列 / punct: 記号 1 文字 */
+  kind: 'word' | 'number' | 'ident' | 'string' | 'punct';
+  text: string;
+}
+
+/**
+ * コメントと文字列リテラルの中身を空白へ置換する前処理。
+ * - `--` 行コメント / `/* *​/` ブロックコメント (ネスト対応) は全体を空白化
+ * - `'...'` 文字列は中身のみ空白化 (両端のクォートは残しトークン境界を保持)。
+ *   `''` の二重化と `\'` (MySQL) のエスケープに対応
+ * - PostgreSQL のドル引用符 (`$$...$$` / `$tag$...$tag$`) は全体を空白化
+ * - クォート識別子 (`"x"` / `` `x` `` / `[x]`) は原文のまま保持
+ */
+function sanitize(sql: string): string {
+  const out = sql.split('');
+  const blank = (from: number, to: number): void => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== '\n' && out[k] !== '\r') out[k] = ' ';
+    }
+  };
+  const n = sql.length;
+  let i = 0;
+  while (i < n) {
+    const ch = sql[i];
+    const next = i + 1 < n ? sql[i + 1] : '';
+    if (ch === '-' && next === '-') {
+      const lineEnd = sql.indexOf('\n', i);
+      const stop = lineEnd === -1 ? n : lineEnd;
+      blank(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      let depth = 1;
+      let j = i + 2;
+      while (j < n && depth > 0) {
+        if (sql[j] === '/' && sql[j + 1] === '*') {
+          depth += 1;
+          j += 2;
+        } else if (sql[j] === '*' && sql[j + 1] === '/') {
+          depth -= 1;
+          j += 2;
+        } else {
+          j += 1;
+        }
+      }
+      blank(i, j);
+      i = j;
+      continue;
+    }
+    if (ch === "'") {
+      let j = i + 1;
+      let closed = false;
+      while (j < n) {
+        if (sql[j] === '\\') {
+          j += 2;
+          continue;
+        }
+        if (sql[j] === "'") {
+          if (j + 1 < n && sql[j + 1] === "'") {
+            j += 2;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+        j += 1;
+      }
+      blank(i + 1, j);
+      i = closed ? j + 1 : n;
+      continue;
+    }
+    if (ch === '$' && !/[A-Za-z0-9_$]/.test(i > 0 ? sql[i - 1] : '')) {
+      const m = /^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/.exec(sql.slice(i));
+      if (m) {
+        const tag = m[0];
+        const close = sql.indexOf(tag, i + tag.length);
+        const j = close === -1 ? n : close + tag.length;
+        blank(i, j);
+        i = j;
+        continue;
+      }
+    }
+    if (ch === '"' || ch === '`') {
+      let j = i + 1;
+      let closed = false;
+      while (j < n) {
+        if (sql[j] === ch) {
+          if (j + 1 < n && sql[j + 1] === ch) {
+            j += 2;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+        j += 1;
+      }
+      i = closed ? j + 1 : n;
+      continue;
+    }
+    if (ch === '[') {
+      let j = i + 1;
+      let closed = false;
+      while (j < n) {
+        if (sql[j] === ']') {
+          if (j + 1 < n && sql[j + 1] === ']') {
+            j += 2;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+        j += 1;
+      }
+      i = closed ? j + 1 : n;
+      continue;
+    }
+    i += 1;
+  }
+  return out.join('');
+}
+
+const WORD_RE = /[A-Za-z_#@\u0080-\uFFFF][A-Za-z0-9_#@$\u0080-\uFFFF]*/y;
+const NUMBER_RE = /\d+(?:\.\d+)?/y;
+
+function unescapeQuoted(inner: string, quote: string): string {
+  return inner.split(quote + quote).join(quote);
+}
+
+/** sanitize 済みテキストをトークン列に変換する */
+function tokenize(text: string): Token[] {
+  const tokens: Token[] = [];
+  const n = text.length;
+  let i = 0;
+  while (i < n) {
+    const ch = text[i];
+    if (/\s/.test(ch)) {
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === '`') {
+      let j = i + 1;
+      let closed = false;
+      while (j < n) {
+        if (text[j] === ch) {
+          if (j + 1 < n && text[j + 1] === ch) {
+            j += 2;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+        j += 1;
+      }
+      tokens.push({ kind: 'ident', text: unescapeQuoted(text.slice(i + 1, j), ch) });
+      i = closed ? j + 1 : n;
+      continue;
+    }
+    if (ch === '[') {
+      let j = i + 1;
+      let closed = false;
+      while (j < n) {
+        if (text[j] === ']') {
+          if (j + 1 < n && text[j + 1] === ']') {
+            j += 2;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+        j += 1;
+      }
+      tokens.push({
+        kind: 'ident',
+        text: text
+          .slice(i + 1, j)
+          .split(']]')
+          .join(']'),
+      });
+      i = closed ? j + 1 : n;
+      continue;
+    }
+    if (ch === "'") {
+      // sanitize 済みのため中身は空白のみ。閉じクォートまで読み飛ばす
+      let j = i + 1;
+      while (j < n && text[j] !== "'") j += 1;
+      tokens.push({ kind: 'string', text: '' });
+      i = j < n ? j + 1 : n;
+      continue;
+    }
+    WORD_RE.lastIndex = i;
+    const wordMatch = WORD_RE.exec(text);
+    if (wordMatch) {
+      tokens.push({ kind: 'word', text: wordMatch[0] });
+      i += wordMatch[0].length;
+      continue;
+    }
+    NUMBER_RE.lastIndex = i;
+    const numberMatch = NUMBER_RE.exec(text);
+    if (numberMatch) {
+      tokens.push({ kind: 'number', text: numberMatch[0] });
+      i += numberMatch[0].length;
+      continue;
+    }
+    tokens.push({ kind: 'punct', text: ch });
+    i += 1;
+  }
+  return tokens;
+}
+
+function isWord(tokens: Token[], index: number, word: string): boolean {
+  const t = tokens[index];
+  return t !== undefined && t.kind === 'word' && t.text.toLowerCase() === word;
+}
+
+function isWordSeq(tokens: Token[], start: number, words: string[]): boolean {
+  return words.every((w, k) => isWord(tokens, start + k, w));
+}
+
+function isPunct(tokens: Token[], index: number, punct: string): boolean {
+  const t = tokens[index];
+  return t !== undefined && t.kind === 'punct' && t.text === punct;
+}
+
+/** openIndex の '(' に対応する ')' の位置を返す (見つからなければ tokens.length) */
+function findMatchingParen(tokens: Token[], openIndex: number): number {
+  let depth = 0;
+  for (let k = openIndex; k < tokens.length; k++) {
+    const t = tokens[k];
+    if (t.kind !== 'punct') continue;
+    if (t.text === '(') depth += 1;
+    else if (t.text === ')') {
+      depth -= 1;
+      if (depth === 0) return k;
+    }
+  }
+  return tokens.length;
+}
+
+/** トップレベル (括弧深度 0) のカンマで分割する */
+function splitTopLevel(tokens: Token[]): Token[][] {
+  const items: Token[][] = [];
+  let current: Token[] = [];
+  let depth = 0;
+  for (const t of tokens) {
+    if (t.kind === 'punct') {
+      if (t.text === '(') depth += 1;
+      else if (t.text === ')') depth = Math.max(0, depth - 1);
+      else if (t.text === ',' && depth === 0) {
+        if (current.length > 0) items.push(current);
+        current = [];
+        continue;
+      }
+    }
+    current.push(t);
+  }
+  if (current.length > 0) items.push(current);
+  return items;
+}
+
+/** CREATE と TABLE の間に置ける修飾キーワード */
+const CREATE_MODIFIERS = new Set([
+  'or',
+  'replace',
+  'global',
+  'local',
+  'temp',
+  'temporary',
+  'unlogged',
+]);
+
+/** テーブル制約・インデックス定義として無視 (または PK 抽出) する行の先頭キーワード */
+const CONSTRAINT_STARTERS = new Set([
+  'constraint',
+  'primary',
+  'foreign',
+  'unique',
+  'check',
+  'key',
+  'index',
+  'fulltext',
+  'spatial',
+  'exclude',
+  'period',
+  'like',
+]);
+
+/** size を分離して type(size) 表記にする型ファミリー (utils/migrationDdl.ts と同方針) */
+const SIZED_TYPE_RE =
+  /^(n?char|n?varchar|character(?: varying)?|national (?:char|character|varchar)(?: varying)?|varbinary|binary|varchar2|nvarchar2)$/i;
+
+/** MySQL の整数表示幅 (int(11) 等) を無視する型ファミリー */
+const INT_DISPLAY_WIDTH_RE = /^(?:tiny|small|medium|big)?int(?:eger)?$/i;
+
+/** 直前の型語に続けて複数語型を構成できるキーワード */
+const TYPE_CONTINUATIONS = new Set([
+  'varying',
+  'precision',
+  'with',
+  'without',
+  'time',
+  'zone',
+  'unsigned',
+  'zerofill',
+]);
+
+/** 'national' の直後にのみ続けられる型キーワード */
+const NATIONAL_CONTINUATIONS = new Set(['char', 'character', 'varchar', 'nchar', 'nvarchar']);
+
+/** カラム定義 1 件をパースする。列定義と解釈できない場合は null */
+function parseColumnDef(item: Token[]): Column | null {
+  if (item.length < 2) return null;
+  const nameToken = item[0];
+  if (nameToken.kind !== 'word' && nameToken.kind !== 'ident') return null;
+  const name = nameToken.text;
+
+  if (item[1].kind !== 'word') return null;
+  const typeWords: string[] = [item[1].text];
+  let args: string | null = null;
+  let i = 2;
+  while (i < item.length) {
+    const t = item[i];
+    if (t.kind === 'punct' && t.text === '(' && args === null) {
+      const end = findMatchingParen(item, i);
+      args = item
+        .slice(i + 1, end)
+        .map((x) => x.text)
+        .join('');
+      i = end + 1;
+      continue;
+    }
+    if (t.kind === 'word') {
+      const lower = t.text.toLowerCase();
+      const prev = typeWords[typeWords.length - 1].toLowerCase();
+      if (
+        TYPE_CONTINUATIONS.has(lower) ||
+        (prev === 'national' && NATIONAL_CONTINUATIONS.has(lower))
+      ) {
+        typeWords.push(t.text);
+        i += 1;
+        continue;
+      }
+      break;
+    }
+    if (t.kind === 'ident' && t.text === '') {
+      // PostgreSQL の配列型 (text[] 等): sanitize 後は空のブラケット識別子となる
+      typeWords[typeWords.length - 1] += '[]';
+      i += 1;
+      continue;
+    }
+    break;
+  }
+
+  const base = typeWords.join(' ').toLowerCase();
+  let type = base;
+  let size = 0;
+  if (args !== null) {
+    const argsText = args.toLowerCase();
+    if (/^\d+$/.test(argsText) && SIZED_TYPE_RE.test(base)) {
+      size = Number(argsText);
+    } else if (/^\d+$/.test(argsText) && INT_DISPLAY_WIDTH_RE.test(typeWords[0])) {
+      // MySQL の整数表示幅は型情報として扱わない (int(11) → int)
+    } else {
+      type = `${base}(${argsText})`;
+    }
+  }
+
+  let nullable = true;
+  let isPrimaryKey = false;
+  while (i < item.length) {
+    const t = item[i];
+    if (t.kind === 'punct' && t.text === '(') {
+      i = findMatchingParen(item, i) + 1;
+      continue;
+    }
+    if (t.kind === 'word') {
+      const lower = t.text.toLowerCase();
+      if (lower === 'not' && isWord(item, i + 1, 'null')) {
+        nullable = false;
+        i += 2;
+        continue;
+      }
+      if (lower === 'primary' && isWord(item, i + 1, 'key')) {
+        isPrimaryKey = true;
+        i += 2;
+        continue;
+      }
+      if (lower === 'default') {
+        // DEFAULT 直後の値 (NULL リテラル・式・文字列) は nullable 判定に影響させない
+        i += 1;
+        if (isPunct(item, i, '(')) i = findMatchingParen(item, i) + 1;
+        else if (i < item.length) i += 1;
+        continue;
+      }
+    }
+    i += 1;
+  }
+  if (isPrimaryKey) nullable = false;
+
+  return { name, type, size, nullable, isPrimaryKey };
+}
+
+/**
+ * テーブル制約行から PRIMARY KEY の対象カラム名を抽出する。
+ * `CONSTRAINT <name> PRIMARY KEY [CLUSTERED|USING ...] (col [ASC|DESC], ...)` 形式に対応。
+ * PRIMARY KEY 以外の制約 (FOREIGN KEY / UNIQUE / CHECK / INDEX 等) は空配列を返す。
+ */
+function extractPrimaryKeyColumns(item: Token[]): string[] {
+  let i = 0;
+  if (isWord(item, i, 'constraint')) {
+    i += 1;
+    const nameToken = item[i];
+    if (nameToken !== undefined && (nameToken.kind === 'word' || nameToken.kind === 'ident')) {
+      i += 1;
+    }
+  }
+  if (!isWordSeq(item, i, ['primary', 'key'])) return [];
+  i += 2;
+  while (i < item.length && item[i].kind === 'word') i += 1; // CLUSTERED / USING BTREE 等
+  if (!isPunct(item, i, '(')) return [];
+  const end = findMatchingParen(item, i);
+  const names: string[] = [];
+  for (const group of splitTopLevel(item.slice(i + 1, end))) {
+    const head = group[0];
+    if (head !== undefined && (head.kind === 'word' || head.kind === 'ident')) {
+      names.push(head.text);
+    }
+  }
+  return names;
+}
+
+/** CREATE TABLE 本体 (括弧内) をパースする */
+function parseTableBody(nameParts: string[], body: Token[]): SchemaTable {
+  const name = nameParts[nameParts.length - 1];
+  const schema = nameParts.length >= 2 ? nameParts[nameParts.length - 2] : '';
+  const columns: Column[] = [];
+  const pkNames: string[] = [];
+  for (const item of splitTopLevel(body)) {
+    const first = item[0];
+    if (first.kind === 'word' && CONSTRAINT_STARTERS.has(first.text.toLowerCase())) {
+      pkNames.push(...extractPrimaryKeyColumns(item));
+      continue;
+    }
+    const column = parseColumnDef(item);
+    if (column) columns.push(column);
+  }
+  for (const pkName of pkNames) {
+    const column =
+      columns.find((c) => c.name === pkName) ??
+      columns.find((c) => c.name.toLowerCase() === pkName.toLowerCase());
+    if (column) {
+      column.isPrimaryKey = true;
+      column.nullable = false;
+    }
+  }
+  return { schema, name, columns };
+}
+
+/**
+ * DDL ソースと DB ソース (ODBC getColumns) を比較する前の正規化。
+ * - 型名を小文字へ揃える
+ * - 文字列/バイナリ系以外の size は取得元によって意味が揃わない (ODBC は int に 4 等を
+ *   返すが DDL には現れない) ため 0 に揃え、無意味な size 差分を抑止する
+ */
+export function normalizeTablesForDdlComparison(tables: SchemaTable[]): SchemaTable[] {
+  return tables.map((table) => ({
+    ...table,
+    columns: table.columns.map((column) => ({
+      ...column,
+      type: column.type.toLowerCase(),
+      size: SIZED_TYPE_RE.test(column.type.trim()) ? column.size : 0,
+    })),
+  }));
+}
+
+/**
+ * SQL テキストから CREATE TABLE 文を抽出し SchemaTable[] を返す。
+ *
+ * - スキーマプレフィックス (`dbo.Users` / `db.schema.Users`) は末尾 2 要素を schema.name とする
+ * - PRIMARY KEY カラムは nullable=false に正規化する (DB 側の getColumns と揃える)
+ * - 同一キーのテーブルが複数回定義された場合は後勝ち
+ * - CREATE TABLE が 1 件も見つからない場合は空配列 (例外は投げない)
+ */
+export function parseDdl(sql: string): SchemaTable[] {
+  const tokens = tokenize(sanitize(sql));
+  const byKey = new Map<string, SchemaTable>();
+  let i = 0;
+  while (i < tokens.length) {
+    if (!isWord(tokens, i, 'create')) {
+      i += 1;
+      continue;
+    }
+    let j = i + 1;
+    while (
+      j < tokens.length &&
+      tokens[j].kind === 'word' &&
+      CREATE_MODIFIERS.has(tokens[j].text.toLowerCase())
+    ) {
+      j += 1;
+    }
+    if (!isWord(tokens, j, 'table')) {
+      i = j;
+      continue;
+    }
+    j += 1;
+    if (isWordSeq(tokens, j, ['if', 'not', 'exists'])) j += 3;
+
+    const nameParts: string[] = [];
+    while (j < tokens.length && (tokens[j].kind === 'word' || tokens[j].kind === 'ident')) {
+      nameParts.push(tokens[j].text);
+      j += 1;
+      if (isPunct(tokens, j, '.')) {
+        j += 1;
+        continue;
+      }
+      break;
+    }
+    if (nameParts.length === 0 || !isPunct(tokens, j, '(')) {
+      // CREATE TABLE ... AS SELECT (CTAS) や名前なしはスキップ
+      i = j;
+      continue;
+    }
+
+    const bodyEnd = findMatchingParen(tokens, j);
+    const table = parseTableBody(nameParts, tokens.slice(j + 1, bodyEnd));
+    if (table.columns.length > 0) byKey.set(tableKey(table), table);
+    i = bodyEnd + 1;
+  }
+  return [...byKey.values()];
+}


### PR DESCRIPTION
## 概要

SQL ファイル (DDL) をスキーマ情報のソースとして扱えるようにする (#261)。DataGrip の「DDL Data Source」相当の MVP として、スキーマ比較 (#257) に統合。フロントエンドのみで完結し backend 変更なし。

## 変更内容

### `utils/ddlParser.ts` (新規)

sanitize (コメント/リテラル除去) → トークナイズ → CREATE TABLE 抽出の 3 段構成の純関数 `parseDdl(sql)`。

- 3 方言クォート (`[x]` / `"x"` / `` `x` ``、各エスケープ対応)、schema プレフィックス、`IF NOT EXISTS`、`GO` 区切り
- サイズ付き型 (`varchar(50)` 分離、`decimal(10,2)` / `varchar(max)` は括弧ごと保持)、複数語型 (`character varying` 等)、MySQL 表示幅正規化、PostgreSQL 配列型
- インライン PK / テーブル制約 PK (PK 列は nullable=false に正規化)、NULL/NOT NULL
- `--` / ネスト `/* */` コメント、エスケープ付き文字列、ドル引用符をスキップ。CTAS・FK/UNIQUE/CHECK/INDEX 行は無視
- `normalizeTablesForDdlComparison()`: DDL ソースを含む比較時のみ型名小文字化 + 非文字列系 size を 0 に正規化し、ODBC メタデータとの無意味な size 差分を抑止 (DB↔DB 比較は不変)

### `SchemaCompareDialog.tsx`

- 左右各ソースに「ソース種別」セレクタ (接続/データベース ⇄ DDL ファイル (.sql)) を追加
- DDL 選択時は `<input type="file">` + FileReader で読込 (IPC 不要)。ファイル名とパース済みテーブル数を表示、0 テーブル/読込失敗時はエラー表示 + 比較ボタン無効
- 差分表示・移行 DDL 生成・方言切替・保存は既存ロジックをそのまま利用。DB↔DDL / DDL↔DDL 比較が可能

### 既知の制限

型名は小文字へ正規化。`enum(...)` の値リストは失われる。DDL 側にスキーマ修飾がない場合は DB 側 (`dbo` 等) とテーブルキーが一致しない。

## テスト

- `ddlParser.test.ts` 38 ケース (方言別・エッジケース)、`SchemaCompareDialog.test.tsx` 17 ケース (DDL ソース 5 新規、既存 12 無変更で通過)
- pre-push フックで全テスト・typecheck・biome 通過

Fixes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
